### PR TITLE
docs: mention required logLevel

### DIFF
--- a/packages/nitrogen/README.md
+++ b/packages/nitrogen/README.md
@@ -35,6 +35,7 @@ Every nitro module must have a `nitro.json` file at it's root level (i.e. the fo
 
 ```json
 {
+  "logLevel": "debug",
   "cxxNamespace": ["image"],
   "ios": {
     "iosModulename": "NitroImage"


### PR DESCRIPTION
Example `nitro.json` is not complete. It misses `logLevel` property.

> Error: Invalid nitro.json config file! `logLevel` must be 'debug' | 'info' | 'warning' | 'error', but is undefined.

Added `logLevel` to docs.