### PR TITLE
 feat: Cache toObject(...) using jsi::WeakObject and correctly set `externalExternalMemoryPressure`

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -96,7 +96,7 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
       return object;
     }
   }
-  
+
   // 2. Get the object's base prototype (global & shared)
   jsi::Value prototype = getPrototype(runtime);
 
@@ -106,10 +106,10 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
 
   // 4. Create the object using Object.create(...)
   jsi::Object object = create.call(runtime, prototype).asObject(runtime);
-  
+
   // 5. Assign NativeState to the object so the prototype can resolve the native methods
   object.setNativeState(runtime, shared_from_this());
-  
+
   // 6. Set memory size so Hermes GC knows about actual memory
   object.setExternalMemoryPressure(runtime, getExternalMemorySize());
 
@@ -117,7 +117,7 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
   // 7. Assign a private __type property for debugging - this will be used so users know it's not just an empty object.
   object.setProperty(runtime, "__type", jsi::String::createFromUtf8(runtime, "NativeState<" + std::string(_name) + ">"));
 #endif
-  
+
   // 8. Throw a jsi::WeakObject pointing to our object into cache so subsequent calls can use it from cache
   JSICacheReference cache = JSICache::getOrCreateCache(runtime);
   _objectCache.emplace(&runtime, cache.makeShared(jsi::WeakObject(runtime, object)));

--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp
@@ -43,7 +43,7 @@ public:
    * HybridObjects cannot be moved.
    */
   HybridObject(HybridObject&& move) = delete;
-  
+
 public:
   /**
    * Return the `jsi::Object` that holds this `HybridObject`. (boxed in a `jsi::Value`)
@@ -52,7 +52,7 @@ public:
    * Additionally, this sets the external memory pressure for proper GC memory management.
    */
   jsi::Value toObject(jsi::Runtime& runtime);
-  
+
 public:
   /**
    * Get the `std::shared_ptr` instance of this HybridObject.
@@ -62,7 +62,7 @@ public:
   std::shared_ptr<Derived> shared() {
     return std::static_pointer_cast<Derived>(shared_from_this());
   }
-  
+
 public:
   /**
    * Get the HybridObject's name
@@ -79,7 +79,7 @@ public:
    * they might still be the same `HybridObject` - in this case `equals(other)` will return true.
    */
   bool equals(std::shared_ptr<HybridObject> other);
-  
+
 protected:
   /**
    * Get the size of any external (heap) allocations this `HybridObject` has made, in bytes.
@@ -88,7 +88,7 @@ protected:
   virtual inline size_t getExternalMemorySize() noexcept {
     return 0;
   }
-  
+
 protected:
   /**
    * Loads all native methods of this `HybridObject` to be exposed to JavaScript.
@@ -108,7 +108,7 @@ protected:
    * ```
    */
   virtual void loadHybridMethods() override;
-  
+
 private:
   static constexpr auto TAG = "HybridObject";
   const char* _name = TAG;

--- a/packages/react-native-nitro-modules/cpp/jsi/JSICache.cpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSICache.cpp
@@ -14,17 +14,25 @@ namespace margelo::nitro {
 
 static constexpr auto CACHE_PROP_NAME = "__nitroModulesJSICache";
 
-JSICache::~JSICache() {
-  Logger::log(TAG, "Destroying JSICache...");
-  std::unique_lock lock(_mutex);
-
-  for (auto& func : _cache) {
-    OwningReference<jsi::Object> owning = func.lock();
+template <typename T>
+inline void destroyReferences(const std::vector<BorrowingReference<T>>& references) {
+  for (auto& func : references) {
+    OwningReference<T> owning = func.lock();
     if (owning) {
       // Destroy all functions that we might still have in cache, some callbacks and Promises may now become invalid.
       owning.destroy();
     }
   }
+}
+
+JSICache::~JSICache() {
+  Logger::log(TAG, "Destroying JSICache...");
+  std::unique_lock lock(_mutex);
+
+  destroyReferences(_objectCache);
+  destroyReferences(_functionCache);
+  destroyReferences(_weakObjectCache);
+  destroyReferences(_arrayBufferCache);
 }
 
 JSICacheReference JSICache::getOrCreateCache(jsi::Runtime& runtime) {

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+ArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+ArrayBuffer.hpp
@@ -41,7 +41,7 @@ struct JSIConverter<T, std::enable_if_t<is_shared_ptr_to_v<T, jsi::MutableBuffer
 #endif
 
     JSICacheReference cache = JSICache::getOrCreateCache(runtime);
-    auto borrowingArrayBuffer = cache.makeShared<jsi::ArrayBuffer>(object.getArrayBuffer(runtime));
+    auto borrowingArrayBuffer = cache.makeShared(object.getArrayBuffer(runtime));
 
     return std::make_shared<JSArrayBuffer>(&runtime, borrowingArrayBuffer);
   }

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Function.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Function.hpp
@@ -35,7 +35,7 @@ struct JSIConverter<std::function<ReturnType(Args...)>> {
     // Make function global - it'll be managed by the Runtime's memory, and we only have a weak_ref to it.
     auto cache = JSICache::getOrCreateCache(runtime);
     jsi::Function function = arg.asObject(runtime).asFunction(runtime);
-    OwningReference<jsi::Function> sharedFunction = cache.makeShared<jsi::Function>(std::move(function));
+    OwningReference<jsi::Function> sharedFunction = cache.makeShared(std::move(function));
 
     std::shared_ptr<Dispatcher> strongDispatcher = Dispatcher::getRuntimeGlobalDispatcher(runtime);
     std::weak_ptr<Dispatcher> weakDispatcher = strongDispatcher;

--- a/packages/react-native-nitro-modules/cpp/jsi/Promise.cpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/Promise.cpp
@@ -9,8 +9,8 @@ using namespace facebook;
 
 Promise::Promise(jsi::Runtime& runtime, jsi::Function&& resolver, jsi::Function&& rejecter) {
   auto functionCache = JSICache::getOrCreateCache(runtime);
-  _resolver = functionCache.makeShared<jsi::Function>(std::move(resolver));
-  _rejecter = functionCache.makeShared<jsi::Function>(std::move(rejecter));
+  _resolver = functionCache.makeShared(std::move(resolver));
+  _rejecter = functionCache.makeShared(std::move(rejecter));
 }
 
 jsi::Value Promise::createPromise(jsi::Runtime& runtime, RunPromise&& run) {

--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference+Owning.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference+Owning.hpp
@@ -22,7 +22,7 @@ BorrowingReference<T>::BorrowingReference(const OwningReference<T>& ref) {
 }
 
 template <typename T>
-OwningReference<T> BorrowingReference<T>::lock() {
+OwningReference<T> BorrowingReference<T>::lock() const {
   std::unique_lock lock(*_mutex);
 
   if (*_isDeleted) {

--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
@@ -82,7 +82,7 @@ public:
    Try to lock the borrowing reference to an owning reference, or `nullptr` if it has already been deleted.
    */
   [[nodiscard]]
-  OwningReference<T> lock();
+  OwningReference<T> lock() const;
 
 public:
   friend class OwningReference<T>;


### PR DESCRIPTION
This PR now improves performance of passing HybridObjects to JS.

1. `jsi::Object` instances of a given `HybridObject` are now cached using `WeakObject`, and can be re-used in subsequent calls.
    Subsequent calls use the cached object and return it to JS, which avoids going the long prototype assignment route.
2. Additionally, `setExternalMemoryPressure` can now finally be used properly, since we know that we only have one `jsi::Object` instance of the same `HybridObject` in memory, so it will no longer track memory for the same object twice/thrice/...! 🥳
3. And lastly; `obj.foo == obj.foo` now works, since we actually return the same `jsi::Object`! It's cached in a weakref, so that finally works. cc @wcandillon 