### PR TITLE
fix: Fix `NITRO_DEBUG` debug/release preprocessor directive

### DIFF
--- a/example/ios/NitroExample.xcodeproj/xcshareddata/xcschemes/NitroExample.xcscheme
+++ b/example/ios/NitroExample.xcodeproj/xcshareddata/xcschemes/NitroExample.xcscheme
@@ -41,7 +41,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/example/ios/NitroExample.xcodeproj/xcshareddata/xcschemes/NitroExample.xcscheme
+++ b/example/ios/NitroExample.xcodeproj/xcshareddata/xcschemes/NitroExample.xcscheme
@@ -41,7 +41,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/example/src/screens/HybridObjectTestsScreen.tsx
+++ b/example/src/screens/HybridObjectTestsScreen.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react'
 
-import { StyleSheet, View, Text, ScrollView, Button } from 'react-native'
+import {
+  StyleSheet,
+  View,
+  Text,
+  ScrollView,
+  Button,
+  Platform,
+} from 'react-native'
 import {
   HybridTestObjectCpp,
   HybridTestObjectSwiftKotlin,
@@ -139,7 +146,7 @@ export function HybridObjectTestsScreen() {
           }}
         />
         <View style={styles.flex} />
-        <Text>{NitroModules.buildType}</Text>
+        <Text style={styles.buildTypeText}>{NitroModules.buildType}</Text>
       </View>
 
       <ScrollView contentContainerStyle={styles.scrollContent}>
@@ -176,9 +183,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: 15,
   },
   topControls: {
-    marginLeft: 15,
+    marginHorizontal: 15,
     marginBottom: 10,
     flexDirection: 'row',
+    alignItems: 'center',
+  },
+  buildTypeText: {
+    fontFamily: Platform.select({
+      ios: 'Menlo',
+      macos: 'Menlo',
+      android: 'monospace',
+    }),
+    fontWeight: 'bold',
   },
   segmentedControl: {
     minWidth: 180,

--- a/example/src/screens/HybridObjectTestsScreen.tsx
+++ b/example/src/screens/HybridObjectTestsScreen.tsx
@@ -9,6 +9,7 @@ import { getTests, type TestRunner } from '../getTests'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { logPrototypeChain } from '../logPrototypeChain'
 import SegmentedControl from '@react-native-segmented-control/segmented-control'
+import { NitroModules } from 'react-native-nitro-modules'
 
 logPrototypeChain(HybridTestObjectCpp)
 
@@ -128,14 +129,18 @@ export function HybridObjectTestsScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <Text style={styles.header}>HybridObject Tests</Text>
-      <SegmentedControl
-        style={styles.segmentedControl}
-        values={['C++', 'Swift/Kotlin']}
-        selectedIndex={selectedIndex}
-        onChange={({ nativeEvent: { selectedSegmentIndex } }) => {
-          setSelectedIndex(selectedSegmentIndex)
-        }}
-      />
+      <View style={styles.topControls}>
+        <SegmentedControl
+          style={styles.segmentedControl}
+          values={['C++', 'Swift/Kotlin']}
+          selectedIndex={selectedIndex}
+          onChange={({ nativeEvent: { selectedSegmentIndex } }) => {
+            setSelectedIndex(selectedSegmentIndex)
+          }}
+        />
+        <View style={styles.flex} />
+        <Text>{NitroModules.buildType}</Text>
+      </View>
 
       <ScrollView contentContainerStyle={styles.scrollContent}>
         {tests.map((t, i) => (
@@ -170,11 +175,13 @@ const styles = StyleSheet.create({
   scrollContent: {
     paddingHorizontal: 15,
   },
-  segmentedControl: {
-    alignSelf: 'flex-start',
-    minWidth: 180,
+  topControls: {
     marginLeft: 15,
     marginBottom: 10,
+    flexDirection: 'row',
+  },
+  segmentedControl: {
+    minWidth: 180,
   },
   box: {
     width: 60,

--- a/packages/nitrogen/src/autolinking/android/createHybridObjectInitializer.ts
+++ b/packages/nitrogen/src/autolinking/android/createHybridObjectInitializer.ts
@@ -56,6 +56,7 @@ export function createHybridObjectIntializer(): SourceFile[] {
 ${createFileMetadataString(`${autolinkingClassName}.hpp`)}
 
 #include <jni.h>
+#include <NitroModules/NitroDefines.hpp>
 
 namespace ${cxxNamespace} {
 

--- a/packages/nitrogen/src/syntax/kotlin/KotlinHybridObjectRegistration.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinHybridObjectRegistration.ts
@@ -42,7 +42,7 @@ HybridObjectRegistry::registerHybridObjectConstructor(
     static auto defaultConstructor = javaClass->getConstructor<${JHybridTSpec}::javaobject()>();
 
     auto instance = javaClass->newObject(defaultConstructor);
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
     if (instance == nullptr) [[unlikely]] {
       throw std::runtime_error("Failed to create an instance of \\"${JHybridTSpec}\\" - the constructor returned null!");
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -43,9 +43,9 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static auto javaClass = jni::findClassStatic("com/margelo/nitro/image/ImageFactory");
         static auto defaultConstructor = javaClass->getConstructor<JHybridImageFactorySpec::javaobject()>();
-    
+
         auto instance = javaClass->newObject(defaultConstructor);
-    #ifndef NDEBUG
+    #ifdef NITRO_DEBUG
         if (instance == nullptr) [[unlikely]] {
           throw std::runtime_error("Failed to create an instance of \"JHybridImageFactorySpec\" - the constructor returned null!");
         }
@@ -68,9 +68,9 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static auto javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridTestObjectKotlin");
         static auto defaultConstructor = javaClass->getConstructor<JHybridTestObjectSwiftKotlinSpec::javaobject()>();
-    
+
         auto instance = javaClass->newObject(defaultConstructor);
-    #ifndef NDEBUG
+    #ifdef NITRO_DEBUG
         if (instance == nullptr) [[unlikely]] {
           throw std::runtime_error("Failed to create an instance of \"JHybridTestObjectSwiftKotlinSpec\" - the constructor returned null!");
         }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -43,7 +43,7 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static auto javaClass = jni::findClassStatic("com/margelo/nitro/image/ImageFactory");
         static auto defaultConstructor = javaClass->getConstructor<JHybridImageFactorySpec::javaobject()>();
-
+    
         auto instance = javaClass->newObject(defaultConstructor);
     #ifdef NITRO_DEBUG
         if (instance == nullptr) [[unlikely]] {
@@ -68,7 +68,7 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static auto javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridTestObjectKotlin");
         static auto defaultConstructor = javaClass->getConstructor<JHybridTestObjectSwiftKotlinSpec::javaobject()>();
-
+    
         auto instance = javaClass->newObject(defaultConstructor);
     #ifdef NITRO_DEBUG
         if (instance == nullptr) [[unlikely]] {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.hpp
@@ -6,6 +6,7 @@
 ///
 
 #include <jni.h>
+#include <NitroModules/NitroDefines.hpp>
 
 namespace margelo::nitro::image {
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/platform/NitroLogger.cpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/platform/NitroLogger.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "NitroLogger.hpp"
+#include "NitroDefines.hpp"
 #include <android/log.h>
 
 namespace margelo::nitro {
@@ -26,7 +27,7 @@ int levelToAndroidLevel(LogLevel level) {
 }
 
 void Logger::nativeLog(LogLevel level, const char* tag, const std::string& message) {
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
   int logLevel = levelToAndroidLevel(level);
   std::string combinedTag = "Nitro." + std::string(tag);
   __android_log_print(logLevel, combinedTag.c_str(), "%s", message.c_str());

--- a/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.cpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.cpp
@@ -8,6 +8,7 @@
 #include "JHybridObjectRegistry.hpp"
 #include "HybridObjectRegistry.hpp"
 #include "JNISharedPtr.hpp"
+#include "NitroDefines.hpp"
 
 namespace margelo::nitro {
 
@@ -17,7 +18,7 @@ void JHybridObjectRegistry::registerHybridObjectConstructor(jni::alias_ref<jni::
   HybridObjectRegistry::registerHybridObjectConstructor(hybridObjectName, [=]() -> std::shared_ptr<HybridObject> {
     // 1. Call the Java initializer function
     jni::local_ref<JHybridObject::javaobject> hybridObject = sharedInitializer->call();
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
     if (hybridObject == nullptr) [[unlikely]] {
       throw std::runtime_error("Failed to create HybridObject \"" + hybridObjectName + "\" - the constructor returned null!");
     }

--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -14,6 +14,7 @@ struct JSIConverter;
 
 #include "CountTrailingOptionals.hpp"
 #include "JSIConverter.hpp"
+#include "NitroDefines.hpp"
 #include "TypeInfo.hpp"
 #include <functional>
 #include <jsi/jsi.h>
@@ -170,7 +171,7 @@ private:
   static inline std::shared_ptr<THybrid> getHybridObjectNativeState(jsi::Runtime& runtime, const jsi::Value& value, FunctionKind funcKind,
                                                                     const std::string& funcName) {
     // 1. Convert jsi::Value to jsi::Object
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
     if (!value.isObject()) [[unlikely]] {
       throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) + " - `this` is not bound!");
     }
@@ -178,7 +179,7 @@ private:
     jsi::Object object = value.getObject(runtime);
 
     // 2. Check if it even has any kind of `NativeState`
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
     if (!object.hasNativeState(runtime)) [[unlikely]] {
       throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) +
                                       " - `this` does not have a NativeState! Suggestions:\n"
@@ -191,7 +192,7 @@ private:
 
     // 3. Get `NativeState` from the jsi::Object and check if it is non-null
     std::shared_ptr<jsi::NativeState> nativeState = object.getNativeState(runtime);
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
     if (nativeState == nullptr) [[unlikely]] {
       throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) +
                                       " - `this`'s `NativeState` is `nullptr`, "
@@ -201,7 +202,7 @@ private:
 
     // 4. Try casting it to our desired target type.
     std::shared_ptr<THybrid> hybridInstance = std::dynamic_pointer_cast<THybrid>(nativeState);
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
     if (hybridInstance == nullptr) [[unlikely]] {
       throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) +
                                       " - `this` has a NativeState, but it's the wrong type!");

--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -4,6 +4,7 @@
 
 #include "HybridObject.hpp"
 #include "JSIConverter.hpp"
+#include "NitroDefines.hpp"
 
 namespace margelo::nitro {
 
@@ -70,7 +71,7 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
   // 6. Set memory size so Hermes GC knows about actual memory
   object.setExternalMemoryPressure(runtime, getExternalMemorySize());
 
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
   // 7. Assign a private __type property for debugging - this will be used so users know it's not just an empty object.
   object.setProperty(runtime, "__type", jsi::String::createFromUtf8(runtime, "NativeState<" + std::string(_name) + ">"));
 #endif

--- a/packages/react-native-nitro-modules/cpp/jsi/JSICache.cpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSICache.cpp
@@ -7,6 +7,7 @@
 
 #include "JSICache.hpp"
 #include "JSIHelpers.hpp"
+#include "NitroDefines.hpp"
 
 namespace margelo::nitro {
 
@@ -46,7 +47,7 @@ JSICacheReference JSICache::getOrCreateCache(jsi::Runtime& runtime) {
     Logger::log(LogLevel::Warning, TAG, "JSICache was created, but it is no longer strong!");
   }
 
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
   if (runtime.global().hasProperty(runtime, CACHE_PROP_NAME)) [[unlikely]] {
     throw std::runtime_error("The Runtime \"" + getRuntimeId(runtime) + "\" already has a global cache! (\"" + CACHE_PROP_NAME + "\")");
   }

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+HybridObject.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+HybridObject.hpp
@@ -10,6 +10,7 @@ class HybridObject;
 } // namespace margelo::nitro
 
 #include "IsSharedPtrTo.hpp"
+#include "NitroDefines.hpp"
 #include "TypeInfo.hpp"
 #include <jsi/jsi.h>
 #include <type_traits>
@@ -24,7 +25,7 @@ struct JSIConverter<T, std::enable_if_t<is_shared_ptr_to_v<T, jsi::NativeState>>
   using TPointee = typename T::element_type;
 
   static inline T fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
     if (!arg.isObject()) [[unlikely]] {
       if (arg.isUndefined()) [[unlikely]] {
         throw jsi::JSError(runtime, invalidTypeErrorMessage("undefined", "It is undefined!"));
@@ -36,7 +37,7 @@ struct JSIConverter<T, std::enable_if_t<is_shared_ptr_to_v<T, jsi::NativeState>>
 #endif
     jsi::Object object = arg.asObject(runtime);
 
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
     if (!object.hasNativeState<TPointee>(runtime)) [[unlikely]] {
       if (!object.hasNativeState(runtime)) [[unlikely]] {
         std::string stringRepresentation = arg.toString(runtime).utf8(runtime);

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIHelpers.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIHelpers.hpp
@@ -1,6 +1,6 @@
 //
 //  JSIHelpers.hpp
-//  Pods
+//  Nitro
 //
 //  Created by Marc Rousavy on 07.08.24.
 //

--- a/packages/react-native-nitro-modules/cpp/platform/NitroLogger.hpp
+++ b/packages/react-native-nitro-modules/cpp/platform/NitroLogger.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "NitroDefines.hpp"
 #include <cstdarg>
 #include <cstdio>
 #include <iostream>
@@ -22,7 +23,7 @@ private:
 public:
   template <typename... Args>
   static void log(LogLevel level, const char* tag, const char* format, Args... args) {
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
     // 1. Make sure args can be passed to sprintf(..)
     static_assert(all_are_trivially_copyable<Args...>(), "All arguments passed to Logger::log(..) must be trivially copyable! "
                                                          "Did you try to pass a complex type, like std::string?");

--- a/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
+++ b/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "HybridObjectPrototype.hpp"
+#include "NitroDefines.hpp"
 #include "NitroLogger.hpp"
 
 namespace margelo::nitro {
@@ -69,7 +70,7 @@ jsi::Value HybridObjectPrototype::createPrototype(jsi::Runtime& runtime, const s
   prototypeCache.emplace(prototype->getNativeInstanceId(), cachedObject);
 
   // 7. In DEBUG, add a __type info to the prototype object.
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
   auto typeName = "Prototype<" + std::string(prototype->getNativeInstanceId().name()) + ">";
   cachedObject->setProperty(runtime, "__type", jsi::String::createFromUtf8(runtime, typeName));
 #endif

--- a/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
+++ b/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "HybridObjectRegistry.hpp"
+#include "NitroDefines.hpp"
 #include "NitroLogger.hpp"
 
 namespace margelo::nitro {
@@ -31,7 +32,7 @@ std::vector<std::string> HybridObjectRegistry::getAllHybridObjectNames() {
 void HybridObjectRegistry::registerHybridObjectConstructor(const std::string& hybridObjectName, HybridObjectConstructorFn&& constructorFn) {
   Logger::log(LogLevel::Info, TAG, "Registering HybridObject \"%s\"...", hybridObjectName.c_str());
   auto& map = HybridObjectRegistry::getRegistry();
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
   if (map.contains(hybridObjectName)) [[unlikely]] {
     auto message =
         "HybridObject \"" + std::string(hybridObjectName) +
@@ -63,7 +64,7 @@ std::shared_ptr<HybridObject> HybridObjectRegistry::createHybridObject(const std
   }
   std::shared_ptr<HybridObject> instance = fn->second();
 
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
   if (instance == nullptr) [[unlikely]] {
     throw std::runtime_error("Failed to create HybridObject \"" + hybridObjectName +
                              "\" - "

--- a/packages/react-native-nitro-modules/cpp/threading/Dispatcher.cpp
+++ b/packages/react-native-nitro-modules/cpp/threading/Dispatcher.cpp
@@ -1,5 +1,6 @@
 #include "Dispatcher.hpp"
 #include "JSIHelpers.hpp"
+#include "NitroDefines.hpp"
 #include "NitroLogger.hpp"
 
 namespace margelo::nitro {
@@ -41,8 +42,8 @@ std::shared_ptr<Dispatcher> Dispatcher::getRuntimeGlobalDispatcher(jsi::Runtime&
 }
 
 jsi::Value Dispatcher::getRuntimeGlobalDispatcherHolder(jsi::Runtime& runtime) {
-#ifndef NDEBUG
-  if (!runtime.global().hasProperty(runtime, GLOBAL_DISPATCHER_HOLDER_NAME)) {
+#ifdef NITRO_DEBUG
+  if (!runtime.global().hasProperty(runtime, GLOBAL_DISPATCHER_HOLDER_NAME)) [[unlikely]] {
     throw std::runtime_error("Failed to get current Dispatcher - the global Dispatcher "
                              "holder (global." +
                              std::string(GLOBAL_DISPATCHER_HOLDER_NAME) +

--- a/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
+++ b/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
@@ -87,6 +87,13 @@ jsi::Value NativeNitroModules::get(jsi::Runtime& runtime, const jsi::PropNameID&
           return jsi::Value::undefined();
         });
   }
+  if (name == "buildType") {
+#ifdef NITRO_DEBUG
+    return jsi::String::createFromAscii(runtime, "debug");
+#else
+    return jsi::String::createFromAscii(runtime, "release");
+#endif
+  }
 
   return jsi::Value::undefined();
 }

--- a/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
+++ b/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
@@ -9,6 +9,7 @@
 #include "CallInvokerDispatcher.hpp"
 #include "Dispatcher.hpp"
 #include "HybridObjectRegistry.hpp"
+#include "NitroDefines.hpp"
 
 namespace facebook::react {
 
@@ -34,7 +35,7 @@ jsi::Value NativeNitroModules::get(jsi::Runtime& runtime, const jsi::PropNameID&
     return jsi::Function::createFromHostFunction(
         runtime, jsi::PropNameID::forUtf8(runtime, "createHybridObject"), 2,
         [this](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args, size_t count) -> jsi::Value {
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
           if (count != 1 && count != 2) [[unlikely]] {
             throw jsi::JSError(runtime, "NitroModules.createHybridObject(..) expects 1 or 2 arguments, but " + std::to_string(count) +
                                             " were supplied!");
@@ -53,7 +54,7 @@ jsi::Value NativeNitroModules::get(jsi::Runtime& runtime, const jsi::PropNameID&
     return jsi::Function::createFromHostFunction(
         runtime, jsi::PropNameID::forUtf8(runtime, "hasHybridObject"), 1,
         [this](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args, size_t count) -> jsi::Value {
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
           if (count != 1) [[unlikely]] {
             throw jsi::JSError(runtime,
                                "NitroModules.hasHybridObject(..) expects 1 argument (name), but received " + std::to_string(count) + "!");

--- a/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
@@ -1,12 +1,20 @@
 //
 //  NitroDefines.hpp
-//  Pods
+//  Nitro
 //
 //  Created by Marc Rousavy on 29.07.24.
 //
 
 #ifndef NitroDefines_h
 #define NitroDefines_h
+
+// Sets whether to use debug or optimized production build flags
+#ifdef DEBUG
+#define NITRO_DEBUG
+#endif
+#ifdef NDEBUG
+#undef NITRO_DEBUG
+#endif
 
 // Helper to find out if a C++ compiler attribute is available
 #ifdef __has_attribute

--- a/packages/react-native-nitro-modules/cpp/utils/OwningLock.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/OwningLock.hpp
@@ -1,6 +1,6 @@
 //
 //  OwningLock.hpp
-//  Pods
+//  Nitro
 //
 //  Created by Marc Rousavy on 30.07.24.
 //

--- a/packages/react-native-nitro-modules/cpp/utils/TypeInfo.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/TypeInfo.hpp
@@ -1,6 +1,6 @@
 //
 //  TypeInfo.hpp
-//  Pods
+//  Nitro
 //
 //  Created by Marc Rousavy on 17.07.24.
 //

--- a/packages/react-native-nitro-modules/ios/core/PromiseHolder.hpp
+++ b/packages/react-native-nitro-modules/ios/core/PromiseHolder.hpp
@@ -1,6 +1,6 @@
 //
 //  PromiseHolder.hpp
-//  Pods
+//  Nitro
 //
 //  Created by Marc Rousavy on 15.08.24.
 //

--- a/packages/react-native-nitro-modules/ios/platform/NitroLogger.mm
+++ b/packages/react-native-nitro-modules/ios/platform/NitroLogger.mm
@@ -7,6 +7,7 @@
 
 #include "NitroLogger.hpp"
 #include "AnyMapHolder.hpp"
+#include "NitroDefines.hpp"
 #include <Foundation/Foundation.h>
 
 namespace margelo::nitro {
@@ -27,7 +28,7 @@ const char* levelToString(LogLevel level) {
 }
 
 void Logger::nativeLog(LogLevel level, const char* tag, const std::string& message) {
-#ifndef NDEBUG
+#ifdef NITRO_DEBUG
   const char* logLevel = levelToString(level);
   NSLog(@"[%s] [Nitro.%s] %s", logLevel, tag, message.c_str());
 #endif

--- a/packages/react-native-nitro-modules/src/NativeNitroModules.ts
+++ b/packages/react-native-nitro-modules/src/NativeNitroModules.ts
@@ -13,6 +13,7 @@ export interface Spec extends TurboModule {
   // JSI Helpers
   hasNativeState(obj: UnsafeObject): boolean
   removeNativeState(obj: UnsafeObject): void
+  buildType: 'debug' | 'release'
 }
 
 let turboModule: Spec | undefined

--- a/packages/react-native-nitro-modules/src/NitroModules.ts
+++ b/packages/react-native-nitro-modules/src/NitroModules.ts
@@ -65,4 +65,12 @@ export const NitroModules = {
     const nitro = getNativeNitroModules()
     nitro.removeNativeState(object)
   },
+  /**
+   * Gets the current build type configuration as defined in the `NITRO_DEBUG`
+   * preprocessor flag.
+   */
+  get buildType(): 'debug' | 'release' {
+    const nitro = getNativeNitroModules()
+    return nitro.buildType
+  },
 }


### PR DESCRIPTION
Properly uses `NITRO_DEBUG` on DEBUG/!NDEBUG builds, and release code otherwise.