### PR TITLE
fix: Forward declare HybridObjects as well in Swift headers

### DIFF
--- a/packages/nitrogen/src/createPlatformSpec.ts
+++ b/packages/nitrogen/src/createPlatformSpec.ts
@@ -7,12 +7,18 @@ import { Property } from './syntax/Property.js'
 import { Method } from './syntax/Method.js'
 import { createSwiftHybridObject } from './syntax/swift/SwiftHybridObject.js'
 import { createKotlinHybridObject } from './syntax/kotlin/KotlinHybridObject.js'
+import { createType } from './syntax/createType.js'
 
 export function generatePlatformFiles(
   declaration: InterfaceDeclaration,
   language: Language
 ): SourceFile[] {
   const spec = getHybridObjectSpec(declaration, language)
+
+  // TODO: We currently just call this so the HybridObject itself is a "known type".
+  // This causes the Swift Umbrella header to properly forward-declare it.
+  // Without this, only Hybrid Objects that are actually used in public APIs will be forward-declared.
+  createType(declaration.getType(), false)
 
   switch (language) {
     case 'c++':

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Umbrella.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Umbrella.hpp
@@ -14,6 +14,8 @@ namespace NitroModules { class AnyMap; }
 namespace NitroModules { class ArrayBuffer; }
 // Forward declaration of `Car` to properly resolve imports.
 namespace margelo::nitro::image { struct Car; }
+// Forward declaration of `HybridImageFactorySpec` to properly resolve imports.
+namespace margelo::nitro::image { class HybridImageFactorySpec; }
 // Forward declaration of `HybridImageSpec` to properly resolve imports.
 namespace margelo::nitro::image { class HybridImageSpec; }
 // Forward declaration of `HybridTestObjectCppSpec` to properly resolve imports.
@@ -35,6 +37,7 @@ namespace margelo::nitro::image { enum class Powertrain; }
 
 // Include C++ defined types
 #include "Car.hpp"
+#include "HybridImageFactorySpec.hpp"
 #include "HybridImageSpec.hpp"
 #include "HybridTestObjectCppSpec.hpp"
 #include "HybridTestObjectSwiftKotlinSpec.hpp"
@@ -65,6 +68,8 @@ namespace margelo::nitro::image { enum class Powertrain; }
 #include <NitroModules/PromiseHolder.hpp>
 
 // Forward declarations of Swift defined types
+// Forward declaration of `HybridImageFactorySpecCxx` to properly resolve imports.
+namespace NitroImage { class HybridImageFactorySpecCxx; }
 // Forward declaration of `HybridImageSpecCxx` to properly resolve imports.
 namespace NitroImage { class HybridImageSpecCxx; }
 // Forward declaration of `HybridTestObjectCppSpecCxx` to properly resolve imports.


### PR DESCRIPTION
Also throw HybridObject declarations themself into the "known types" list. That way they will be forward declared in the generated Swift headers.

- Fixes https://github.com/mrousavy/nitro/issues/133