### PR TITLE
perf: Mark all `protocol`s as `AnyObject`, since they're always classes

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -42,7 +42,7 @@ import NitroModules
  * }
  * \`\`\`
  */
-public protocol ${protocolName}: ${baseClasses.join(', ')} {
+public protocol ${protocolName}: AnyObject, ${baseClasses.join(', ')} {
   // Properties
   ${indent(properties, '  ')}
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -27,7 +27,7 @@ import NitroModules
  * }
  * ```
  */
-public protocol HybridBaseSpec: HybridObjectSpec {
+public protocol HybridBaseSpec: AnyObject, HybridObjectSpec {
   // Properties
   var baseValue: Double { get }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -27,7 +27,7 @@ import NitroModules
  * }
  * ```
  */
-public protocol HybridChildSpec: HybridObjectSpec, HybridBaseSpec {
+public protocol HybridChildSpec: AnyObject, HybridObjectSpec, HybridBaseSpec {
   // Properties
   var childValue: Double { get }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -27,7 +27,7 @@ import NitroModules
  * }
  * ```
  */
-public protocol HybridImageFactorySpec: HybridObjectSpec {
+public protocol HybridImageFactorySpec: AnyObject, HybridObjectSpec {
   // Properties
   
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -27,7 +27,7 @@ import NitroModules
  * }
  * ```
  */
-public protocol HybridImageSpec: HybridObjectSpec {
+public protocol HybridImageSpec: AnyObject, HybridObjectSpec {
   // Properties
   var size: ImageSize { get }
   var pixelFormat: PixelFormat { get }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -27,7 +27,7 @@ import NitroModules
  * }
  * ```
  */
-public protocol HybridTestObjectSwiftKotlinSpec: HybridObjectSpec {
+public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
   // Properties
   var thisObject: HybridTestObjectSwiftKotlinSpec { get }
   var numberValue: Double { get set }

--- a/packages/react-native-nitro-modules/ios/core/HybridObjectSpec.swift
+++ b/packages/react-native-nitro-modules/ios/core/HybridObjectSpec.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  * A base protocol for all Swift-based Hybrid Objects.
  */
-public protocol HybridObjectSpec {
+public protocol HybridObjectSpec: AnyObject {
   /**
    * Holds the C++ HybridObject and it's context.
    * Use the default initializer in your implementation, C++ will set and get this value.


### PR DESCRIPTION
Per ["Swift Optimization Tips: Mark protocols that are only satisfied by classes as class-protocols"](https://github.com/swiftlang/swift/blob/main/docs/OptimizationTips.rst#advice-mark-protocols-that-are-only-satisfied-by-classes-as-class-protocols), marking `protocol`s as `AnyObject` could increase performance since we know that HybridObjects are never structs anyways.