### PR TITLE
fix: Provide helpful error message if `this` is not bound

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -173,7 +173,14 @@ private:
     // 1. Convert jsi::Value to jsi::Object
 #ifdef NITRO_DEBUG
     if (!value.isObject()) [[unlikely]] {
-      throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) + " - `this` is not bound!");
+      throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) +
+                                      " - `this` is not bound! Suggestions:\n"
+                                      "- Did you accidentally destructure the `HybridObject` (`const { " +
+                                      funcName +
+                                      " } = ...`) and lose a reference to the original object?\n"
+                                      "- Did you call `dispose()` on the `HybridObject` before?"
+                                      "- Did you accidentally call `" +
+                                      funcName + "` on the prototype directly?\n");
     }
 #endif
     jsi::Object object = value.getObject(runtime);
@@ -183,7 +190,9 @@ private:
     if (!object.hasNativeState(runtime)) [[unlikely]] {
       throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) +
                                       " - `this` does not have a NativeState! Suggestions:\n"
-                                      "- Did you accidentally destructure the `HybridObject` and lose a reference to the original object?\n"
+                                      "- Did you accidentally destructure the `HybridObject` (`const { " +
+                                      funcName +
+                                      " } = ...`) and lose a reference to the original object?\n"
                                       "- Did you call `dispose()` on the `HybridObject` before?"
                                       "- Did you accidentally call `" +
                                       funcName + "` on the prototype directly?\n");

--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -175,12 +175,12 @@ private:
     if (!value.isObject()) [[unlikely]] {
       throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) +
                                       " - `this` is not bound! Suggestions:\n"
-                                      "- Did you accidentally destructure the `HybridObject` (`const { " +
+                                      "- Did you accidentally destructure the `HybridObject`? (`const { " +
                                       funcName +
-                                      " } = ...`) and lose a reference to the original object?\n"
+                                      " } = ...`)\n"
                                       "- Did you call `dispose()` on the `HybridObject` before?"
                                       "- Did you accidentally call `" +
-                                      funcName + "` on the prototype directly?\n");
+                                      funcName + "` on the prototype directly?");
     }
 #endif
     jsi::Object object = value.getObject(runtime);
@@ -190,12 +190,12 @@ private:
     if (!object.hasNativeState(runtime)) [[unlikely]] {
       throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) +
                                       " - `this` does not have a NativeState! Suggestions:\n"
-                                      "- Did you accidentally destructure the `HybridObject` (`const { " +
+                                      "- Did you accidentally destructure the `HybridObject`? (`const { " +
                                       funcName +
-                                      " } = ...`) and lose a reference to the original object?\n"
+                                      " } = ...`)\n"
                                       "- Did you call `dispose()` on the `HybridObject` before?"
                                       "- Did you accidentally call `" +
-                                      funcName + "` on the prototype directly?\n");
+                                      funcName + "` on the prototype directly?");
     }
 #endif
 


### PR DESCRIPTION
When you accidentally destructure the HybridObject in JS, the NativeState gets lost and it cannot properly resolve the prototype anymore (by design):

```ts
const math = NitroModules.createHybridObject<Math>('Math')
const { add } = math
     // ^ destructured! `this` is not bound to `math` anymore on `add`
```

This PR now provides a more helpful error message - the error thrown when trying to call `add` without a properly bound `this` now like this:

```diff
- Cannot call Math.add(...) - `this` is not bound! Suggestions:
- - Did you accidentally destructure the `HybridObject`? (`const { add } = ...`)
- - Did you call `dispose()` on the `HybridObject` before?
- - Did you accidentally call `add` on the prototype directly?
```