### PR TITLE
fix: template new library android sync project error

### DIFF
--- a/packages/template/android/build.gradle
+++ b/packages/template/android/build.gradle
@@ -5,7 +5,8 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:7.2.1"
+    classpath "com.android.tools.build:gradle:8.1.1"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$<<androidCxxLibName>>_kotlinVersion"
   }
 }
 

--- a/packages/template/android/gradle.properties
+++ b/packages/template/android/gradle.properties
@@ -3,3 +3,4 @@
 <<androidCxxLibName>>_targetSdkVersion=34
 <<androidCxxLibName>>_compileSdkVersion=34
 <<androidCxxLibName>>_ndkVersion=26.1.10909125
+reactNativeArchitectures=true

--- a/packages/template/android/settings.gradle
+++ b/packages/template/android/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = "<<androidCxxLibName>>"
+include ":react-native-nitro-modules"
+project(":react-native-nitro-modules").projectDir = file("../../../node_modules/react-native-nitro-modules/android")


### PR DESCRIPTION
When I create a new library following the tutorial above in [Creating a Nitro Module](https://mrousavy.github.io/nitro/docs/nitro-modules#creating-a-nitro-module), I get some error in the `Android Studio` `sync project` with errors, so fix these exceptions.

1. Add the location of the `react-native-nitro-module module` to `settings.gradle`:
![image](https://github.com/user-attachments/assets/be339a23-d55b-4eb2-b824-4fa8049a0fd4)

2. Add `classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$<<androidCxxLibName>>_kotlinVersion"` fix the following problems:
![image](https://github.com/user-attachments/assets/e49ccdb0-add9-4fb3-b495-98a2b163fcb8)

3. Upgraded the version of `com.android.tools.build:gradle` because `compileSdkVersion` `34` requires at least version `8.1.1`.

4. use `reactNativeArchitectures=true` fix the following problems:
![image](https://github.com/user-attachments/assets/bb83f8cd-a505-41d2-bede-e697aad02aec)
