### PR TITLE
feat: cleanup generated folder

### DIFF
--- a/packages/nitrogen/src/index.ts
+++ b/packages/nitrogen/src/index.ts
@@ -8,6 +8,7 @@ import path from 'path'
 import { getBaseDirectory, prettifyDirectory } from './getCurrentDir.js'
 import { capitalizeName, errorToString, indent } from './stringUtils.js'
 import { writeFile } from './writeFile.js'
+import { removeFolder } from './removeFolder.js'
 import chalk from 'chalk'
 import { getFiles } from './getFiles.js'
 import { groupByPlatform, type SourceFile } from './syntax/SourceFile.js'
@@ -45,6 +46,11 @@ for (const dir of project.getDirectories()) {
   )
 }
 
+// at this point we should try to clean generated folder to mimic the actual state
+const outFolder = path.join(baseDirectory, 'nitrogen', 'generated')
+
+await removeFolder(outFolder)
+
 // If no source files are found, we can exit
 if (project.getSourceFiles().length === 0) {
   console.log(
@@ -55,7 +61,6 @@ if (project.getSourceFiles().length === 0) {
   process.exit()
 }
 
-const outFolder = path.join(baseDirectory, 'nitrogen', 'generated')
 const filesBefore = await getFiles(outFolder)
 const filesAfter: string[] = []
 const writtenFiles: SourceFile[] = []

--- a/packages/nitrogen/src/removeFolder.ts
+++ b/packages/nitrogen/src/removeFolder.ts
@@ -1,0 +1,21 @@
+import { promises as fs } from 'fs'
+import { prettifyDirectory } from './getCurrentDir.js'
+
+/**
+ * Removes the given folder and all its contents if exists
+ */
+export async function removeFolder(folderPath: string): Promise<void> {
+    // check if exists and is a directory
+    const hasFolder = await fs.stat(folderPath)
+        .then(stat => stat.isDirectory())
+        .catch(() => false)
+
+    if (!hasFolder) {
+        return Promise.resolve()
+    }
+
+    console.log(`🗑️ Removing ${prettifyDirectory(folderPath)}`)
+
+    // Remove directory recursively
+    await fs.rm(folderPath, { recursive: true })
+}


### PR DESCRIPTION
When I was experimenting with some nitrogen options, I noticed that the generated folder retains old directories and doesn't remove them when there is no spec.

This small PR ensures that the generated folder will be removed recursively whenever the user runs script. Additionally, if the user decides to remove specs and runs the script again, the folder will be empty.

Before:

Example if I try to generate code from swift / kotlin to C++
![image](https://github.com/user-attachments/assets/460d27a3-139d-4c58-9e70-5f965da95ca1)

After:

![image](https://github.com/user-attachments/assets/65c2194c-b858-4e06-869f-f8e83e1b7723)


Also there is a small indicator that folder has been removed:
![image](https://github.com/user-attachments/assets/c4be5490-f10f-4566-b3c9-c22db431ccff)
