### PR TITLE
fix: Rename `value` to `__result` to fix naming collisions

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -150,8 +150,8 @@ return ${bridged.parseFromSwiftToCpp('result', 'c++')};
       if (hasResult) {
         // func returns something
         body = `
-auto value = _swiftPart.${m.name}(${params});
-return ${bridgedReturnType.parseFromSwiftToCpp('value', 'c++')};
+auto __result = _swiftPart.${m.name}(${params});
+return ${bridgedReturnType.parseFromSwiftToCpp('__result', 'c++')};
         `.trim()
       } else {
         // void func


### PR DESCRIPTION
Renames `value` to `__result` to fix naming collisions. People sometimes used `value` as a method parameter.

- fixes https://github.com/mrousavy/nitro/issues/88