### PR TITLE
feat: Add `NitroModules.hasNativeState` and `NitroModules.removeNativeState`

### DIFF
--- a/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
+++ b/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
@@ -68,6 +68,24 @@ jsi::Value NativeNitroModules::get(jsi::Runtime& runtime, const jsi::PropNameID&
                                                  [this](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args,
                                                         size_t count) -> jsi::Value { return getAllHybridObjectNames(runtime); });
   }
+  if (name == "hasNativeState") {
+    return jsi::Function::createFromHostFunction(
+        runtime, jsi::PropNameID::forUtf8(runtime, "hasNativeState"), 1,
+        [](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args, size_t count) -> jsi::Value {
+          jsi::Object object = args[0].asObject(runtime);
+          bool has = object.hasNativeState(runtime) && object.getNativeState(runtime) != nullptr;
+          return jsi::Value(has);
+        });
+  }
+  if (name == "removeNativeState") {
+    return jsi::Function::createFromHostFunction(
+        runtime, jsi::PropNameID::forUtf8(runtime, "removeNativeState"), 1,
+        [](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args, size_t count) -> jsi::Value {
+          jsi::Object object = args[0].asObject(runtime);
+          object.setNativeState(runtime, nullptr);
+          return jsi::Value::undefined();
+        });
+  }
 
   return jsi::Value::undefined();
 }

--- a/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.hpp
+++ b/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.hpp
@@ -22,7 +22,9 @@ public:
 public:
   jsi::Value get(jsi::Runtime& runtime, const jsi::PropNameID& propName) override;
 
+  // Setup
   void install(jsi::Runtime& runtime);
+  // Hybrid Objects stuff
   jsi::Value createHybridObject(jsi::Runtime& runtime, const jsi::String& hybridObjectName, const std::optional<jsi::Object>& args);
   jsi::Value hasHybridObject(jsi::Runtime& runtime, const jsi::String& hybridObjectName);
   jsi::Value getAllHybridObjectNames(jsi::Runtime& runtime);

--- a/packages/react-native-nitro-modules/src/NativeNitroModules.ts
+++ b/packages/react-native-nitro-modules/src/NativeNitroModules.ts
@@ -4,10 +4,15 @@ import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes'
 import { ModuleNotFoundError } from './ModuleNotFoundError'
 
 export interface Spec extends TurboModule {
+  // Set up
   install(): void
+  // Hybrid Objects stuff
   createHybridObject(name: string, args?: UnsafeObject): UnsafeObject
   hasHybridObject(name: string): boolean
   getAllHybridObjectNames(): string[]
+  // JSI Helpers
+  hasNativeState(obj: UnsafeObject): boolean
+  removeNativeState(obj: UnsafeObject): void
 }
 
 let turboModule: Spec | undefined

--- a/packages/react-native-nitro-modules/src/NitroModules.ts
+++ b/packages/react-native-nitro-modules/src/NitroModules.ts
@@ -41,4 +41,28 @@ export const NitroModules = {
     const nitro = getNativeNitroModules()
     return nitro.hasHybridObject(name)
   },
+  /**
+   * Returns whether the given {@linkcode object} has a `NativeState` or not.
+   *
+   * This can be a quick way to check if an object is a valid {@linkcode HybridObject},
+   * and has not yet been disposed.
+   * @example
+   * ```ts
+   * const someObject = NitroModules.createHybridObject<Some>('Some')
+   * console.log(NitroModules.hasNativeState(someObject)) // -> true
+   * someObject.dispose()
+   * console.log(NitroModules.hasNativeState(someObject)) // -> false
+   * ```
+   */
+  hasNativeState(object: object): boolean {
+    const nitro = getNativeNitroModules()
+    return nitro.hasNativeState(object)
+  },
+  /**
+   * Forcefully removes the `NativeState` of the given {@linkcode object}.
+   */
+  removeNativeState(object: object): void {
+    const nitro = getNativeNitroModules()
+    nitro.removeNativeState(object)
+  },
 }


### PR DESCRIPTION
Shouldn't be really used by anyone, this is mainly just for testing.

Example usage:

```ts
const someObject = NitroModules.createHybridObject<Some>('Some')
console.log(NitroModules.hasNativeState(someObject)) // -> true
someObject.dispose()
console.log(NitroModules.hasNativeState(someObject)) // -> false
```