### PR TITLE
fix: Make string literals throw again, and test optional enums

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -29,7 +29,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - NitroModules (0.8.0):
+  - NitroModules (0.9.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1828,7 +1828,7 @@ SPEC CHECKSUMS:
   glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
   hermes-engine: 3b6e0717ca847e2fc90a201e59db36caf04dee88
   NitroImage: 0cffeee137c14b8c8df97649626646528cb89b28
-  NitroModules: 7184d6a9527f2d015c7e4865ee6615b3e26d9cfb
+  NitroModules: a3e3619f2c74dd9a706d3597d7c359d56e94ef22
   RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
   RCTDeprecation: 34cbf122b623037ea9facad2e92e53434c5c7422
   RCTRequired: 24c446d7bcd0f517d516b6265d8df04dc3eb1219

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -307,6 +307,16 @@ export function getTests(
         .didNotThrow()
         .equals('passed')
     ),
+    createTest('tryOptionalEnum(...)', () =>
+      it(() => testObject.tryOptionalEnum('gas'))
+        .didNotThrow()
+        .equals('gas')
+    ),
+    createTest('tryMiddleParam(...)', () =>
+      it(() => testObject.tryOptionalEnum(undefined))
+        .didNotThrow()
+        .equals(undefined)
+    ),
 
     // Variants tests
     ...('someVariant' in testObject

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -312,7 +312,7 @@ export function getTests(
         .didNotThrow()
         .equals('gas')
     ),
-    createTest('tryMiddleParam(...)', () =>
+    createTest('tryOptionalEnum(...)', () =>
       it(() => testObject.tryOptionalEnum(undefined))
         .didNotThrow()
         .equals(undefined)

--- a/packages/nitrogen/src/syntax/createType.ts
+++ b/packages/nitrogen/src/syntax/createType.ts
@@ -265,7 +265,9 @@ export function createType(type: TSMorphType, isOptional: boolean): Type {
         `Anonymous objects cannot be represented in C++! Extract "${type.getText()}" to a separate interface/type declaration.`
       )
     } else if (type.isStringLiteral()) {
-      return new StringType()
+      throw new Error(
+        `String literal ${type.getText()} cannot be represented in C++ because it is ambiguous between a string and a discriminating union enum.`
+      )
     } else {
       throw new Error(
         `The TypeScript type "${type.getText()}" cannot be represented in C++!`

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -52,6 +52,10 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
       case 'enum':
         // Enums cannot be referenced from C++ <-> Swift bi-directionally,
         // so we just pass the underlying raw value (int32), and cast from Int <-> Enum.
+        if (this.isBridgingToDirectCppTarget) {
+          // ...unless we bridge directly to a C++ target. Then we don't need special conversion.
+          return false
+        }
         return true
       case 'hybrid-object':
         // Swift HybridObjects need to be wrapped in our own *Cxx Swift classes.
@@ -83,6 +87,9 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
         return true
       case 'array-buffer':
         // ArrayBufferHolder <> std::shared_ptr<ArrayBuffer>
+        if (this.isBridgingToDirectCppTarget) {
+          return false
+        }
         return true
       case 'promise':
         // PromiseHolder<T> <> std::shared_ptr<std::promise<T>>
@@ -351,6 +358,9 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
         const wrapping = new SwiftCxxBridgedType(optional.wrappingType, true)
         switch (language) {
           case 'swift':
+            if (!wrapping.needsSpecialHandling) {
+              return `${cppParameterName}.value`
+            }
             return `
 { () -> ${optional.getCode('swift')} in
   if let actualValue = ${cppParameterName}.value {

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -348,7 +348,7 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
       }
       case 'optional': {
         const optional = getTypeAs(this.type, OptionalType)
-        const wrapping = new SwiftCxxBridgedType(optional.wrappingType)
+        const wrapping = new SwiftCxxBridgedType(optional.wrappingType, true)
         switch (language) {
           case 'swift':
             return `
@@ -525,7 +525,7 @@ case ${i}:
         }
       case 'optional': {
         const optional = getTypeAs(this.type, OptionalType)
-        const wrapping = new SwiftCxxBridgedType(optional.wrappingType)
+        const wrapping = new SwiftCxxBridgedType(optional.wrappingType, true)
         const bridge = this.getBridgeOrThrow()
         const makeFunc = `bridge.${bridge.funcName}`
         switch (language) {

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -71,6 +71,11 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
         return str
     }
 
+
+    override fun tryOptionalEnum(powertrain: Powertrain?): Powertrain? {
+        return powertrain
+    }
+
     override fun calculateFibonacciSync(value: Double): Long {
         val n = value.toInt()
         if (n == 0) return 0L

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -72,8 +72,8 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
     }
 
 
-    override fun tryOptionalEnum(powertrain: Powertrain?): Powertrain? {
-        return powertrain
+    override fun tryOptionalEnum(value: Powertrain?): Powertrain? {
+        return value
     }
 
     override fun calculateFibonacciSync(value: Double): Long {

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -145,6 +145,10 @@ std::string HybridTestObjectCpp::tryMiddleParam(double num, std::optional<bool> 
   return str;
 }
 
+std::optional<Powertrain> HybridTestObjectCpp::tryOptionalEnum(std::optional<Powertrain> value) {
+  return value;
+}
+
 std::variant<std::string, double>
 HybridTestObjectCpp::passVariant(const std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>& either) {
   if (std::holds_alternative<std::string>(either)) {

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -70,6 +70,7 @@ public:
   double funcThatThrows() override;
   std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) override;
   std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) override;
+  std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) override;
   std::variant<std::string, double>
   passVariant(const std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>& either) override;
 

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -100,8 +100,8 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     return str
   }
 
-  func tryOptionalEnum(powertrain: Powertrain?) throws -> Powertrain? {
-    return powertrain
+  func tryOptionalEnum(value: Powertrain?) throws -> Powertrain? {
+    return value
   }
 
   func calculateFibonacciSync(value: Double) throws -> Int64 {

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -100,6 +100,10 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     return str
   }
 
+  func tryOptionalEnum(powertrain: Powertrain?) throws -> Powertrain? {
+    return powertrain
+  }
+
   func calculateFibonacciSync(value: Double) throws -> Int64 {
     let n = Int64(value)
     if n <= 1 {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -11,10 +11,10 @@
 namespace margelo::nitro::image { class HybridTestObjectSwiftKotlinSpec; }
 // Forward declaration of `AnyMap` to properly resolve imports.
 namespace NitroModules { class AnyMap; }
-// Forward declaration of `Car` to properly resolve imports.
-namespace margelo::nitro::image { struct Car; }
 // Forward declaration of `Powertrain` to properly resolve imports.
 namespace margelo::nitro::image { enum class Powertrain; }
+// Forward declaration of `Car` to properly resolve imports.
+namespace margelo::nitro::image { struct Car; }
 // Forward declaration of `Person` to properly resolve imports.
 namespace margelo::nitro::image { struct Person; }
 // Forward declaration of `ArrayBuffer` to properly resolve imports.
@@ -28,12 +28,12 @@ namespace NitroModules { class ArrayBuffer; }
 #include <NitroModules/JNISharedPtr.hpp>
 #include <NitroModules/AnyMap.hpp>
 #include <NitroModules/JAnyMap.hpp>
+#include "Powertrain.hpp"
+#include "JPowertrain.hpp"
 #include <future>
 #include <NitroModules/JPromise.hpp>
 #include "Car.hpp"
 #include "JCar.hpp"
-#include "Powertrain.hpp"
-#include "JPowertrain.hpp"
 #include "Person.hpp"
 #include "JPerson.hpp"
 #include <NitroModules/ArrayBuffer.hpp>
@@ -171,6 +171,11 @@ namespace margelo::nitro::image {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jni::alias_ref<jni::JBoolean> /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryMiddleParam");
     auto result = method(_javaPart, num, boo.has_value() ? jni::JBoolean::valueOf(boo.value()) : nullptr, jni::make_jstring(str));
     return result->toStdString();
+  }
+  std::optional<Powertrain> JHybridTestObjectSwiftKotlinSpec::tryOptionalEnum(std::optional<Powertrain> value) {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPowertrain>(jni::alias_ref<JPowertrain> /* value */)>("tryOptionalEnum");
+    auto result = method(_javaPart, value.has_value() ? JPowertrain::fromCpp(value.value()) : nullptr);
+    return result != nullptr ? std::make_optional(result->toCpp()) : std::nullopt;
   }
   int64_t JHybridTestObjectSwiftKotlinSpec::calculateFibonacciSync(double value) {
     static const auto method = _javaPart->getClass()->getMethod<int64_t(double /* value */)>("calculateFibonacciSync");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -65,6 +65,7 @@ namespace margelo::nitro::image {
     double funcThatThrows() override;
     std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) override;
     std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) override;
+    std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) override;
     int64_t calculateFibonacciSync(double value) override;
     std::future<int64_t> calculateFibonacciAsync(double value) override;
     std::future<void> wait(double seconds) override;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -118,6 +118,10 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun tryOptionalEnum(value: Powertrain?): Powertrain?
+  
+  @DoNotStrip
+  @Keep
   abstract fun calculateFibonacciSync(value: Double): Long
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -144,6 +144,14 @@ namespace margelo::nitro::image::bridge::swift {
   }
   
   /**
+   * Specialized version of `std::optional<Powertrain>`.
+   */
+  using std__optional_Powertrain_ = std::optional<Powertrain>;
+  inline std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value) {
+    return std::optional<Powertrain>(value);
+  }
+  
+  /**
    * Specialized version of `std::vector<double>`.
    */
   using std__vector_double_ = std::vector<double>;

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -18,10 +18,10 @@ namespace margelo::nitro::image { class HybridTestObjectSwiftKotlinSpec; }
 namespace margelo::nitro::image { class HybridTestObjectSwiftKotlinSpecSwift; }
 // Forward declaration of `AnyMap` to properly resolve imports.
 namespace NitroModules { class AnyMap; }
-// Forward declaration of `Car` to properly resolve imports.
-namespace margelo::nitro::image { struct Car; }
 // Forward declaration of `Powertrain` to properly resolve imports.
 namespace margelo::nitro::image { enum class Powertrain; }
+// Forward declaration of `Car` to properly resolve imports.
+namespace margelo::nitro::image { struct Car; }
 // Forward declaration of `Person` to properly resolve imports.
 namespace margelo::nitro::image { struct Person; }
 // Forward declaration of `ArrayBuffer` to properly resolve imports.
@@ -35,11 +35,11 @@ namespace NitroModules { class ArrayBufferHolder; }
 #include "HybridTestObjectSwiftKotlinSpec.hpp"
 #include "HybridTestObjectSwiftKotlinSpecSwift.hpp"
 #include <NitroModules/AnyMap.hpp>
+#include "Powertrain.hpp"
 #include <future>
 #include <NitroModules/PromiseHolder.hpp>
 #include <functional>
 #include "Car.hpp"
-#include "Powertrain.hpp"
 #include "Person.hpp"
 #include <NitroModules/ArrayBuffer.hpp>
 #include <NitroModules/ArrayBufferHolder.hpp>
@@ -168,6 +168,10 @@ namespace margelo::nitro::image {
     }
     inline std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) override {
       auto __result = _swiftPart.tryMiddleParam(std::forward<decltype(num)>(num), boo, str);
+      return __result;
+    }
+    inline std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) override {
+      auto __result = _swiftPart.tryOptionalEnum(value);
       return __result;
     }
     inline int64_t calculateFibonacciSync(double value) override {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -48,6 +48,7 @@ public protocol HybridTestObjectSwiftKotlinSpec: HybridObjectSpec {
   func funcThatThrows() throws -> Double
   func tryOptionalParams(num: Double, boo: Bool, str: String?) throws -> String
   func tryMiddleParam(num: Double, boo: Bool?, str: String) throws -> String
+  func tryOptionalEnum(value: Powertrain?) throws -> Powertrain?
   func calculateFibonacciSync(value: Double) throws -> Int64
   func calculateFibonacciAsync(value: Double) throws -> Promise<Int64>
   func wait(seconds: Double) throws -> Promise<Void>

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -292,6 +292,29 @@ public final class HybridTestObjectSwiftKotlinSpecCxx {
   }
   
   @inline(__always)
+  public func tryOptionalEnum(value: bridge.std__optional_Powertrain_) -> bridge.std__optional_Powertrain_ {
+    do {
+      let result = try self.implementation.tryOptionalEnum(value: { () -> Powertrain? in
+        if let actualValue = value.value {
+          return margelo.nitro.image.Powertrain(rawValue: actualValue)!
+        } else {
+          return nil
+        }
+      }())
+      return { () -> bridge.std__optional_Powertrain_ in
+        if let actualValue = result {
+          return bridge.create_std__optional_Powertrain_(actualValue.rawValue)
+        } else {
+          return .init()
+        }
+      }()
+    } catch {
+      let message = "\(error.localizedDescription)"
+      fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
+    }
+  }
+  
+  @inline(__always)
   public func calculateFibonacciSync(value: Double) -> Int64 {
     do {
       let result = try self.implementation.calculateFibonacciSync(value: value)

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -296,14 +296,14 @@ public final class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       let result = try self.implementation.tryOptionalEnum(value: { () -> Powertrain? in
         if let actualValue = value.value {
-          return margelo.nitro.image.Powertrain(rawValue: actualValue)!
+          return margelo.nitro.image.Powertrain(rawValue: actualValue.rawValue)!
         } else {
           return nil
         }
       }())
       return { () -> bridge.std__optional_Powertrain_ in
         if let actualValue = result {
-          return bridge.create_std__optional_Powertrain_(actualValue.rawValue)
+          return bridge.create_std__optional_Powertrain_(actualValue)
         } else {
           return .init()
         }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -296,7 +296,7 @@ public final class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       let result = try self.implementation.tryOptionalEnum(value: { () -> Powertrain? in
         if let actualValue = value.value {
-          return margelo.nitro.image.Powertrain(rawValue: actualValue.rawValue)!
+          return actualValue
         } else {
           return nil
         }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -277,13 +277,7 @@ public final class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func tryMiddleParam(num: Double, boo: bridge.std__optional_bool_, str: std.string) -> std.string {
     do {
-      let result = try self.implementation.tryMiddleParam(num: num, boo: { () -> Bool? in
-        if let actualValue = boo.value {
-          return actualValue
-        } else {
-          return nil
-        }
-      }(), str: String(str))
+      let result = try self.implementation.tryMiddleParam(num: num, boo: boo.value, str: String(str))
       return std.string(result)
     } catch {
       let message = "\(error.localizedDescription)"
@@ -294,13 +288,7 @@ public final class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func tryOptionalEnum(value: bridge.std__optional_Powertrain_) -> bridge.std__optional_Powertrain_ {
     do {
-      let result = try self.implementation.tryOptionalEnum(value: { () -> Powertrain? in
-        if let actualValue = value.value {
-          return actualValue
-        } else {
-          return nil
-        }
-      }())
+      let result = try self.implementation.tryOptionalEnum(value: value.value)
       return { () -> bridge.std__optional_Powertrain_ in
         if let actualValue = result {
           return bridge.create_std__optional_Powertrain_(actualValue)

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -42,6 +42,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("funcThatThrows", &HybridTestObjectCppSpec::funcThatThrows);
       prototype.registerHybridMethod("tryOptionalParams", &HybridTestObjectCppSpec::tryOptionalParams);
       prototype.registerHybridMethod("tryMiddleParam", &HybridTestObjectCppSpec::tryMiddleParam);
+      prototype.registerHybridMethod("tryOptionalEnum", &HybridTestObjectCppSpec::tryOptionalEnum);
       prototype.registerHybridMethod("passVariant", &HybridTestObjectCppSpec::passVariant);
       prototype.registerHybridMethod("getVariantEnum", &HybridTestObjectCppSpec::getVariantEnum);
       prototype.registerHybridMethod("getVariantObjects", &HybridTestObjectCppSpec::getVariantObjects);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -17,6 +17,8 @@
 namespace margelo::nitro::image { class HybridTestObjectCppSpec; }
 // Forward declaration of `AnyMap` to properly resolve imports.
 namespace NitroModules { class AnyMap; }
+// Forward declaration of `Powertrain` to properly resolve imports.
+namespace margelo::nitro::image { enum class Powertrain; }
 // Forward declaration of `OldEnum` to properly resolve imports.
 namespace margelo::nitro::image { enum class OldEnum; }
 // Forward declaration of `Person` to properly resolve imports.
@@ -33,6 +35,7 @@ namespace NitroModules { class ArrayBuffer; }
 #include <memory>
 #include "HybridTestObjectCppSpec.hpp"
 #include <NitroModules/AnyMap.hpp>
+#include "Powertrain.hpp"
 #include <vector>
 #include "OldEnum.hpp"
 #include "Person.hpp"
@@ -96,6 +99,7 @@ namespace margelo::nitro::image {
       virtual double funcThatThrows() = 0;
       virtual std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) = 0;
       virtual std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) = 0;
+      virtual std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) = 0;
       virtual std::variant<std::string, double> passVariant(const std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>& either) = 0;
       virtual std::variant<bool, OldEnum> getVariantEnum(const std::variant<bool, OldEnum>& variant) = 0;
       virtual std::variant<Person, Car> getVariantObjects(const std::variant<Person, Car>& variant) = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -38,6 +38,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("funcThatThrows", &HybridTestObjectSwiftKotlinSpec::funcThatThrows);
       prototype.registerHybridMethod("tryOptionalParams", &HybridTestObjectSwiftKotlinSpec::tryOptionalParams);
       prototype.registerHybridMethod("tryMiddleParam", &HybridTestObjectSwiftKotlinSpec::tryMiddleParam);
+      prototype.registerHybridMethod("tryOptionalEnum", &HybridTestObjectSwiftKotlinSpec::tryOptionalEnum);
       prototype.registerHybridMethod("calculateFibonacciSync", &HybridTestObjectSwiftKotlinSpec::calculateFibonacciSync);
       prototype.registerHybridMethod("calculateFibonacciAsync", &HybridTestObjectSwiftKotlinSpec::calculateFibonacciAsync);
       prototype.registerHybridMethod("wait", &HybridTestObjectSwiftKotlinSpec::wait);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -17,6 +17,8 @@
 namespace margelo::nitro::image { class HybridTestObjectSwiftKotlinSpec; }
 // Forward declaration of `AnyMap` to properly resolve imports.
 namespace NitroModules { class AnyMap; }
+// Forward declaration of `Powertrain` to properly resolve imports.
+namespace margelo::nitro::image { enum class Powertrain; }
 // Forward declaration of `Car` to properly resolve imports.
 namespace margelo::nitro::image { struct Car; }
 // Forward declaration of `Person` to properly resolve imports.
@@ -29,6 +31,7 @@ namespace NitroModules { class ArrayBuffer; }
 #include <memory>
 #include "HybridTestObjectSwiftKotlinSpec.hpp"
 #include <NitroModules/AnyMap.hpp>
+#include "Powertrain.hpp"
 #include <future>
 #include <functional>
 #include "Car.hpp"
@@ -86,6 +89,7 @@ namespace margelo::nitro::image {
       virtual double funcThatThrows() = 0;
       virtual std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) = 0;
       virtual std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) = 0;
+      virtual std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) = 0;
       virtual int64_t calculateFibonacciSync(double value) = 0;
       virtual std::future<int64_t> calculateFibonacciAsync(double value) = 0;
       virtual std::future<void> wait(double seconds) = 0;

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -52,6 +52,7 @@ export interface TestObjectCpp extends HybridObject<{ ios: 'c++' }> {
   // Optional parameters
   tryOptionalParams(num: number, boo: boolean, str?: string): string
   tryMiddleParam(num: number, boo: boolean | undefined, str: string): string
+  tryOptionalEnum(value?: Powertrain): Powertrain | undefined
 
   // Variants
   someVariant: number | string
@@ -127,6 +128,7 @@ export interface TestObjectSwiftKotlin
   // Optional parameters
   tryOptionalParams(num: number, boo: boolean, str?: string): string
   tryMiddleParam(num: number, boo: boolean | undefined, str: string): string
+  tryOptionalEnum(value?: Powertrain): Powertrain | undefined
 
   // TODO: Variants are not yet supported in Swift/Kotlin!
   // Variants

--- a/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
+++ b/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
@@ -58,22 +58,26 @@ std::shared_ptr<HybridObject> HybridObjectRegistry::createHybridObject(const std
   auto fn = map.find(hybridObjectName);
   if (fn == map.end()) [[unlikely]] {
     auto message = "Cannot create an instance of HybridObject \"" + std::string(hybridObjectName) +
-                   "\" - "
-                   "It has not yet been registered in the Nitro Modules HybridObjectRegistry!";
+                   "\" - It has not yet been registered in the Nitro Modules HybridObjectRegistry! Suggestions:\n"
+                   "- If you use Nitrogen, make sure your `nitro.json` contains `" +
+                   std::string(hybridObjectName) +
+                   "` on this platform.\n"
+                   "- If you use Nitrogen, make sure your library (*Package.java)/app (MainApplication.java) calls "
+                   "`System.loadLibrary(\"<<androidCxxLibName>>\")` somewhere on app-startup.\n"
+                   "- If you use Nitrogen, make sure your cpp-adapter.cpp calls `margelo::nitro::<<cxxNamespace>>::initialize(vm)`.\n"
+                   "- If you don't use Nitrogen, make sure you called `HybridObjectRegistry.registerHybridObject(...)`.\n";
     throw std::runtime_error(message);
   }
   std::shared_ptr<HybridObject> instance = fn->second();
 
 #ifdef NITRO_DEBUG
   if (instance == nullptr) [[unlikely]] {
-    throw std::runtime_error("Failed to create HybridObject \"" + hybridObjectName +
-                             "\" - "
-                             "The constructor returned a nullptr!");
+    throw std::runtime_error("Failed to create HybridObject \"" + hybridObjectName + "\" - The constructor returned a nullptr!");
   }
   if (instance->getName() != hybridObjectName) [[unlikely]] {
     throw std::runtime_error("HybridObject's name (\"" + instance->getName() +
-                             "\") does not match"
-                             "the name it was registered with (\"" +
+                             "\") "
+                             "does not match the name it was registered with (\"" +
                              hybridObjectName + "\")!");
   }
 #endif

--- a/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
+++ b/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<HybridObject> HybridObjectRegistry::createHybridObject(const std
                    "`System.loadLibrary(\"<<androidCxxLibName>>\")` somewhere on app-startup.\n"
                    "- If you use Nitrogen, make sure your cpp-adapter.cpp calls `margelo::nitro::<<cxxNamespace>>::initialize(vm)`.\n"
                    "- If you use Nitrogen, inspect the generated `<<androidCxxLibName>>OnLoad.cpp` file.\n"
-                   "- If you don't use Nitrogen, make sure you called `HybridObjectRegistry.registerHybridObject(...)`.\n";
+                   "- If you don't use Nitrogen, make sure you called `HybridObjectRegistry.registerHybridObject(...)`.";
     throw std::runtime_error(message);
   }
   std::shared_ptr<HybridObject> instance = fn->second();

--- a/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
+++ b/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
@@ -65,6 +65,7 @@ std::shared_ptr<HybridObject> HybridObjectRegistry::createHybridObject(const std
                    "- If you use Nitrogen, make sure your library (*Package.java)/app (MainApplication.java) calls "
                    "`System.loadLibrary(\"<<androidCxxLibName>>\")` somewhere on app-startup.\n"
                    "- If you use Nitrogen, make sure your cpp-adapter.cpp calls `margelo::nitro::<<cxxNamespace>>::initialize(vm)`.\n"
+                   "- If you use Nitrogen, inspect the generated `<<androidCxxLibName>>OnLoad.cpp` file.\n"
                    "- If you don't use Nitrogen, make sure you called `HybridObjectRegistry.registerHybridObject(...)`.\n";
     throw std::runtime_error(message);
   }

--- a/packages/react-native-nitro-modules/package.json
+++ b/packages/react-native-nitro-modules/package.json
@@ -147,5 +147,8 @@
         }
       ]
     ]
+  },
+  "codegenConfig": {
+    "includesGeneratedCode": true
   }
 }

--- a/packages/react-native-nitro-modules/package.json
+++ b/packages/react-native-nitro-modules/package.json
@@ -147,8 +147,5 @@
         }
       ]
     ]
-  },
-  "codegenConfig": {
-    "includesGeneratedCode": true
   }
 }

--- a/packages/react-native-nitro-modules/src/NativeNitroModules.ts
+++ b/packages/react-native-nitro-modules/src/NativeNitroModules.ts
@@ -3,7 +3,7 @@ import { TurboModuleRegistry } from 'react-native'
 import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes'
 import { ModuleNotFoundError } from './ModuleNotFoundError'
 
-export interface Spec extends TurboModule {
+export interface NativeNitroSpec extends TurboModule {
   // Set up
   install(): void
   // Hybrid Objects stuff
@@ -16,12 +16,13 @@ export interface Spec extends TurboModule {
   buildType: 'debug' | 'release'
 }
 
-let turboModule: Spec | undefined
-export function getNativeNitroModules(): Spec {
+let turboModule: NativeNitroSpec | undefined
+export function getNativeNitroModules(): NativeNitroSpec {
   if (turboModule == null) {
     try {
       // 1. Get (and initialize) the C++ TurboModule
-      turboModule = TurboModuleRegistry.getEnforcing<Spec>('NitroModulesCxx')
+      turboModule =
+        TurboModuleRegistry.getEnforcing<NativeNitroSpec>('NitroModulesCxx')
 
       // 2. Install Dispatcher and required bindings into the Runtime
       turboModule.install()

--- a/packages/react-native-nitro-modules/src/NativeNitroModules.web.ts
+++ b/packages/react-native-nitro-modules/src/NativeNitroModules.web.ts
@@ -1,9 +1,0 @@
-import type { TurboModule } from 'react-native'
-
-export interface Spec extends TurboModule {}
-
-export function getNativeNitroModules(): Spec {
-  throw new Error(
-    `Native NitroModules are not available on web! Make sure you're not calling getNativeNitroModules() in a web (.web.ts) environment.`
-  )
-}

--- a/packages/react-native-nitro-modules/src/NitroModules.ts
+++ b/packages/react-native-nitro-modules/src/NitroModules.ts
@@ -1,4 +1,4 @@
-import { getNativeNitroModules } from './NativeNitroModules'
+import { getNativeNitroModules } from './NitroModulesTurboModule'
 import type { HybridObject } from './HybridObject'
 
 // TODO: Do we wanna support such constructors?

--- a/packages/react-native-nitro-modules/src/NitroModulesTurboModule.ts
+++ b/packages/react-native-nitro-modules/src/NitroModulesTurboModule.ts
@@ -3,6 +3,9 @@ import { TurboModuleRegistry } from 'react-native'
 import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes'
 import { ModuleNotFoundError } from './ModuleNotFoundError'
 
+// This TurboModule is *not* codegen'd.
+// It's handwritten, because otherwise the app's CMakeLists wants to build it.
+// Instead, we want to build it ourselves and have full control over the CMakeLists.
 export interface NativeNitroSpec extends TurboModule {
   // Set up
   install(): void

--- a/packages/react-native-nitro-modules/src/NitroModulesTurboModule.web.ts
+++ b/packages/react-native-nitro-modules/src/NitroModulesTurboModule.web.ts
@@ -1,0 +1,7 @@
+import { Platform } from 'react-native'
+
+export function getNativeNitroModules(): never {
+  throw new Error(
+    `Native NitroModules are not available on ${Platform.OS}! Make sure you're not calling getNativeNitroModules() in a ${Platform.OS} (.${Platform.OS}.ts) environment.`
+  )
+}


### PR DESCRIPTION
When using a single string literal in Nitrogen, it must throw again because it is simply ambiguous between a string and an enum. We don't know what it is, so we need to tell the user to be more explicit.

Also fixes:

- Optionals in Swift can be passed through as is if possible - no optional lambda try/unwrapping
- Disable codegen for Android (it failed because I don't use it)