### PR TITLE
fix: Make Nitro core compile on non-react-native environments

### DIFF
--- a/docs/src/pages/markdown-page.md
+++ b/docs/src/pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.

--- a/packages/react-native-nitro-modules/cpp/threading/CallInvokerDispatcher.hpp
+++ b/packages/react-native-nitro-modules/cpp/threading/CallInvokerDispatcher.hpp
@@ -5,6 +5,9 @@
 #pragma once
 
 #include "Dispatcher.hpp"
+
+// This is react-native specific
+#if __has_include(<ReactCommon/CallInvoker.h>)
 #include <ReactCommon/CallInvoker.h>
 
 namespace margelo::nitro {
@@ -31,3 +34,5 @@ private:
 };
 
 } // namespace margelo::nitro
+
+#endif


### PR DESCRIPTION
Guards `CallInvokerDispatcher` only if <ReactCommon/CallInvoker.h> is available