### PR TITLE
fix: Fix optional enums in Nitrogen

### DIFF
--- a/packages/nitrogen/src/syntax/createType.ts
+++ b/packages/nitrogen/src/syntax/createType.ts
@@ -229,6 +229,7 @@ export function createType(type: TSMorphType, isOptional: boolean): Type {
       } else {
         // It consists of different types - that means it's a variant!
         let variants = type
+          .getNonNullableType()
           .getUnionTypes()
           // Filter out any nulls or undefineds, as those are already treated as `isOptional`.
           .filter((t) => !t.isNull() && !t.isUndefined() && !t.isVoid())

--- a/packages/nitrogen/src/syntax/createType.ts
+++ b/packages/nitrogen/src/syntax/createType.ts
@@ -208,7 +208,10 @@ export function createType(type: TSMorphType, isOptional: boolean): Type {
       )
       return new EnumType(typename, enumDeclaration)
     } else if (type.isUnion()) {
-      // It is some kind of union - either full of strings (then it's an enum, or different types, then it's a Variant)
+      // It is some kind of union;
+      // - of string literals (then it's an enum)
+      // - of type `T | undefined` (then it's just optional `T`)
+      // - of different types (then it's a variant `A | B | C`)
       const types = type.getUnionTypes()
       const nonNullTypes = types.filter(
         (t) => !t.isNull() && !t.isUndefined() && !t.isVoid()
@@ -229,7 +232,6 @@ export function createType(type: TSMorphType, isOptional: boolean): Type {
       } else {
         // It consists of different types - that means it's a variant!
         let variants = type
-          .getNonNullableType()
           .getUnionTypes()
           // Filter out any nulls or undefineds, as those are already treated as `isOptional`.
           .filter((t) => !t.isNull() && !t.isUndefined() && !t.isVoid())

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridKotlinTestObjectSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridKotlinTestObjectSpec.cpp
@@ -176,5 +176,9 @@ namespace margelo::nitro::image {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void_Person::javaobject> /* callback */)>("addOnPersonBornListener");
     method(_javaPart, JFunc_void_Person::fromCpp(callback));
   }
+  void JHybridKotlinTestObjectSpec::something1(std::optional<Powertrain> optional) {
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JPowertrain> /* optional */)>("something1");
+    method(_javaPart, optional.has_value() ? JPowertrain::fromCpp(optional.value()) : nullptr);
+  }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridKotlinTestObjectSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridKotlinTestObjectSpec.hpp
@@ -56,6 +56,7 @@ namespace margelo::nitro::image {
     std::future<void> asyncTest() override;
     std::shared_ptr<AnyMap> createMap() override;
     void addOnPersonBornListener(const std::function<void(const Person& /* p */)>& callback) override;
+    void something1(std::optional<Powertrain> optional) override;
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridKotlinTestObjectSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridKotlinTestObjectSpec.kt
@@ -88,6 +88,10 @@ abstract class HybridKotlinTestObjectSpec: HybridObject() {
     val result = addOnPersonBornListener(callback.toLambda())
     return result
   }
+  
+  @DoNotStrip
+  @Keep
+  abstract fun something1(optional: Powertrain?): Unit
 
   private external fun initHybrid(): HybridData
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -556,5 +556,13 @@ namespace margelo::nitro::image::bridge::swift {
   inline std::shared_ptr<Func_void_Person_Wrapper> share_Func_void_Person(const Func_void_Person& value) {
     return std::make_shared<Func_void_Person_Wrapper>(value);
   }
+  
+  /**
+   * Specialized version of `std::optional<Powertrain>`.
+   */
+  using std__optional_Powertrain_ = std::optional<Powertrain>;
+  inline std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value) {
+    return std::optional<Powertrain>(value);
+  }
 
 } // namespace margelo::nitro::image::bridge::swift

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridKotlinTestObjectSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridKotlinTestObjectSpec.cpp
@@ -29,6 +29,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("asyncTest", &HybridKotlinTestObjectSpec::asyncTest);
       prototype.registerHybridMethod("createMap", &HybridKotlinTestObjectSpec::createMap);
       prototype.registerHybridMethod("addOnPersonBornListener", &HybridKotlinTestObjectSpec::addOnPersonBornListener);
+      prototype.registerHybridMethod("something1", &HybridKotlinTestObjectSpec::something1);
     });
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridKotlinTestObjectSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridKotlinTestObjectSpec.hpp
@@ -21,6 +21,8 @@ namespace NitroModules { class ArrayBuffer; }
 namespace NitroModules { class AnyMap; }
 // Forward declaration of `Person` to properly resolve imports.
 namespace margelo::nitro::image { struct Person; }
+// Forward declaration of `Powertrain` to properly resolve imports.
+namespace margelo::nitro::image { enum class Powertrain; }
 
 #include <optional>
 #include <vector>
@@ -32,6 +34,7 @@ namespace margelo::nitro::image { struct Person; }
 #include <NitroModules/AnyMap.hpp>
 #include <functional>
 #include "Person.hpp"
+#include "Powertrain.hpp"
 
 namespace margelo::nitro::image {
 
@@ -75,6 +78,7 @@ namespace margelo::nitro::image {
       virtual std::future<void> asyncTest() = 0;
       virtual std::shared_ptr<AnyMap> createMap() = 0;
       virtual void addOnPersonBornListener(const std::function<void(const Person& /* p */)>& callback) = 0;
+      virtual void something1(std::optional<Powertrain> optional) = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -167,5 +167,7 @@ export interface KotlinTestObject extends HybridObject<{ android: 'kotlin' }> {
 
   addOnPersonBornListener(callback: (p: Person) => void): void
 
+  something1(optional?: Powertrain): void
+
   someRecord: Record<string, string>
 }


### PR DESCRIPTION
Fixes enum parsing by properly detecting the non-nullable type in unions.

This change now allows these APIs to work:

```ts
(event?: Type | TypeB)
(event: Type | TypeB)
```

Previously that broke.

- Fixes https://github.com/mrousavy/nitro/issues/125
- Fixes https://github.com/mrousavy/nitro/pull/116