### PR TITLE
fix: fix android placeholders

### DIFF
--- a/packages/template/android/src/main/java/com/margelo/nitro/<<androidNamespace>>/<<androidCxxLibName>>Package.java
+++ b/packages/template/android/src/main/java/com/margelo/nitro/<<androidNamespace>>/<<androidCxxLibName>>Package.java
@@ -1,4 +1,4 @@
-package com.margelo.nitro.image;
+package com.margelo.nitro.<<androidNamespace>>;
 
 import android.util.Log;
 
@@ -21,14 +21,14 @@ public class <<androidCxxLibName>>Package extends TurboReactPackage {
     return null;
   }
 
-  public <<androidCxxLibName>>Package() {
-    // TODO: Register Hybrid Objects here
-  }
-
   @Override
   public ReactModuleInfoProvider getReactModuleInfoProvider() {
     return () -> {
         return new HashMap<>();
     };
+  }
+
+  static {
+    System.loadLibrary("<<androidCxxLibName>>");
   }
 }


### PR DESCRIPTION
## Summary

The `<<androidCxxLibName>>Package.java` has the `image` component package at the very top but instead should be the placeholder.

Also we can add loading the c++ library with the placeholder