### PR TITLE
fix: template cpp-adapter.cpp for Android

### DIFF
--- a/packages/template/android/src/main/cpp/cpp-adapter.cpp
+++ b/packages/template/android/src/main/cpp/cpp-adapter.cpp
@@ -2,8 +2,6 @@
 
 #include "JFunc_void_Person.hpp"
 #include "JFunc_void_std__string.hpp"
-#include "JHybridImageFactorySpec.hpp"
-#include "JHybridImageSpec.hpp"
 #include "JHybridKotlinTestObjectSpec.hpp"
 
 #include "HybridTestObject.hpp"

--- a/packages/template/android/src/main/cpp/cpp-adapter.cpp
+++ b/packages/template/android/src/main/cpp/cpp-adapter.cpp
@@ -10,7 +10,7 @@
 #include <NitroModules/HybridObjectRegistry.hpp>
 #include <fbjni/fbjni.h>
 
-using namespace margelo::nitro::image;
+using namespace margelo::nitro::<<androidCxxLibName>>;
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
   return facebook::jni::initialize(vm, [] {


### PR DESCRIPTION
Think this might have been missed in the template. Still trying to get this up and running locally

Edit: Looking at the CMake file, i am seeing the Hybrid test object, but no `JHybridKotlinTestObjectSpec`. Guessing that will be part of the autogenerated spec. Removed the HybridImageFactory though as that looks like it comes straight from the sample proj