### PR TITLE
perf: Mark SwiftCxx wrappers `struct` instead of `class` for better performance

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -50,15 +50,15 @@ import Foundation
 import NitroModules
 
 /**
- * A class implementation that bridges ${name.HybridTSpec} over to C++.
- * In C++, we cannot use Swift protocols - so we need to wrap it in a class to make it strongly defined.
+ * A concrete class/struct implementation that bridges ${name.HybridTSpec} over to C++.
+ * In C++, we cannot use Swift protocols - so we need to wrap it in a class/struct to make it strongly defined.
  *
  * Also, some Swift types need to be bridged with special handling:
  * - Enums need to be wrapped in Structs, otherwise they cannot be accessed bi-directionally (Swift bug: https://github.com/swiftlang/swift/issues/75330)
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-${hasBase ? `public class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : `public class ${name.HybridTSpecCxx}`} {
+${hasBase ? `public struct ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : `public struct ${name.HybridTSpecCxx}`} {
   /**
    * The Swift <> C++ bridge's namespace (\`${NitroConfig.getCxxNamespace('c++', 'bridge', 'swift')}\`)
    * from \`${moduleName}-Swift-Cxx-Bridge.hpp\`.
@@ -227,7 +227,7 @@ ${createFileMetadataString(`${name.HybridTSpecSwift}.hpp`)}
 
 #include "${name.HybridTSpec}.hpp"
 
-${getForwardDeclaration('class', name.HybridTSpecCxx, iosModuleName)}
+${getForwardDeclaration('struct', name.HybridTSpecCxx, iosModuleName)}
 
 ${extraForwardDeclarations.join('\n')}
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.hpp
@@ -10,7 +10,7 @@
 #include "HybridBaseSpec.hpp"
 
 // Forward declaration of `HybridBaseSpecCxx` to properly resolve imports.
-namespace NitroImage { class HybridBaseSpecCxx; }
+namespace NitroImage { struct HybridBaseSpecCxx; }
 
 
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
@@ -10,7 +10,7 @@
 #include "HybridChildSpec.hpp"
 
 // Forward declaration of `HybridChildSpecCxx` to properly resolve imports.
-namespace NitroImage { class HybridChildSpecCxx; }
+namespace NitroImage { struct HybridChildSpecCxx; }
 
 // Forward declaration of `HybridBaseSpecSwift` to properly resolve imports.
 namespace margelo::nitro::image { class HybridBaseSpecSwift; }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.hpp
@@ -10,7 +10,7 @@
 #include "HybridImageFactorySpec.hpp"
 
 // Forward declaration of `HybridImageFactorySpecCxx` to properly resolve imports.
-namespace NitroImage { class HybridImageFactorySpecCxx; }
+namespace NitroImage { struct HybridImageFactorySpecCxx; }
 
 // Forward declaration of `HybridImageSpec` to properly resolve imports.
 namespace margelo::nitro::image { class HybridImageSpec; }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
@@ -10,7 +10,7 @@
 #include "HybridImageSpec.hpp"
 
 // Forward declaration of `HybridImageSpecCxx` to properly resolve imports.
-namespace NitroImage { class HybridImageSpecCxx; }
+namespace NitroImage { struct HybridImageSpecCxx; }
 
 // Forward declaration of `ImageSize` to properly resolve imports.
 namespace margelo::nitro::image { struct ImageSize; }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -10,7 +10,7 @@
 #include "HybridTestObjectSwiftKotlinSpec.hpp"
 
 // Forward declaration of `HybridTestObjectSwiftKotlinSpecCxx` to properly resolve imports.
-namespace NitroImage { class HybridTestObjectSwiftKotlinSpecCxx; }
+namespace NitroImage { struct HybridTestObjectSwiftKotlinSpecCxx; }
 
 // Forward declaration of `HybridTestObjectSwiftKotlinSpec` to properly resolve imports.
 namespace margelo::nitro::image { class HybridTestObjectSwiftKotlinSpec; }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpecCxx.swift
@@ -9,15 +9,15 @@ import Foundation
 import NitroModules
 
 /**
- * A class implementation that bridges HybridBaseSpec over to C++.
- * In C++, we cannot use Swift protocols - so we need to wrap it in a class to make it strongly defined.
+ * A concrete class/struct implementation that bridges HybridBaseSpec over to C++.
+ * In C++, we cannot use Swift protocols - so we need to wrap it in a class/struct to make it strongly defined.
  *
  * Also, some Swift types need to be bridged with special handling:
  * - Enums need to be wrapped in Structs, otherwise they cannot be accessed bi-directionally (Swift bug: https://github.com/swiftlang/swift/issues/75330)
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-public class HybridBaseSpecCxx {
+public struct HybridBaseSpecCxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::image::bridge::swift`)
    * from `NitroImage-Swift-Cxx-Bridge.hpp`.

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpecCxx.swift
@@ -9,15 +9,15 @@ import Foundation
 import NitroModules
 
 /**
- * A class implementation that bridges HybridChildSpec over to C++.
- * In C++, we cannot use Swift protocols - so we need to wrap it in a class to make it strongly defined.
+ * A concrete class/struct implementation that bridges HybridChildSpec over to C++.
+ * In C++, we cannot use Swift protocols - so we need to wrap it in a class/struct to make it strongly defined.
  *
  * Also, some Swift types need to be bridged with special handling:
  * - Enums need to be wrapped in Structs, otherwise they cannot be accessed bi-directionally (Swift bug: https://github.com/swiftlang/swift/issues/75330)
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-public class HybridChildSpecCxx : HybridBaseSpecCxx {
+public struct HybridChildSpecCxx : HybridBaseSpecCxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::image::bridge::swift`)
    * from `NitroImage-Swift-Cxx-Bridge.hpp`.

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpecCxx.swift
@@ -9,15 +9,15 @@ import Foundation
 import NitroModules
 
 /**
- * A class implementation that bridges HybridImageFactorySpec over to C++.
- * In C++, we cannot use Swift protocols - so we need to wrap it in a class to make it strongly defined.
+ * A concrete class/struct implementation that bridges HybridImageFactorySpec over to C++.
+ * In C++, we cannot use Swift protocols - so we need to wrap it in a class/struct to make it strongly defined.
  *
  * Also, some Swift types need to be bridged with special handling:
  * - Enums need to be wrapped in Structs, otherwise they cannot be accessed bi-directionally (Swift bug: https://github.com/swiftlang/swift/issues/75330)
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-public class HybridImageFactorySpecCxx {
+public struct HybridImageFactorySpecCxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::image::bridge::swift`)
    * from `NitroImage-Swift-Cxx-Bridge.hpp`.

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpecCxx.swift
@@ -9,15 +9,15 @@ import Foundation
 import NitroModules
 
 /**
- * A class implementation that bridges HybridImageSpec over to C++.
- * In C++, we cannot use Swift protocols - so we need to wrap it in a class to make it strongly defined.
+ * A concrete class/struct implementation that bridges HybridImageSpec over to C++.
+ * In C++, we cannot use Swift protocols - so we need to wrap it in a class/struct to make it strongly defined.
  *
  * Also, some Swift types need to be bridged with special handling:
  * - Enums need to be wrapped in Structs, otherwise they cannot be accessed bi-directionally (Swift bug: https://github.com/swiftlang/swift/issues/75330)
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-public class HybridImageSpecCxx {
+public struct HybridImageSpecCxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::image::bridge::swift`)
    * from `NitroImage-Swift-Cxx-Bridge.hpp`.

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -9,15 +9,15 @@ import Foundation
 import NitroModules
 
 /**
- * A class implementation that bridges HybridTestObjectSwiftKotlinSpec over to C++.
- * In C++, we cannot use Swift protocols - so we need to wrap it in a class to make it strongly defined.
+ * A concrete class/struct implementation that bridges HybridTestObjectSwiftKotlinSpec over to C++.
+ * In C++, we cannot use Swift protocols - so we need to wrap it in a class/struct to make it strongly defined.
  *
  * Also, some Swift types need to be bridged with special handling:
  * - Enums need to be wrapped in Structs, otherwise they cannot be accessed bi-directionally (Swift bug: https://github.com/swiftlang/swift/issues/75330)
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-public class HybridTestObjectSwiftKotlinSpecCxx {
+public struct HybridTestObjectSwiftKotlinSpecCxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::image::bridge::swift`)
    * from `NitroImage-Swift-Cxx-Bridge.hpp`.


### PR DESCRIPTION
`struct` has better performance than `class`, let's see if this actually works tho