### PR TITLE
fix: pass in generic types and export Specs

### DIFF
--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -105,7 +105,7 @@ Nitrogen parses all TypeScript files that end in `.nitro.ts`.
 For example, let's create `Math.nitro.ts`:
 
 ```ts title="Math.nitro.ts"
-interface Math extends HybridObject {
+export interface Math extends HybridObject<{ ios: 'swift', android: 'kotlin'}> {
   add(a: number, b: number): number
 }
 ```

--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -335,7 +335,7 @@ class MainApplication {
 
 ### 6. Initialize the Hybrid Objects
 
-And finally, to initialize `HybridMath` from JS you just need to call `createHybridObject`, passing in the `Math` Spec defined in `Math.nitro.ts` as a generic type parameter:
+And finally, to initialize `HybridMath` from JS you just need to call `createHybridObject`:
 
 ```ts
 export const MathModule = NitroModules.createHybridObject<Math>("Math")

--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -203,6 +203,12 @@ To implement `Math` now, you just need to implement the spec:
   <TabItem value="swift" label="Swift" default>
     ```swift title="HybridMath.swift"
     class HybridMath : HybridMathSpec {
+      var hybridContext = margelo.nitro.HybridContext()
+
+      var memorySize: Int {
+        return getSizeOf(self)
+      }
+
       public func add(a: Double, b: Double) throws -> Double {
         return a + b
       }
@@ -212,6 +218,9 @@ To implement `Math` now, you just need to implement the spec:
   <TabItem value="kotlin" label="Kotlin">
     ```kotlin title="HybridMath.kt"
     class HybridMath : HybridMathSpec() {
+      override val memorySize: Long
+        get() = 0L
+
       override fun add(a: Double, b: Double): Double {
         return a + b
       }

--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -105,7 +105,7 @@ Nitrogen parses all TypeScript files that end in `.nitro.ts`.
 For example, let's create `Math.nitro.ts`:
 
 ```ts title="Math.nitro.ts"
-export interface Math extends HybridObject<{ ios: 'swift', android: 'kotlin'}> {
+interface Math extends HybridObject<{ ios: 'swift', android: 'kotlin' }> {
   add(a: number, b: number): number
 }
 ```

--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -204,7 +204,6 @@ To implement `Math` now, you just need to implement the spec:
     ```swift title="HybridMath.swift"
     class HybridMath : HybridMathSpec {
       var hybridContext = margelo.nitro.HybridContext()
-
       var memorySize: Int {
         return getSizeOf(self)
       }

--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -336,7 +336,7 @@ class MainApplication {
 
 ### 6. Initialize the Hybrid Objects
 
-And finally, to initialize `HybridMath` from JS you just need to call `createHybridObject`:
+And finally, to initialize `HybridMath` from JS you just need to call `createHybridObject`, passing in the `Math` Spec defined in `Math.nitro.ts` as a generic type parameter:
 
 ```ts
 export const MathModule = NitroModules.createHybridObject<Math>("Math")


### PR DESCRIPTION
## Summary
The nitrogen page is a step by step guide on running Nitro Codegen but following as it is now leads user to errors.

When defining the Spec, HybridObject requires a generic parameter or else the user would get:
```
        ❌  Failed to generate spec for RNFilePicker! Error: RNFilePicker does not properly extend HybridObject<T> - HybridObject does not have a single generic type argument for platform spec languages.
    ❌  No specs found in RNFilePicker.nitro.ts!
```

So this pr adds the generic type for guide completeness and exports the Spec since it is used in step 6 which I also made obvious in that step that this is the spec defined in .nitro.ts file.

Also the classes are missing the memorySize and hybridContext(for ios) for completeness. I copy pasted them, only to get a cryptic error in the console till i opened xcode. C++ needs to be updated too for memorySize? Not sure