### PR TITLE
fix: Remove unused `args` parameter in `createHybridObject(..)`

### DIFF
--- a/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
+++ b/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
@@ -19,8 +19,6 @@ using namespace margelo::nitro;
 NativeNitroModules::NativeNitroModules(std::shared_ptr<CallInvoker> jsInvoker)
     : TurboModule(kModuleName, jsInvoker), _callInvoker(jsInvoker) {}
 
-NativeNitroModules::~NativeNitroModules() {}
-
 jsi::Value NativeNitroModules::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {
   std::string name = propName.utf8(runtime);
 

--- a/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
+++ b/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
@@ -34,21 +34,16 @@ jsi::Value NativeNitroModules::get(jsi::Runtime& runtime, const jsi::PropNameID&
   }
   if (name == "createHybridObject") {
     return jsi::Function::createFromHostFunction(
-        runtime, jsi::PropNameID::forUtf8(runtime, "createHybridObject"), 2,
+        runtime, jsi::PropNameID::forUtf8(runtime, "createHybridObject"), 1,
         [this](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args, size_t count) -> jsi::Value {
 #ifdef NITRO_DEBUG
-          if (count != 1 && count != 2) [[unlikely]] {
-            throw jsi::JSError(runtime, "NitroModules.createHybridObject(..) expects 1 or 2 arguments, but " + std::to_string(count) +
+          if (count != 1) [[unlikely]] {
+            throw jsi::JSError(runtime, "NitroModules.createHybridObject(..) expects 1 argument, but " + std::to_string(count) +
                                             " were supplied!");
           }
 #endif
           jsi::String objectName = args[0].asString(runtime);
-          std::optional<jsi::Object> optionalArgs = std::nullopt;
-          if (count > 1) {
-            optionalArgs = args[1].asObject(runtime);
-          }
-
-          return createHybridObject(runtime, objectName, optionalArgs);
+          return createHybridObject(runtime, objectName);
         });
   }
   if (name == "hasHybridObject") {
@@ -129,11 +124,9 @@ void NativeNitroModules::install(jsi::Runtime& runtime) {
   Dispatcher::installRuntimeGlobalDispatcher(runtime, dispatcher);
 }
 
-jsi::Value NativeNitroModules::createHybridObject(jsi::Runtime& runtime, const jsi::String& hybridObjectName,
-                                                  const std::optional<jsi::Object>&) {
+jsi::Value NativeNitroModules::createHybridObject(jsi::Runtime& runtime, const jsi::String& hybridObjectName) {
   auto name = hybridObjectName.utf8(runtime);
-  // TODO: Pass args? Do we need that?
-  auto hybridObject = HybridObjectRegistry::createHybridObject(name.c_str());
+  auto hybridObject = HybridObjectRegistry::createHybridObject(name);
   return hybridObject->toObject(runtime);
 }
 

--- a/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
+++ b/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.cpp
@@ -38,8 +38,8 @@ jsi::Value NativeNitroModules::get(jsi::Runtime& runtime, const jsi::PropNameID&
         [this](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args, size_t count) -> jsi::Value {
 #ifdef NITRO_DEBUG
           if (count != 1) [[unlikely]] {
-            throw jsi::JSError(runtime, "NitroModules.createHybridObject(..) expects 1 argument, but " + std::to_string(count) +
-                                            " were supplied!");
+            throw jsi::JSError(runtime,
+                               "NitroModules.createHybridObject(..) expects 1 argument, but " + std::to_string(count) + " were supplied!");
           }
 #endif
           jsi::String objectName = args[0].asString(runtime);

--- a/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.hpp
+++ b/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.hpp
@@ -16,8 +16,7 @@ using namespace facebook;
 // The base C++-based TurboModule. This is the entry point where all nitro modules get initialized.
 class NativeNitroModules : public TurboModule {
 public:
-  NativeNitroModules(std::shared_ptr<CallInvoker> jsInvoker);
-  ~NativeNitroModules();
+  explicit NativeNitroModules(std::shared_ptr<CallInvoker> jsInvoker);
 
 public:
   jsi::Value get(jsi::Runtime& runtime, const jsi::PropNameID& propName) override;

--- a/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.hpp
+++ b/packages/react-native-nitro-modules/cpp/turbomodule/NativeNitroModules.hpp
@@ -25,7 +25,7 @@ public:
   // Setup
   void install(jsi::Runtime& runtime);
   // Hybrid Objects stuff
-  jsi::Value createHybridObject(jsi::Runtime& runtime, const jsi::String& hybridObjectName, const std::optional<jsi::Object>& args);
+  jsi::Value createHybridObject(jsi::Runtime& runtime, const jsi::String& hybridObjectName);
   jsi::Value hasHybridObject(jsi::Runtime& runtime, const jsi::String& hybridObjectName);
   jsi::Value getAllHybridObjectNames(jsi::Runtime& runtime);
 

--- a/packages/react-native-nitro-modules/src/NitroModulesTurboModule.ts
+++ b/packages/react-native-nitro-modules/src/NitroModulesTurboModule.ts
@@ -10,7 +10,7 @@ export interface NativeNitroSpec extends TurboModule {
   // Set up
   install(): void
   // Hybrid Objects stuff
-  createHybridObject(name: string, args?: UnsafeObject): UnsafeObject
+  createHybridObject(name: string): UnsafeObject
   hasHybridObject(name: string): boolean
   getAllHybridObjectNames(): string[]
   // JSI Helpers


### PR DESCRIPTION
Parameter was unused anyways, so remove it.

Hybrid Objects that can be default-constructed using `createHybridObject(..)` should not take any arguments anyways, as this just overly complicates things (how do we parse the args? Do we convert them to Swift/Kotlin types? How do we length-check them? It needs to be compile-time, etc), as well as potentially uses unsafe typings (we are not in a Nitro context yet so we cannot use the JSIConverter template stuff).

If you need arguments here, create a default-constructible "factory" HybridObject first, then create your other HybridObjects from that factory with some helper methods - those are fast, type-safe, and compile-time generated.