### PR TITLE
fix: code block overflow

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -14,7 +14,12 @@
   --ifm-color-primary-lighter: #6aa6f2; /* Even lighter for hover states, etc. */
   --ifm-color-primary-lightest: #8abcfb; /* Lightest Blue for backgrounds */
   --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.05); /* Reduced contrast for better readability */
+  --docusaurus-highlighted-code-line-bg: rgba(
+    0,
+    0,
+    0,
+    0.05
+  ); /* Reduced contrast for better readability */
 
   /* Accent color for specific elements */
   --ifm-color-accent: #ff4c4c; /* Slightly brighter Red accent for better contrast */
@@ -32,7 +37,12 @@
   --ifm-color-primary-light: #66b2ff; /* Very Light Blue */
   --ifm-color-primary-lighter: #80c1ff; /* Lighter Blue */
   --ifm-color-primary-lightest: #99d1ff; /* Lightest Blue */
-  --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.2); /* Slightly more contrast */
+  --docusaurus-highlighted-code-line-bg: rgba(
+    255,
+    255,
+    255,
+    0.2
+  ); /* Slightly more contrast */
 
   /* Accent color for specific elements */
   --ifm-color-accent: #ff4c4c; /* Slightly brighter Red accent for better contrast */
@@ -40,7 +50,6 @@
   --code-diff-add: #81c78466;
   --code-diff-remove: #e5737366;
 }
-
 
 /* For adding diff + / - to prism codeblocks */
 .code-block-diff-add-line {
@@ -85,20 +94,17 @@
  * use magic comments to mark diff blocks
  */
 pre code:has(.code-block-diff-add-line) {
-  padding-left: 40px!important;
+  padding-left: 40px !important;
 }
 
 pre code:has(.code-block-diff-remove-line) {
-  padding-left: 40px!important;
+  padding-left: 40px !important;
 }
 
 .side-by-side-container {
   display: flex;
   flex-direction: row;
   gap: 15px;
-  max-width: 100%;
-  box-sizing: border-box;
-  align-items: stretch;
 }
 
 @media (max-width: 768px) or (((min-width: 997px) and (max-width: 1320px))) {
@@ -111,9 +117,7 @@ pre code:has(.code-block-diff-remove-line) {
 .side-by-side-block {
   flex: 1 1 0;
   min-width: 0;
-  box-sizing: border-box;
-  flex-direction: row;
-  align-items: stretch;
+  flex-direction: column;
   display: flex;
 }
 


### PR DESCRIPTION
This PR fixes the overflow issue with code blocks on smaller screens, ensuring they fit within their container and do not cause horizontal scrolling. It also removes unnecessary CSS to clean up the codebase.

## 🛠️ What changed?

- Fixed code block overflow on smaller screens by updating CSS.
- Removed unused CSS classes for better maintainability.

### 📺 Screenshots

| Before | After |
|--------|-------|
| <img width="643" alt="image" src="https://github.com/user-attachments/assets/e5e9d7bb-4245-4e8c-96b6-3ec816f9296f"> | <img width="613" alt="image" src="https://github.com/user-attachments/assets/1efe087a-1dd3-4fa0-9a79-7570f1edea57"> |


### 🧪 How to test?

1. Open the app on different screen sizes
2. Navigate to a page with code blocks and check for overflow.
3. Verify that code blocks fit within their containers without causing scrolling.

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation (non-breaking change that adds or changes documentation)
- [ ] Refactor (non-breaking change that is code cleanup)
- [ ] Configuration & build (webpack, linters, GitHub templates, etc)
