### PR TITLE
feat: Add String extensions (`init` and `stringValue`) to Swift enums

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftEnum.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftEnum.ts
@@ -1,10 +1,24 @@
 import { NitroConfig } from '../../config/NitroConfig.js'
+import { indent, toLowerCamelCase } from '../../utils.js'
 import { createFileMetadataString } from '../helpers.js'
 import type { SourceFile } from '../SourceFile.js'
 import type { EnumType } from '../types/EnumType.js'
 
 export function createSwiftEnumBridge(enumType: EnumType): SourceFile {
   const fullName = NitroConfig.getCxxNamespace('swift', enumType.enumName)
+
+  const initializeCases = enumType.enumMembers.map((m) =>
+    `
+case "${m.stringValue}":
+  self = .${toLowerCamelCase(m.name)}
+    `.trim()
+  )
+  const toStringCases = enumType.enumMembers.map((m) =>
+    `
+case .${toLowerCamelCase(m.name)}:
+  return "${m.stringValue}"
+`.trim()
+  )
 
   const code = `
 ${createFileMetadataString(`${enumType.enumName}.swift`)}
@@ -13,6 +27,29 @@ ${createFileMetadataString(`${enumType.enumName}.swift`)}
  * Represents the JS ${enumType.jsType} \`${enumType.enumName}\`, backed by a C++ enum.
  */
 public typealias ${enumType.enumName} = ${fullName}
+
+public extension ${enumType.enumName} {
+  /**
+   * Get a ${enumType.enumName} for the given String value, or
+   * return \`nil\` if the given value was invalid/unknown.
+   */
+  init?(fromString string: String) {
+    switch string {
+      ${indent(initializeCases.join('\n'), '      ')}
+      default:
+        return nil
+    }
+  }
+
+  /**
+   * Get the String value this ${enumType.enumName} represents.
+   */
+  var stringValue: String {
+    switch self {
+      ${indent(toStringCases.join('\n'), '      ')}
+    }
+  }
+}
   `.trim()
 
   return {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/ImageFormat.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/ImageFormat.swift
@@ -10,3 +10,32 @@
  * Represents the JS union `ImageFormat`, backed by a C++ enum.
  */
 public typealias ImageFormat = margelo.nitro.image.ImageFormat
+
+public extension ImageFormat {
+  /**
+   * Get a ImageFormat for the given String value, or
+   * return `nil` if the given value was invalid/unknown.
+   */
+  init?(fromString string: String) {
+    switch string {
+      case "jpg":
+        self = .jpg
+      case "png":
+        self = .png
+      default:
+        return nil
+    }
+  }
+
+  /**
+   * Get the String value this ImageFormat represents.
+   */
+  var stringValue: String {
+    switch self {
+      case .jpg:
+        return "jpg"
+      case .png:
+        return "png"
+    }
+  }
+}

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/OldEnum.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/OldEnum.swift
@@ -10,3 +10,36 @@
  * Represents the JS enum `OldEnum`, backed by a C++ enum.
  */
 public typealias OldEnum = margelo.nitro.image.OldEnum
+
+public extension OldEnum {
+  /**
+   * Get a OldEnum for the given String value, or
+   * return `nil` if the given value was invalid/unknown.
+   */
+  init?(fromString string: String) {
+    switch string {
+      case "FIRST":
+        self = .first
+      case "SECOND":
+        self = .second
+      case "THIRD":
+        self = .third
+      default:
+        return nil
+    }
+  }
+
+  /**
+   * Get the String value this OldEnum represents.
+   */
+  var stringValue: String {
+    switch self {
+      case .first:
+        return "FIRST"
+      case .second:
+        return "SECOND"
+      case .third:
+        return "THIRD"
+    }
+  }
+}

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/PixelFormat.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/PixelFormat.swift
@@ -10,3 +10,36 @@
  * Represents the JS union `PixelFormat`, backed by a C++ enum.
  */
 public typealias PixelFormat = margelo.nitro.image.PixelFormat
+
+public extension PixelFormat {
+  /**
+   * Get a PixelFormat for the given String value, or
+   * return `nil` if the given value was invalid/unknown.
+   */
+  init?(fromString string: String) {
+    switch string {
+      case "rgb":
+        self = .rgb
+      case "yuv-8bit":
+        self = .yuv8bit
+      case "yuv-10bit":
+        self = .yuv10bit
+      default:
+        return nil
+    }
+  }
+
+  /**
+   * Get the String value this PixelFormat represents.
+   */
+  var stringValue: String {
+    switch self {
+      case .rgb:
+        return "rgb"
+      case .yuv8bit:
+        return "yuv-8bit"
+      case .yuv10bit:
+        return "yuv-10bit"
+    }
+  }
+}

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Powertrain.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Powertrain.swift
@@ -10,3 +10,36 @@
  * Represents the JS union `Powertrain`, backed by a C++ enum.
  */
 public typealias Powertrain = margelo.nitro.image.Powertrain
+
+public extension Powertrain {
+  /**
+   * Get a Powertrain for the given String value, or
+   * return `nil` if the given value was invalid/unknown.
+   */
+  init?(fromString string: String) {
+    switch string {
+      case "electric":
+        self = .electric
+      case "gas":
+        self = .gas
+      case "hybrid":
+        self = .hybrid
+      default:
+        return nil
+    }
+  }
+
+  /**
+   * Get the String value this Powertrain represents.
+   */
+  var stringValue: String {
+    switch self {
+      case .electric:
+        return "electric"
+      case .gas:
+        return "gas"
+      case .hybrid:
+        return "hybrid"
+    }
+  }
+}


### PR DESCRIPTION
Before:

```ts
public typealias Powertrain = margelo.nitro.image.Powertrain
```

After:

```ts
public typealias Powertrain = margelo.nitro.image.Powertrain

public extension Powertrain {
  init?(fromString string: String) {
    switch string {
      case "electric":
        self = .electric
      case "gas":
        self = .gas
      case "hybrid":
        self = .hybrid
      default:
        return nil
    }
  }

  var stringValue: String {
    switch self {
      case .electric:
        return "electric"
      case .gas:
        return "gas"
      case .hybrid:
        return "hybrid"
    }
  }
}
```


Resolves https://github.com/mrousavy/nitro/issues/85