### PR TITLE
feat: Annotate native callbacks with `@FastNative` (objects) or `@Critical` (primitives)

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinBoxedPrimitive.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinBoxedPrimitive.ts
@@ -1,3 +1,5 @@
+import { ArrayType } from '../types/ArrayType.js'
+import { getTypeAs } from '../types/getTypeAs.js'
 import type { Type } from '../types/Type.js'
 
 /**
@@ -16,4 +18,23 @@ export function getKotlinBoxedPrimitiveType(type: Type): string {
     default:
       throw new Error(`Type ${type.kind} is not a primitive!`)
   }
+}
+
+export function isPrimitive(type: Type): boolean {
+  switch (type.kind) {
+    case 'number':
+    case 'boolean':
+    case 'bigint':
+    case 'void':
+    case 'null':
+      return true
+    default:
+      return false
+  }
+}
+
+export function isArrayOfPrimitives(type: Type): boolean {
+  if (type.kind !== 'array') return false
+  const array = getTypeAs(type, ArrayType)
+  return isPrimitive(array.itemType)
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__string.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__string.kt
@@ -11,6 +11,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import dalvik.annotation.optimization.FastNative
 
 /**
  * Represents the JavaScript callback "(path: String) -> Unit".
@@ -28,5 +29,6 @@ class Func_void_std__string @DoNotStrip @Keep private constructor(hybridData: Hy
    * Call the given JS callback.
    * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
    */
+  @FastNative
   external fun call(path: String): Unit
 }


### PR DESCRIPTION
For JS callbacks (C++ methods that are called from Kotlin), we now annotate the external/native function (JNI func) with either `@FastNative` (if there are any objects) or `@CriticalNative` (if there are only primitives/void).

This speeds up native method execution by a little. It should only be used really carefully, but in primitive only methods we don't interact with the Java runtime, and we only delegate the call to C++ (JS Thread), so I think this should be fine. We should further test this though.

According to [the `@CriticalNative` documentation](https://developer.android.com/reference/dalvik/annotation/optimization/CriticalNative), this could speed up JNI calls by 4.5x.
I think the performance gain here is really small as the body of the method is likely gonna be longer than those few nanoseconds, but hey if we use it safely, it's a free perf gain that could sum up on a lot of callbacks.

![Screenshot 2024-08-20 at 14 58 51](https://github.com/user-attachments/assets/a9b21d92-64f0-4f7e-aab3-e1296c2f15a3)
