### PR TITLE
fix: Prefix all variable names with `__`

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -29,7 +29,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - NitroModules (0.10.0):
+  - NitroModules (0.11.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1828,7 +1828,7 @@ SPEC CHECKSUMS:
   glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   hermes-engine: 3b6e0717ca847e2fc90a201e59db36caf04dee88
   NitroImage: 0cffeee137c14b8c8df97649626646528cb89b28
-  NitroModules: 3ec68910d7e9d157609efc1e3907ebc476db3559
+  NitroModules: e8722903c6ca5c7616f62c0d7a926a903ae75bce
   RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
   RCTDeprecation: 34cbf122b623037ea9facad2e92e53434c5c7422
   RCTRequired: 24c446d7bcd0f517d516b6265d8df04dc3eb1219
@@ -1889,6 +1889,6 @@ SPEC CHECKSUMS:
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: a1d7895431387402a674fd0d1c04ec85e87909b8
 
-PODFILE CHECKSUM: 83ff0c12eb91f4379210b71045e485dacb487fe9
+PODFILE CHECKSUM: 2146660f454ce3dcf0b35d6eb1becea8db4d65c7
 
 COCOAPODS: 1.15.2

--- a/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
@@ -232,8 +232,8 @@ function getFbjniMethodForwardImplementation(
     // return something - we need to parse it
     body = `
 static const auto method = _javaPart->getClass()->getMethod<${cxxSignature}>("${method.name}");
-auto result = method(${paramsForward.join(', ')});
-return ${returnJNI.parse('result', 'kotlin', 'c++', 'c++')};
+auto __result = method(${paramsForward.join(', ')});
+return ${returnJNI.parse('__result', 'kotlin', 'c++', 'c++')};
     `
   } else {
     // void method. no return

--- a/packages/nitrogen/src/syntax/kotlin/KotlinHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinHybridObject.ts
@@ -139,14 +139,17 @@ function getMethodForwardImplementation(method: Method): string {
       const bridge = new KotlinCxxBridgedType(p.type)
       return bridge.parseFromCppToKotlin(p.name, 'kotlin')
     })
-    const returnForward = bridgedReturn.parseFromKotlinToCpp('result', 'kotlin')
+    const returnForward = bridgedReturn.parseFromKotlinToCpp(
+      '__result',
+      'kotlin'
+    )
     return `
 ${code}
 
 @DoNotStrip
 @Keep
 private fun ${method.name}(${paramsSignature.join(', ')}): ${bridgedReturn.getTypeCode('kotlin')} {
-  val result = ${method.name}(${paramsForward.join(', ')})
+  val __result = ${method.name}(${paramsForward.join(', ')})
   return ${returnForward}
 }
     `.trim()

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -192,8 +192,8 @@ function createCxxFunctionSwiftHelper(type: FunctionType): SwiftCxxHelper {
   let callCppFuncBody: string
   if (returnBridge.hasType) {
     callCppFuncBody = `
-    auto result = function(${indent(callParamsForward.join(', '), '    ')});
-    return ${indent(returnBridge.parseFromCppToSwift('result', 'c++'), '    ')};
+    auto __result = function(${indent(callParamsForward.join(', '), '    ')});
+    return ${indent(returnBridge.parseFromCppToSwift('__result', 'c++'), '    ')};
     `.trim()
   } else {
     callCppFuncBody = `function(${indent(callParamsForward.join(', '), '    ')});`
@@ -202,8 +202,8 @@ function createCxxFunctionSwiftHelper(type: FunctionType): SwiftCxxHelper {
   let callSwiftFuncBody: string
   if (returnBridge.hasType) {
     callSwiftFuncBody = `
-    auto result = call(${indent(paramsForward.join(', '), '    ')});
-    return ${indent(returnBridge.parseFromSwiftToCpp('result', 'c++'), '    ')};
+    auto __result = call(${indent(paramsForward.join(', '), '    ')});
+    return ${indent(returnBridge.parseFromSwiftToCpp('__result', 'c++'), '    ')};
     `.trim()
   } else {
     callSwiftFuncBody = `call(${indent(paramsForward.join(', '), '    ')});`

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridBaseSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridBaseSpec.cpp
@@ -31,8 +31,8 @@ namespace margelo::nitro::image {
   // Properties
   double JHybridBaseSpec::getBaseValue() {
     static const auto method = _javaPart->getClass()->getMethod<double()>("getBaseValue");
-    auto result = method(_javaPart);
-    return result;
+    auto __result = method(_javaPart);
+    return __result;
   }
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridChildSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridChildSpec.cpp
@@ -31,13 +31,13 @@ namespace margelo::nitro::image {
   // Properties
   double JHybridChildSpec::getChildValue() {
     static const auto method = _javaPart->getClass()->getMethod<double()>("getChildValue");
-    auto result = method(_javaPart);
-    return result;
+    auto __result = method(_javaPart);
+    return __result;
   }
   double JHybridChildSpec::getBaseValue() {
     static const auto method = _javaPart->getClass()->getMethod<double()>("getBaseValue");
-    auto result = method(_javaPart);
-    return result;
+    auto __result = method(_javaPart);
+    return __result;
   }
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageFactorySpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageFactorySpec.cpp
@@ -39,23 +39,23 @@ namespace margelo::nitro::image {
   // Methods
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::loadImageFromFile(const std::string& path) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromFile");
-    auto result = method(_javaPart, jni::make_jstring(path));
-    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(result));
+    auto __result = method(_javaPart, jni::make_jstring(path));
+    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::loadImageFromURL(const std::string& path) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromURL");
-    auto result = method(_javaPart, jni::make_jstring(path));
-    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(result));
+    auto __result = method(_javaPart, jni::make_jstring(path));
+    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::loadImageFromSystemName(const std::string& path) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromSystemName");
-    auto result = method(_javaPart, jni::make_jstring(path));
-    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(result));
+    auto __result = method(_javaPart, jni::make_jstring(path));
+    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::bounceBack(const std::shared_ptr<margelo::nitro::image::HybridImageSpec>& image) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<JHybridImageSpec::javaobject> /* image */)>("bounceBack");
-    auto result = method(_javaPart, std::dynamic_pointer_cast<JHybridImageSpec>(image)->getJavaPart());
-    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(result));
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridImageSpec>(image)->getJavaPart());
+    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
   }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.cpp
@@ -44,18 +44,18 @@ namespace margelo::nitro::image {
   // Properties
   ImageSize JHybridImageSpec::getSize() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JImageSize>()>("getSize");
-    auto result = method(_javaPart);
-    return result->toCpp();
+    auto __result = method(_javaPart);
+    return __result->toCpp();
   }
   PixelFormat JHybridImageSpec::getPixelFormat() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPixelFormat>()>("getPixelFormat");
-    auto result = method(_javaPart);
-    return result->toCpp();
+    auto __result = method(_javaPart);
+    return __result->toCpp();
   }
   double JHybridImageSpec::getSomeSettableProp() {
     static const auto method = _javaPart->getClass()->getMethod<double()>("getSomeSettableProp");
-    auto result = method(_javaPart);
-    return result;
+    auto __result = method(_javaPart);
+    return __result;
   }
   void JHybridImageSpec::setSomeSettableProp(double someSettableProp) {
     static const auto method = _javaPart->getClass()->getMethod<void(double /* someSettableProp */)>("setSomeSettableProp");
@@ -65,8 +65,8 @@ namespace margelo::nitro::image {
   // Methods
   double JHybridImageSpec::toArrayBuffer(ImageFormat format) {
     static const auto method = _javaPart->getClass()->getMethod<double(jni::alias_ref<JImageFormat> /* format */)>("toArrayBuffer");
-    auto result = method(_javaPart, JImageFormat::fromCpp(format));
-    return result;
+    auto __result = method(_javaPart, JImageFormat::fromCpp(format));
+    return __result;
   }
   void JHybridImageSpec::saveToFile(const std::string& path, const std::function<void(const std::string& /* path */)>& onFinished) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* path */, jni::alias_ref<JFunc_void_std__string::javaobject> /* onFinished */)>("saveToFile");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -72,13 +72,13 @@ namespace margelo::nitro::image {
   // Properties
   std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> JHybridTestObjectSwiftKotlinSpec::getThisObject() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("getThisObject");
-    auto result = method(_javaPart);
-    return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(result));
+    auto __result = method(_javaPart);
+    return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result));
   }
   double JHybridTestObjectSwiftKotlinSpec::getNumberValue() {
     static const auto method = _javaPart->getClass()->getMethod<double()>("getNumberValue");
-    auto result = method(_javaPart);
-    return result;
+    auto __result = method(_javaPart);
+    return __result;
   }
   void JHybridTestObjectSwiftKotlinSpec::setNumberValue(double numberValue) {
     static const auto method = _javaPart->getClass()->getMethod<void(double /* numberValue */)>("setNumberValue");
@@ -86,8 +86,8 @@ namespace margelo::nitro::image {
   }
   bool JHybridTestObjectSwiftKotlinSpec::getBoolValue() {
     static const auto method = _javaPart->getClass()->getMethod<jboolean()>("getBoolValue");
-    auto result = method(_javaPart);
-    return result;
+    auto __result = method(_javaPart);
+    return __result;
   }
   void JHybridTestObjectSwiftKotlinSpec::setBoolValue(bool boolValue) {
     static const auto method = _javaPart->getClass()->getMethod<void(jboolean /* boolValue */)>("setBoolValue");
@@ -95,8 +95,8 @@ namespace margelo::nitro::image {
   }
   std::string JHybridTestObjectSwiftKotlinSpec::getStringValue() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringValue");
-    auto result = method(_javaPart);
-    return result->toStdString();
+    auto __result = method(_javaPart);
+    return __result->toStdString();
   }
   void JHybridTestObjectSwiftKotlinSpec::setStringValue(const std::string& stringValue) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringValue */)>("setStringValue");
@@ -104,8 +104,8 @@ namespace margelo::nitro::image {
   }
   int64_t JHybridTestObjectSwiftKotlinSpec::getBigintValue() {
     static const auto method = _javaPart->getClass()->getMethod<int64_t()>("getBigintValue");
-    auto result = method(_javaPart);
-    return result;
+    auto __result = method(_javaPart);
+    return __result;
   }
   void JHybridTestObjectSwiftKotlinSpec::setBigintValue(int64_t bigintValue) {
     static const auto method = _javaPart->getClass()->getMethod<void(int64_t /* bigintValue */)>("setBigintValue");
@@ -113,8 +113,8 @@ namespace margelo::nitro::image {
   }
   std::optional<std::string> JHybridTestObjectSwiftKotlinSpec::getStringOrUndefined() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringOrUndefined");
-    auto result = method(_javaPart);
-    return result != nullptr ? std::make_optional(result->toStdString()) : std::nullopt;
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setStringOrUndefined(const std::optional<std::string>& stringOrUndefined) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringOrUndefined */)>("setStringOrUndefined");
@@ -122,8 +122,8 @@ namespace margelo::nitro::image {
   }
   std::optional<std::string> JHybridTestObjectSwiftKotlinSpec::getStringOrNull() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringOrNull");
-    auto result = method(_javaPart);
-    return result != nullptr ? std::make_optional(result->toStdString()) : std::nullopt;
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setStringOrNull(const std::optional<std::string>& stringOrNull) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringOrNull */)>("setStringOrNull");
@@ -131,8 +131,8 @@ namespace margelo::nitro::image {
   }
   std::optional<std::string> JHybridTestObjectSwiftKotlinSpec::getOptionalString() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getOptionalString");
-    auto result = method(_javaPart);
-    return result != nullptr ? std::make_optional(result->toStdString()) : std::nullopt;
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalString(const std::optional<std::string>& optionalString) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* optionalString */)>("setOptionalString");
@@ -140,8 +140,8 @@ namespace margelo::nitro::image {
   }
   std::variant<std::string, double> JHybridTestObjectSwiftKotlinSpec::getSomeVariant() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JVariant_String_Double>()>("getSomeVariant");
-    auto result = method(_javaPart);
-    return result->toCpp();
+    auto __result = method(_javaPart);
+    return __result->toCpp();
   }
   void JHybridTestObjectSwiftKotlinSpec::setSomeVariant(const std::variant<std::string, double>& someVariant) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JVariant_String_Double> /* someVariant */)>("setSomeVariant");
@@ -151,8 +151,8 @@ namespace margelo::nitro::image {
   // Methods
   std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> JHybridTestObjectSwiftKotlinSpec::newTestObject() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("newTestObject");
-    auto result = method(_javaPart);
-    return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(result));
+    auto __result = method(_javaPart);
+    return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result));
   }
   void JHybridTestObjectSwiftKotlinSpec::simpleFunc() {
     static const auto method = _javaPart->getClass()->getMethod<void()>("simpleFunc");
@@ -160,13 +160,13 @@ namespace margelo::nitro::image {
   }
   double JHybridTestObjectSwiftKotlinSpec::addNumbers(double a, double b) {
     static const auto method = _javaPart->getClass()->getMethod<double(double /* a */, double /* b */)>("addNumbers");
-    auto result = method(_javaPart, a, b);
-    return result;
+    auto __result = method(_javaPart, a, b);
+    return __result;
   }
   std::string JHybridTestObjectSwiftKotlinSpec::addStrings(const std::string& a, const std::string& b) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(jni::alias_ref<jni::JString> /* a */, jni::alias_ref<jni::JString> /* b */)>("addStrings");
-    auto result = method(_javaPart, jni::make_jstring(a), jni::make_jstring(b));
-    return result->toStdString();
+    auto __result = method(_javaPart, jni::make_jstring(a), jni::make_jstring(b));
+    return __result->toStdString();
   }
   void JHybridTestObjectSwiftKotlinSpec::multipleArguments(double num, const std::string& str, bool boo) {
     static const auto method = _javaPart->getClass()->getMethod<void(double /* num */, jni::alias_ref<jni::JString> /* str */, jboolean /* boo */)>("multipleArguments");
@@ -174,49 +174,49 @@ namespace margelo::nitro::image {
   }
   std::shared_ptr<AnyMap> JHybridTestObjectSwiftKotlinSpec::createMap() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JAnyMap::javaobject>()>("createMap");
-    auto result = method(_javaPart);
-    return result->cthis()->getMap();
+    auto __result = method(_javaPart);
+    return __result->cthis()->getMap();
   }
   std::shared_ptr<AnyMap> JHybridTestObjectSwiftKotlinSpec::mapRoundtrip(const std::shared_ptr<AnyMap>& map) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JAnyMap::javaobject>(jni::alias_ref<JAnyMap::javaobject> /* map */)>("mapRoundtrip");
-    auto result = method(_javaPart, JAnyMap::create(map));
-    return result->cthis()->getMap();
+    auto __result = method(_javaPart, JAnyMap::create(map));
+    return __result->cthis()->getMap();
   }
   double JHybridTestObjectSwiftKotlinSpec::funcThatThrows() {
     static const auto method = _javaPart->getClass()->getMethod<double()>("funcThatThrows");
-    auto result = method(_javaPart);
-    return result;
+    auto __result = method(_javaPart);
+    return __result;
   }
   std::string JHybridTestObjectSwiftKotlinSpec::tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jboolean /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryOptionalParams");
-    auto result = method(_javaPart, num, boo, str.has_value() ? jni::make_jstring(str.value()) : nullptr);
-    return result->toStdString();
+    auto __result = method(_javaPart, num, boo, str.has_value() ? jni::make_jstring(str.value()) : nullptr);
+    return __result->toStdString();
   }
   std::string JHybridTestObjectSwiftKotlinSpec::tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jni::alias_ref<jni::JBoolean> /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryMiddleParam");
-    auto result = method(_javaPart, num, boo.has_value() ? jni::JBoolean::valueOf(boo.value()) : nullptr, jni::make_jstring(str));
-    return result->toStdString();
+    auto __result = method(_javaPart, num, boo.has_value() ? jni::JBoolean::valueOf(boo.value()) : nullptr, jni::make_jstring(str));
+    return __result->toStdString();
   }
   std::optional<Powertrain> JHybridTestObjectSwiftKotlinSpec::tryOptionalEnum(std::optional<Powertrain> value) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPowertrain>(jni::alias_ref<JPowertrain> /* value */)>("tryOptionalEnum");
-    auto result = method(_javaPart, value.has_value() ? JPowertrain::fromCpp(value.value()) : nullptr);
-    return result != nullptr ? std::make_optional(result->toCpp()) : std::nullopt;
+    auto __result = method(_javaPart, value.has_value() ? JPowertrain::fromCpp(value.value()) : nullptr);
+    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   int64_t JHybridTestObjectSwiftKotlinSpec::calculateFibonacciSync(double value) {
     static const auto method = _javaPart->getClass()->getMethod<int64_t(double /* value */)>("calculateFibonacciSync");
-    auto result = method(_javaPart, value);
-    return result;
+    auto __result = method(_javaPart, value);
+    return __result;
   }
   std::future<int64_t> JHybridTestObjectSwiftKotlinSpec::calculateFibonacciAsync(double value) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* value */)>("calculateFibonacciAsync");
-    auto result = method(_javaPart, value);
+    auto __result = method(_javaPart, value);
     return [&]() {
       auto __promise = std::make_shared<std::promise<int64_t>>();
-      result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
         auto __result = jni::static_ref_cast<jni::JLong>(__boxedResult);
         __promise->set_value(__result->value());
       });
-      result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
         std::runtime_error __error(__message->toStdString());
         __promise->set_exception(std::make_exception_ptr(__error));
       });
@@ -225,13 +225,13 @@ namespace margelo::nitro::image {
   }
   std::future<void> JHybridTestObjectSwiftKotlinSpec::wait(double seconds) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* seconds */)>("wait");
-    auto result = method(_javaPart, seconds);
+    auto __result = method(_javaPart, seconds);
     return [&]() {
       auto __promise = std::make_shared<std::promise<void>>();
-      result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
         __promise->set_value();
       });
-      result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
         std::runtime_error __error(__message->toStdString());
         __promise->set_exception(std::make_exception_ptr(__error));
       });
@@ -252,28 +252,28 @@ namespace margelo::nitro::image {
   }
   Car JHybridTestObjectSwiftKotlinSpec::getCar() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JCar>()>("getCar");
-    auto result = method(_javaPart);
-    return result->toCpp();
+    auto __result = method(_javaPart);
+    return __result->toCpp();
   }
   bool JHybridTestObjectSwiftKotlinSpec::isCarElectric(const Car& car) {
     static const auto method = _javaPart->getClass()->getMethod<jboolean(jni::alias_ref<JCar> /* car */)>("isCarElectric");
-    auto result = method(_javaPart, JCar::fromCpp(car));
-    return result;
+    auto __result = method(_javaPart, JCar::fromCpp(car));
+    return __result;
   }
   std::optional<Person> JHybridTestObjectSwiftKotlinSpec::getDriver(const Car& car) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPerson>(jni::alias_ref<JCar> /* car */)>("getDriver");
-    auto result = method(_javaPart, JCar::fromCpp(car));
-    return result != nullptr ? std::make_optional(result->toCpp()) : std::nullopt;
+    auto __result = method(_javaPart, JCar::fromCpp(car));
+    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   std::shared_ptr<ArrayBuffer> JHybridTestObjectSwiftKotlinSpec::createArrayBuffer() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JArrayBuffer::javaobject>()>("createArrayBuffer");
-    auto result = method(_javaPart);
-    return result->cthis()->getArrayBuffer();
+    auto __result = method(_javaPart);
+    return __result->cthis()->getArrayBuffer();
   }
   double JHybridTestObjectSwiftKotlinSpec::getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) {
     static const auto method = _javaPart->getClass()->getMethod<double(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */)>("getBufferLastItem");
-    auto result = method(_javaPart, JArrayBuffer::wrap(buffer));
-    return result;
+    auto __result = method(_javaPart, JArrayBuffer::wrap(buffer));
+    return __result;
   }
   void JHybridTestObjectSwiftKotlinSpec::setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */, double /* value */)>("setAllValuesTo");
@@ -281,38 +281,38 @@ namespace margelo::nitro::image {
   }
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> JHybridTestObjectSwiftKotlinSpec::createChild() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>()>("createChild");
-    auto result = method(_javaPart);
-    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(result));
+    auto __result = method(_javaPart);
+    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::createBase() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>()>("createBase");
-    auto result = method(_javaPart);
-    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(result));
+    auto __result = method(_javaPart);
+    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::createBaseActualChild() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>()>("createBaseActualChild");
-    auto result = method(_javaPart);
-    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(result));
+    auto __result = method(_javaPart);
+    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> JHybridTestObjectSwiftKotlinSpec::bounceChild(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridChildSpec::javaobject> /* child */)>("bounceChild");
-    auto result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
-    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(result));
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
+    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("bounceBase");
-    auto result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
-    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(result));
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
+    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>(jni::alias_ref<JHybridChildSpec::javaobject> /* child */)>("bounceChildBase");
-    auto result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
-    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(result));
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
+    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> JHybridTestObjectSwiftKotlinSpec::castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("castBase");
-    auto result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
-    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(result));
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
+    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
   }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -211,31 +211,31 @@ namespace margelo::nitro::image {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* value */)>("calculateFibonacciAsync");
     auto result = method(_javaPart, value);
     return [&]() {
-      auto promise = std::make_shared<std::promise<int64_t>>();
-      result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& boxedResult) {
-        auto result = jni::static_ref_cast<jni::JLong>(boxedResult);
-        promise->set_value(result->value());
+      auto __promise = std::make_shared<std::promise<int64_t>>();
+      result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JLong>(__boxedResult);
+        __promise->set_value(__result->value());
       });
-      result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& message) {
-        std::runtime_error error(message->toStdString());
-        promise->set_exception(std::make_exception_ptr(error));
+      result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
+        std::runtime_error __error(__message->toStdString());
+        __promise->set_exception(std::make_exception_ptr(__error));
       });
-      return promise->get_future();
+      return __promise->get_future();
     }();
   }
   std::future<void> JHybridTestObjectSwiftKotlinSpec::wait(double seconds) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* seconds */)>("wait");
     auto result = method(_javaPart, seconds);
     return [&]() {
-      auto promise = std::make_shared<std::promise<void>>();
-      result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& boxedResult) {
-        promise->set_value();
+      auto __promise = std::make_shared<std::promise<void>>();
+      result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        __promise->set_value();
       });
-      result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& message) {
-        std::runtime_error error(message->toStdString());
-        promise->set_exception(std::make_exception_ptr(error));
+      result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
+        std::runtime_error __error(__message->toStdString());
+        __promise->set_exception(std::make_exception_ptr(__error));
       });
-      return promise->get_future();
+      return __promise->get_future();
     }();
   }
   void JHybridTestObjectSwiftKotlinSpec::callCallback(const std::function<void()>& callback) {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -64,8 +64,8 @@ abstract class HybridImageSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun saveToFile(path: String, onFinished: Func_void_std__string): Unit {
-    val result = saveToFile(path, onFinished.toLambda())
-    return result
+    val __result = saveToFile(path, onFinished.toLambda())
+    return __result
   }
 
   private external fun initHybrid(): HybridData

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -154,8 +154,8 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callCallback(callback: Func_void): Unit {
-    val result = callCallback(callback.toLambda())
-    return result
+    val __result = callCallback(callback.toLambda())
+    return __result
   }
   
   @DoNotStrip
@@ -165,8 +165,8 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callAll(first: Func_void, second: Func_void, third: Func_void): Unit {
-    val result = callAll(first.toLambda(), second.toLambda(), third.toLambda())
-    return result
+    val __result = callAll(first.toLambda(), second.toLambda(), third.toLambda())
+    return __result
   }
   
   @DoNotStrip
@@ -176,8 +176,8 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callWithOptional(value: Double?, callback: Func_void_std__optional_double_): Unit {
-    val result = callWithOptional(value, callback.toLambda())
-    return result
+    val __result = callWithOptional(value, callback.toLambda())
+    return __result
   }
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -369,7 +369,7 @@ namespace margelo::nitro::image::bridge::swift {
     explicit Func_std__future_double__Wrapper(std::function<std::future<double>()>&& func): function(std::move(func)) {}
   
     PromiseHolder<double> call() const {
-      auto result = function();
+      auto __result = function();
       return []() -> PromiseHolder<double> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
     }
   
@@ -378,8 +378,8 @@ namespace margelo::nitro::image::bridge::swift {
   inline Func_std__future_double_ create_Func_std__future_double_(void* closureHolder, PromiseHolder<double>(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__future_double_([sharedClosureHolder, call]() -> std::future<double> {
-      auto result = call(sharedClosureHolder.get());
-      return result.getFuture();
+      auto __result = call(sharedClosureHolder.get());
+      return __result.getFuture();
     });
   }
   inline std::shared_ptr<Func_std__future_double__Wrapper> share_Func_std__future_double_(const Func_std__future_double_& value) {
@@ -407,7 +407,7 @@ namespace margelo::nitro::image::bridge::swift {
     explicit Func_std__future_std__string__Wrapper(std::function<std::future<std::string>()>&& func): function(std::move(func)) {}
   
     PromiseHolder<std::string> call() const {
-      auto result = function();
+      auto __result = function();
       return []() -> PromiseHolder<std::string> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
     }
   
@@ -416,8 +416,8 @@ namespace margelo::nitro::image::bridge::swift {
   inline Func_std__future_std__string_ create_Func_std__future_std__string_(void* closureHolder, PromiseHolder<std::string>(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__future_std__string_([sharedClosureHolder, call]() -> std::future<std::string> {
-      auto result = call(sharedClosureHolder.get());
-      return result.getFuture();
+      auto __result = call(sharedClosureHolder.get());
+      return __result.getFuture();
     });
   }
   inline std::shared_ptr<Func_std__future_std__string__Wrapper> share_Func_std__future_std__string_(const Func_std__future_std__string_& value) {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
@@ -65,12 +65,12 @@ namespace margelo::nitro::image {
   public:
     // Properties
     inline ImageSize getSize() noexcept override {
-      auto result = _swiftPart.getSize();
-      return result;
+      auto __result = _swiftPart.getSize();
+      return __result;
     }
     inline PixelFormat getPixelFormat() noexcept override {
-      auto result = _swiftPart.getPixelFormat();
-      return static_cast<PixelFormat>(result);
+      auto __result = _swiftPart.getPixelFormat();
+      return static_cast<PixelFormat>(__result);
     }
     inline double getSomeSettableProp() noexcept override {
       return _swiftPart.getSomeSettableProp();

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -97,8 +97,8 @@ namespace margelo::nitro::image {
   public:
     // Properties
     inline std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> getThisObject() noexcept override {
-      auto result = _swiftPart.getThisObject();
-      return HybridContext::getOrCreate<HybridTestObjectSwiftKotlinSpecSwift>(result);
+      auto __result = _swiftPart.getThisObject();
+      return HybridContext::getOrCreate<HybridTestObjectSwiftKotlinSpecSwift>(__result);
     }
     inline double getNumberValue() noexcept override {
       return _swiftPart.getNumberValue();
@@ -113,8 +113,8 @@ namespace margelo::nitro::image {
       _swiftPart.setBoolValue(std::forward<decltype(boolValue)>(boolValue));
     }
     inline std::string getStringValue() noexcept override {
-      auto result = _swiftPart.getStringValue();
-      return result;
+      auto __result = _swiftPart.getStringValue();
+      return __result;
     }
     inline void setStringValue(const std::string& stringValue) noexcept override {
       _swiftPart.setStringValue(stringValue);
@@ -126,29 +126,29 @@ namespace margelo::nitro::image {
       _swiftPart.setBigintValue(std::forward<decltype(bigintValue)>(bigintValue));
     }
     inline std::optional<std::string> getStringOrUndefined() noexcept override {
-      auto result = _swiftPart.getStringOrUndefined();
-      return result;
+      auto __result = _swiftPart.getStringOrUndefined();
+      return __result;
     }
     inline void setStringOrUndefined(const std::optional<std::string>& stringOrUndefined) noexcept override {
       _swiftPart.setStringOrUndefined(stringOrUndefined);
     }
     inline std::optional<std::string> getStringOrNull() noexcept override {
-      auto result = _swiftPart.getStringOrNull();
-      return result;
+      auto __result = _swiftPart.getStringOrNull();
+      return __result;
     }
     inline void setStringOrNull(const std::optional<std::string>& stringOrNull) noexcept override {
       _swiftPart.setStringOrNull(stringOrNull);
     }
     inline std::optional<std::string> getOptionalString() noexcept override {
-      auto result = _swiftPart.getOptionalString();
-      return result;
+      auto __result = _swiftPart.getOptionalString();
+      return __result;
     }
     inline void setOptionalString(const std::optional<std::string>& optionalString) noexcept override {
       _swiftPart.setOptionalString(optionalString);
     }
     inline std::variant<std::string, double> getSomeVariant() noexcept override {
-      auto result = _swiftPart.getSomeVariant();
-      return result;
+      auto __result = _swiftPart.getSomeVariant();
+      return __result;
     }
     inline void setSomeVariant(const std::variant<std::string, double>& someVariant) noexcept override {
       _swiftPart.setSomeVariant(someVariant);

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Car.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Car.swift
@@ -20,8 +20,8 @@ public extension Car {
    */
   init(year: Double, make: String, model: String, power: Double, powertrain: Powertrain, driver: Person?) {
     self.init(year, std.string(make), std.string(model), power, powertrain, { () -> bridge.std__optional_Person_ in
-      if let actualValue = driver {
-        return bridge.create_std__optional_Person_(actualValue)
+      if let __unwrappedValue = driver {
+        return bridge.create_std__optional_Person_(__unwrappedValue)
       } else {
         return .init()
       }
@@ -87,8 +87,8 @@ public extension Car {
     @inline(__always)
     get {
       return { () -> Person? in
-        if let actualValue = self.__driver.value {
-          return actualValue
+        if let __unwrapped = self.__driver.value {
+          return __unwrapped
         } else {
           return nil
         }
@@ -97,8 +97,8 @@ public extension Car {
     @inline(__always)
     set {
       self.__driver = { () -> bridge.std__optional_Person_ in
-        if let actualValue = newValue {
-          return bridge.create_std__optional_Person_(actualValue)
+        if let __unwrappedValue = newValue {
+          return bridge.create_std__optional_Person_(__unwrappedValue)
         } else {
           return .init()
         }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpecCxx.swift
@@ -28,14 +28,14 @@ public class HybridBaseSpecCxx {
   /**
    * Holds an instance of the `HybridBaseSpec` Swift protocol.
    */
-  private var implementation: HybridBaseSpec
+  private var __implementation: HybridBaseSpec
 
   /**
    * Get the actual `HybridBaseSpec` instance this class wraps.
    */
   @inline(__always)
   public func getHybridBaseSpec() -> HybridBaseSpec {
-    return implementation
+    return __implementation
   }
 
   /**
@@ -43,7 +43,7 @@ public class HybridBaseSpecCxx {
    * All properties and methods bridge to C++ types.
    */
   public init(_ implementation: HybridBaseSpec) {
-    self.implementation = implementation
+    self.__implementation = implementation
     /* no base class */
   }
 
@@ -53,11 +53,11 @@ public class HybridBaseSpecCxx {
   public var hybridContext: margelo.nitro.HybridContext {
     @inline(__always)
     get {
-      return self.implementation.hybridContext
+      return self.__implementation.hybridContext
     }
     @inline(__always)
     set {
-      self.implementation.hybridContext = newValue
+      self.__implementation.hybridContext = newValue
     }
   }
 
@@ -67,14 +67,14 @@ public class HybridBaseSpecCxx {
    */
   @inline(__always)
   public var memorySize: Int {
-    return self.implementation.memorySize
+    return self.__implementation.memorySize
   }
 
   // Properties
   public var baseValue: Double {
     @inline(__always)
     get {
-      return self.implementation.baseValue
+      return self.__implementation.baseValue
     }
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpecCxx.swift
@@ -28,14 +28,14 @@ public class HybridChildSpecCxx : HybridBaseSpecCxx {
   /**
    * Holds an instance of the `HybridChildSpec` Swift protocol.
    */
-  private var implementation: HybridChildSpec
+  private var __implementation: HybridChildSpec
 
   /**
    * Get the actual `HybridChildSpec` instance this class wraps.
    */
   @inline(__always)
   public func getHybridChildSpec() -> HybridChildSpec {
-    return implementation
+    return __implementation
   }
 
   /**
@@ -43,7 +43,7 @@ public class HybridChildSpecCxx : HybridBaseSpecCxx {
    * All properties and methods bridge to C++ types.
    */
   public init(_ implementation: HybridChildSpec) {
-    self.implementation = implementation
+    self.__implementation = implementation
     super.init(implementation)
   }
 
@@ -53,11 +53,11 @@ public class HybridChildSpecCxx : HybridBaseSpecCxx {
   public override var hybridContext: margelo.nitro.HybridContext {
     @inline(__always)
     get {
-      return self.implementation.hybridContext
+      return self.__implementation.hybridContext
     }
     @inline(__always)
     set {
-      self.implementation.hybridContext = newValue
+      self.__implementation.hybridContext = newValue
     }
   }
 
@@ -67,14 +67,14 @@ public class HybridChildSpecCxx : HybridBaseSpecCxx {
    */
   @inline(__always)
   public override var memorySize: Int {
-    return self.implementation.memorySize
+    return self.__implementation.memorySize
   }
 
   // Properties
   public var childValue: Double {
     @inline(__always)
     get {
-      return self.implementation.childValue
+      return self.__implementation.childValue
     }
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpecCxx.swift
@@ -28,14 +28,14 @@ public class HybridImageFactorySpecCxx {
   /**
    * Holds an instance of the `HybridImageFactorySpec` Swift protocol.
    */
-  private var implementation: HybridImageFactorySpec
+  private var __implementation: HybridImageFactorySpec
 
   /**
    * Get the actual `HybridImageFactorySpec` instance this class wraps.
    */
   @inline(__always)
   public func getHybridImageFactorySpec() -> HybridImageFactorySpec {
-    return implementation
+    return __implementation
   }
 
   /**
@@ -43,7 +43,7 @@ public class HybridImageFactorySpecCxx {
    * All properties and methods bridge to C++ types.
    */
   public init(_ implementation: HybridImageFactorySpec) {
-    self.implementation = implementation
+    self.__implementation = implementation
     /* no base class */
   }
 
@@ -53,11 +53,11 @@ public class HybridImageFactorySpecCxx {
   public var hybridContext: margelo.nitro.HybridContext {
     @inline(__always)
     get {
-      return self.implementation.hybridContext
+      return self.__implementation.hybridContext
     }
     @inline(__always)
     set {
-      self.implementation.hybridContext = newValue
+      self.__implementation.hybridContext = newValue
     }
   }
 
@@ -67,7 +67,7 @@ public class HybridImageFactorySpecCxx {
    */
   @inline(__always)
   public var memorySize: Int {
-    return self.implementation.memorySize
+    return self.__implementation.memorySize
   }
 
   // Properties
@@ -77,8 +77,8 @@ public class HybridImageFactorySpecCxx {
   @inline(__always)
   public func loadImageFromFile(path: std.string) -> HybridImageSpecCxx {
     do {
-      let result = try self.implementation.loadImageFromFile(path: String(path))
-      return result.createCxxBridge()
+      let __result = try self.__implementation.loadImageFromFile(path: String(path))
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -88,8 +88,8 @@ public class HybridImageFactorySpecCxx {
   @inline(__always)
   public func loadImageFromURL(path: std.string) -> HybridImageSpecCxx {
     do {
-      let result = try self.implementation.loadImageFromURL(path: String(path))
-      return result.createCxxBridge()
+      let __result = try self.__implementation.loadImageFromURL(path: String(path))
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -99,8 +99,8 @@ public class HybridImageFactorySpecCxx {
   @inline(__always)
   public func loadImageFromSystemName(path: std.string) -> HybridImageSpecCxx {
     do {
-      let result = try self.implementation.loadImageFromSystemName(path: String(path))
-      return result.createCxxBridge()
+      let __result = try self.__implementation.loadImageFromSystemName(path: String(path))
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -110,8 +110,8 @@ public class HybridImageFactorySpecCxx {
   @inline(__always)
   public func bounceBack(image: HybridImageSpecCxx) -> HybridImageSpecCxx {
     do {
-      let result = try self.implementation.bounceBack(image: image.getHybridImageSpec())
-      return result.createCxxBridge()
+      let __result = try self.__implementation.bounceBack(image: image.getHybridImageSpec())
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpecCxx.swift
@@ -112,9 +112,9 @@ public class HybridImageSpecCxx {
   public func saveToFile(path: std.string, onFinished: bridge.Func_void_std__string) -> Void {
     do {
       try self.implementation.saveToFile(path: String(path), onFinished: { () -> ((String) -> Void) in
-        let shared = bridge.share_Func_void_std__string(onFinished)
-        return { (path: String) -> Void in
-          shared.pointee.call(std.string(path))
+        let __sharedClosure = bridge.share_Func_void_std__string(onFinished)
+        return { (__path: String) -> Void in
+          __sharedClosure.pointee.call(std.string(__path))
         }
       }())
       return 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpecCxx.swift
@@ -28,14 +28,14 @@ public class HybridImageSpecCxx {
   /**
    * Holds an instance of the `HybridImageSpec` Swift protocol.
    */
-  private var implementation: HybridImageSpec
+  private var __implementation: HybridImageSpec
 
   /**
    * Get the actual `HybridImageSpec` instance this class wraps.
    */
   @inline(__always)
   public func getHybridImageSpec() -> HybridImageSpec {
-    return implementation
+    return __implementation
   }
 
   /**
@@ -43,7 +43,7 @@ public class HybridImageSpecCxx {
    * All properties and methods bridge to C++ types.
    */
   public init(_ implementation: HybridImageSpec) {
-    self.implementation = implementation
+    self.__implementation = implementation
     /* no base class */
   }
 
@@ -53,11 +53,11 @@ public class HybridImageSpecCxx {
   public var hybridContext: margelo.nitro.HybridContext {
     @inline(__always)
     get {
-      return self.implementation.hybridContext
+      return self.__implementation.hybridContext
     }
     @inline(__always)
     set {
-      self.implementation.hybridContext = newValue
+      self.__implementation.hybridContext = newValue
     }
   }
 
@@ -67,32 +67,32 @@ public class HybridImageSpecCxx {
    */
   @inline(__always)
   public var memorySize: Int {
-    return self.implementation.memorySize
+    return self.__implementation.memorySize
   }
 
   // Properties
   public var size: ImageSize {
     @inline(__always)
     get {
-      return self.implementation.size
+      return self.__implementation.size
     }
   }
   
   public var pixelFormat: Int32 {
     @inline(__always)
     get {
-      return self.implementation.pixelFormat.rawValue
+      return self.__implementation.pixelFormat.rawValue
     }
   }
   
   public var someSettableProp: Double {
     @inline(__always)
     get {
-      return self.implementation.someSettableProp
+      return self.__implementation.someSettableProp
     }
     @inline(__always)
     set {
-      self.implementation.someSettableProp = newValue
+      self.__implementation.someSettableProp = newValue
     }
   }
 
@@ -100,8 +100,8 @@ public class HybridImageSpecCxx {
   @inline(__always)
   public func toArrayBuffer(format: Int32) -> Double {
     do {
-      let result = try self.implementation.toArrayBuffer(format: margelo.nitro.image.ImageFormat(rawValue: format)!)
-      return result
+      let __result = try self.__implementation.toArrayBuffer(format: margelo.nitro.image.ImageFormat(rawValue: format)!)
+      return __result
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -111,7 +111,7 @@ public class HybridImageSpecCxx {
   @inline(__always)
   public func saveToFile(path: std.string, onFinished: bridge.Func_void_std__string) -> Void {
     do {
-      try self.implementation.saveToFile(path: String(path), onFinished: { () -> ((String) -> Void) in
+      try self.__implementation.saveToFile(path: String(path), onFinished: { () -> ((String) -> Void) in
         let __sharedClosure = bridge.share_Func_void_std__string(onFinished)
         return { (__path: String) -> Void in
           __sharedClosure.pointee.call(std.string(__path))

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -126,8 +126,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     get {
       return { () -> bridge.std__optional_std__string_ in
-        if let actualValue = self.implementation.stringOrUndefined {
-          return bridge.create_std__optional_std__string_(std.string(actualValue))
+        if let __unwrappedValue = self.implementation.stringOrUndefined {
+          return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
         } else {
           return .init()
         }
@@ -136,8 +136,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     set {
       self.implementation.stringOrUndefined = { () -> String? in
-        if let actualValue = newValue.value {
-          return String(actualValue)
+        if let __unwrapped = newValue.value {
+          return String(__unwrapped)
         } else {
           return nil
         }
@@ -149,8 +149,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     get {
       return { () -> bridge.std__optional_std__string_ in
-        if let actualValue = self.implementation.stringOrNull {
-          return bridge.create_std__optional_std__string_(std.string(actualValue))
+        if let __unwrappedValue = self.implementation.stringOrNull {
+          return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
         } else {
           return .init()
         }
@@ -159,8 +159,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     set {
       self.implementation.stringOrNull = { () -> String? in
-        if let actualValue = newValue.value {
-          return String(actualValue)
+        if let __unwrapped = newValue.value {
+          return String(__unwrapped)
         } else {
           return nil
         }
@@ -172,8 +172,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     get {
       return { () -> bridge.std__optional_std__string_ in
-        if let actualValue = self.implementation.optionalString {
-          return bridge.create_std__optional_std__string_(std.string(actualValue))
+        if let __unwrappedValue = self.implementation.optionalString {
+          return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
         } else {
           return .init()
         }
@@ -182,8 +182,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     set {
       self.implementation.optionalString = { () -> String? in
-        if let actualValue = newValue.value {
-          return String(actualValue)
+        if let __unwrapped = newValue.value {
+          return String(__unwrapped)
         } else {
           return nil
         }
@@ -196,10 +196,10 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     get {
       return { () -> bridge.std__variant_std__string__double_ in
         switch self.implementation.someVariant {
-          case .someString(let value):
-            return bridge.create_std__variant_std__string__double_(std.string(value))
-          case .someDouble(let value):
-            return bridge.create_std__variant_std__string__double_(value)
+          case .someString(let __value):
+            return bridge.create_std__variant_std__string__double_(std.string(__value))
+          case .someDouble(let __value):
+            return bridge.create_std__variant_std__string__double_(__value)
         }
       }()
     }
@@ -208,11 +208,11 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
       self.implementation.someVariant = { () -> Variant_String_Double in
         switch newValue.index() {
           case 0:
-            let actual = bridge.get_std__variant_std__string__double__0(newValue)
-            return .someString(String(actual))
+            let __actual = bridge.get_std__variant_std__string__double__0(newValue)
+            return .someString(String(__actual))
           case 1:
-            let actual = bridge.get_std__variant_std__string__double__1(newValue)
-            return .someDouble(actual)
+            let __actual = bridge.get_std__variant_std__string__double__1(newValue)
+            return .someDouble(__actual)
           default:
             fatalError("Variant can never have index \(newValue.index())!")
         }
@@ -313,8 +313,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   public func tryOptionalParams(num: Double, boo: Bool, str: bridge.std__optional_std__string_) -> std.string {
     do {
       let result = try self.implementation.tryOptionalParams(num: num, boo: boo, str: { () -> String? in
-        if let actualValue = str.value {
-          return String(actualValue)
+        if let __unwrapped = str.value {
+          return String(__unwrapped)
         } else {
           return nil
         }
@@ -342,8 +342,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       let result = try self.implementation.tryOptionalEnum(value: value.value)
       return { () -> bridge.std__optional_Powertrain_ in
-        if let actualValue = result {
-          return bridge.create_std__optional_Powertrain_(actualValue)
+        if let __unwrappedValue = result {
+          return bridge.create_std__optional_Powertrain_(__unwrappedValue)
         } else {
           return .init()
         }
@@ -370,11 +370,11 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       let result = try self.implementation.calculateFibonacciAsync(value: value)
       return { () -> bridge.PromiseHolder_int64_t_ in
-        let promiseHolder = bridge.create_PromiseHolder_int64_t_()
+        let __promiseHolder = bridge.create_PromiseHolder_int64_t_()
         result
-          .then({ __result in promiseHolder.resolve(__result) })
-          .catch({ __error in promiseHolder.reject(std.string(String(describing: __error))) })
-        return promiseHolder
+          .then({ __result in __promiseHolder.resolve(__result) })
+          .catch({ __error in __promiseHolder.reject(std.string(String(describing: __error))) })
+        return __promiseHolder
       }()
     } catch {
       let message = "\(error.localizedDescription)"
@@ -387,11 +387,11 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       let result = try self.implementation.wait(seconds: seconds)
       return { () -> bridge.PromiseHolder_void_ in
-        let promiseHolder = bridge.create_PromiseHolder_void_()
+        let __promiseHolder = bridge.create_PromiseHolder_void_()
         result
-          .then({ __result in promiseHolder.resolve() })
-          .catch({ __error in promiseHolder.reject(std.string(String(describing: __error))) })
-        return promiseHolder
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(std.string(String(describing: __error))) })
+        return __promiseHolder
       }()
     } catch {
       let message = "\(error.localizedDescription)"
@@ -403,9 +403,9 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   public func callCallback(callback: bridge.Func_void) -> Void {
     do {
       try self.implementation.callCallback(callback: { () -> (() -> Void) in
-        let shared = bridge.share_Func_void(callback)
+        let __sharedClosure = bridge.share_Func_void(callback)
         return { () -> Void in
-          shared.pointee.call()
+          __sharedClosure.pointee.call()
         }
       }())
       return 
@@ -419,19 +419,19 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   public func callAll(first: bridge.Func_void, second: bridge.Func_void, third: bridge.Func_void) -> Void {
     do {
       try self.implementation.callAll(first: { () -> (() -> Void) in
-        let shared = bridge.share_Func_void(first)
+        let __sharedClosure = bridge.share_Func_void(first)
         return { () -> Void in
-          shared.pointee.call()
+          __sharedClosure.pointee.call()
         }
       }(), second: { () -> (() -> Void) in
-        let shared = bridge.share_Func_void(second)
+        let __sharedClosure = bridge.share_Func_void(second)
         return { () -> Void in
-          shared.pointee.call()
+          __sharedClosure.pointee.call()
         }
       }(), third: { () -> (() -> Void) in
-        let shared = bridge.share_Func_void(third)
+        let __sharedClosure = bridge.share_Func_void(third)
         return { () -> Void in
-          shared.pointee.call()
+          __sharedClosure.pointee.call()
         }
       }())
       return 
@@ -445,11 +445,11 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   public func callWithOptional(value: bridge.std__optional_double_, callback: bridge.Func_void_std__optional_double_) -> Void {
     do {
       try self.implementation.callWithOptional(value: value.value, callback: { () -> ((Double?) -> Void) in
-        let shared = bridge.share_Func_void_std__optional_double_(callback)
-        return { (maybe: Double?) -> Void in
-          shared.pointee.call({ () -> bridge.std__optional_double_ in
-          if let actualValue = maybe {
-            return bridge.create_std__optional_double_(actualValue)
+        let __sharedClosure = bridge.share_Func_void_std__optional_double_(callback)
+        return { (__maybe: Double?) -> Void in
+          __sharedClosure.pointee.call({ () -> bridge.std__optional_double_ in
+          if let __unwrappedValue = __maybe {
+            return bridge.create_std__optional_double_(__unwrappedValue)
           } else {
             return .init()
           }
@@ -490,8 +490,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       let result = try self.implementation.getDriver(car: car)
       return { () -> bridge.std__optional_Person_ in
-        if let actualValue = result {
-          return bridge.create_std__optional_Person_(actualValue)
+        if let __unwrappedValue = result {
+          return bridge.create_std__optional_Person_(__unwrappedValue)
         } else {
           return .init()
         }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -28,14 +28,14 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   /**
    * Holds an instance of the `HybridTestObjectSwiftKotlinSpec` Swift protocol.
    */
-  private var implementation: HybridTestObjectSwiftKotlinSpec
+  private var __implementation: HybridTestObjectSwiftKotlinSpec
 
   /**
    * Get the actual `HybridTestObjectSwiftKotlinSpec` instance this class wraps.
    */
   @inline(__always)
   public func getHybridTestObjectSwiftKotlinSpec() -> HybridTestObjectSwiftKotlinSpec {
-    return implementation
+    return __implementation
   }
 
   /**
@@ -43,7 +43,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
    * All properties and methods bridge to C++ types.
    */
   public init(_ implementation: HybridTestObjectSwiftKotlinSpec) {
-    self.implementation = implementation
+    self.__implementation = implementation
     /* no base class */
   }
 
@@ -53,11 +53,11 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   public var hybridContext: margelo.nitro.HybridContext {
     @inline(__always)
     get {
-      return self.implementation.hybridContext
+      return self.__implementation.hybridContext
     }
     @inline(__always)
     set {
-      self.implementation.hybridContext = newValue
+      self.__implementation.hybridContext = newValue
     }
   }
 
@@ -67,58 +67,58 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
    */
   @inline(__always)
   public var memorySize: Int {
-    return self.implementation.memorySize
+    return self.__implementation.memorySize
   }
 
   // Properties
   public var thisObject: HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     get {
-      return self.implementation.thisObject.createCxxBridge()
+      return self.__implementation.thisObject.createCxxBridge()
     }
   }
   
   public var numberValue: Double {
     @inline(__always)
     get {
-      return self.implementation.numberValue
+      return self.__implementation.numberValue
     }
     @inline(__always)
     set {
-      self.implementation.numberValue = newValue
+      self.__implementation.numberValue = newValue
     }
   }
   
   public var boolValue: Bool {
     @inline(__always)
     get {
-      return self.implementation.boolValue
+      return self.__implementation.boolValue
     }
     @inline(__always)
     set {
-      self.implementation.boolValue = newValue
+      self.__implementation.boolValue = newValue
     }
   }
   
   public var stringValue: std.string {
     @inline(__always)
     get {
-      return std.string(self.implementation.stringValue)
+      return std.string(self.__implementation.stringValue)
     }
     @inline(__always)
     set {
-      self.implementation.stringValue = String(newValue)
+      self.__implementation.stringValue = String(newValue)
     }
   }
   
   public var bigintValue: Int64 {
     @inline(__always)
     get {
-      return self.implementation.bigintValue
+      return self.__implementation.bigintValue
     }
     @inline(__always)
     set {
-      self.implementation.bigintValue = newValue
+      self.__implementation.bigintValue = newValue
     }
   }
   
@@ -126,7 +126,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     get {
       return { () -> bridge.std__optional_std__string_ in
-        if let __unwrappedValue = self.implementation.stringOrUndefined {
+        if let __unwrappedValue = self.__implementation.stringOrUndefined {
           return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
         } else {
           return .init()
@@ -135,7 +135,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     }
     @inline(__always)
     set {
-      self.implementation.stringOrUndefined = { () -> String? in
+      self.__implementation.stringOrUndefined = { () -> String? in
         if let __unwrapped = newValue.value {
           return String(__unwrapped)
         } else {
@@ -149,7 +149,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     get {
       return { () -> bridge.std__optional_std__string_ in
-        if let __unwrappedValue = self.implementation.stringOrNull {
+        if let __unwrappedValue = self.__implementation.stringOrNull {
           return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
         } else {
           return .init()
@@ -158,7 +158,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     }
     @inline(__always)
     set {
-      self.implementation.stringOrNull = { () -> String? in
+      self.__implementation.stringOrNull = { () -> String? in
         if let __unwrapped = newValue.value {
           return String(__unwrapped)
         } else {
@@ -172,7 +172,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     get {
       return { () -> bridge.std__optional_std__string_ in
-        if let __unwrappedValue = self.implementation.optionalString {
+        if let __unwrappedValue = self.__implementation.optionalString {
           return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
         } else {
           return .init()
@@ -181,7 +181,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     }
     @inline(__always)
     set {
-      self.implementation.optionalString = { () -> String? in
+      self.__implementation.optionalString = { () -> String? in
         if let __unwrapped = newValue.value {
           return String(__unwrapped)
         } else {
@@ -195,7 +195,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     @inline(__always)
     get {
       return { () -> bridge.std__variant_std__string__double_ in
-        switch self.implementation.someVariant {
+        switch self.__implementation.someVariant {
           case .someString(let __value):
             return bridge.create_std__variant_std__string__double_(std.string(__value))
           case .someDouble(let __value):
@@ -205,7 +205,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     }
     @inline(__always)
     set {
-      self.implementation.someVariant = { () -> Variant_String_Double in
+      self.__implementation.someVariant = { () -> Variant_String_Double in
         switch newValue.index() {
           case 0:
             let __actual = bridge.get_std__variant_std__string__double__0(newValue)
@@ -224,8 +224,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func newTestObject() -> HybridTestObjectSwiftKotlinSpecCxx {
     do {
-      let result = try self.implementation.newTestObject()
-      return result.createCxxBridge()
+      let __result = try self.__implementation.newTestObject()
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -235,7 +235,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func simpleFunc() -> Void {
     do {
-      try self.implementation.simpleFunc()
+      try self.__implementation.simpleFunc()
       return 
     } catch {
       let message = "\(error.localizedDescription)"
@@ -246,8 +246,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func addNumbers(a: Double, b: Double) -> Double {
     do {
-      let result = try self.implementation.addNumbers(a: a, b: b)
-      return result
+      let __result = try self.__implementation.addNumbers(a: a, b: b)
+      return __result
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -257,8 +257,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func addStrings(a: std.string, b: std.string) -> std.string {
     do {
-      let result = try self.implementation.addStrings(a: String(a), b: String(b))
-      return std.string(result)
+      let __result = try self.__implementation.addStrings(a: String(a), b: String(b))
+      return std.string(__result)
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -268,7 +268,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func multipleArguments(num: Double, str: std.string, boo: Bool) -> Void {
     do {
-      try self.implementation.multipleArguments(num: num, str: String(str), boo: boo)
+      try self.__implementation.multipleArguments(num: num, str: String(str), boo: boo)
       return 
     } catch {
       let message = "\(error.localizedDescription)"
@@ -279,8 +279,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func createMap() -> margelo.nitro.TSharedMap {
     do {
-      let result = try self.implementation.createMap()
-      return result.cppPart
+      let __result = try self.__implementation.createMap()
+      return __result.cppPart
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -290,8 +290,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func mapRoundtrip(map: margelo.nitro.TSharedMap) -> margelo.nitro.TSharedMap {
     do {
-      let result = try self.implementation.mapRoundtrip(map: AnyMapHolder(withCppPart: map))
-      return result.cppPart
+      let __result = try self.__implementation.mapRoundtrip(map: AnyMapHolder(withCppPart: map))
+      return __result.cppPart
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -301,8 +301,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func funcThatThrows() -> Double {
     do {
-      let result = try self.implementation.funcThatThrows()
-      return result
+      let __result = try self.__implementation.funcThatThrows()
+      return __result
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -312,14 +312,14 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func tryOptionalParams(num: Double, boo: Bool, str: bridge.std__optional_std__string_) -> std.string {
     do {
-      let result = try self.implementation.tryOptionalParams(num: num, boo: boo, str: { () -> String? in
+      let __result = try self.__implementation.tryOptionalParams(num: num, boo: boo, str: { () -> String? in
         if let __unwrapped = str.value {
           return String(__unwrapped)
         } else {
           return nil
         }
       }())
-      return std.string(result)
+      return std.string(__result)
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -329,8 +329,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func tryMiddleParam(num: Double, boo: bridge.std__optional_bool_, str: std.string) -> std.string {
     do {
-      let result = try self.implementation.tryMiddleParam(num: num, boo: boo.value, str: String(str))
-      return std.string(result)
+      let __result = try self.__implementation.tryMiddleParam(num: num, boo: boo.value, str: String(str))
+      return std.string(__result)
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -340,9 +340,9 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func tryOptionalEnum(value: bridge.std__optional_Powertrain_) -> bridge.std__optional_Powertrain_ {
     do {
-      let result = try self.implementation.tryOptionalEnum(value: value.value)
+      let __result = try self.__implementation.tryOptionalEnum(value: value.value)
       return { () -> bridge.std__optional_Powertrain_ in
-        if let __unwrappedValue = result {
+        if let __unwrappedValue = __result {
           return bridge.create_std__optional_Powertrain_(__unwrappedValue)
         } else {
           return .init()
@@ -357,8 +357,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func calculateFibonacciSync(value: Double) -> Int64 {
     do {
-      let result = try self.implementation.calculateFibonacciSync(value: value)
-      return result
+      let __result = try self.__implementation.calculateFibonacciSync(value: value)
+      return __result
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -368,10 +368,10 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func calculateFibonacciAsync(value: Double) -> bridge.PromiseHolder_int64_t_ {
     do {
-      let result = try self.implementation.calculateFibonacciAsync(value: value)
+      let __result = try self.__implementation.calculateFibonacciAsync(value: value)
       return { () -> bridge.PromiseHolder_int64_t_ in
         let __promiseHolder = bridge.create_PromiseHolder_int64_t_()
-        result
+        __result
           .then({ __result in __promiseHolder.resolve(__result) })
           .catch({ __error in __promiseHolder.reject(std.string(String(describing: __error))) })
         return __promiseHolder
@@ -385,10 +385,10 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func wait(seconds: Double) -> bridge.PromiseHolder_void_ {
     do {
-      let result = try self.implementation.wait(seconds: seconds)
+      let __result = try self.__implementation.wait(seconds: seconds)
       return { () -> bridge.PromiseHolder_void_ in
         let __promiseHolder = bridge.create_PromiseHolder_void_()
-        result
+        __result
           .then({ __result in __promiseHolder.resolve() })
           .catch({ __error in __promiseHolder.reject(std.string(String(describing: __error))) })
         return __promiseHolder
@@ -402,7 +402,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func callCallback(callback: bridge.Func_void) -> Void {
     do {
-      try self.implementation.callCallback(callback: { () -> (() -> Void) in
+      try self.__implementation.callCallback(callback: { () -> (() -> Void) in
         let __sharedClosure = bridge.share_Func_void(callback)
         return { () -> Void in
           __sharedClosure.pointee.call()
@@ -418,7 +418,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func callAll(first: bridge.Func_void, second: bridge.Func_void, third: bridge.Func_void) -> Void {
     do {
-      try self.implementation.callAll(first: { () -> (() -> Void) in
+      try self.__implementation.callAll(first: { () -> (() -> Void) in
         let __sharedClosure = bridge.share_Func_void(first)
         return { () -> Void in
           __sharedClosure.pointee.call()
@@ -444,7 +444,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func callWithOptional(value: bridge.std__optional_double_, callback: bridge.Func_void_std__optional_double_) -> Void {
     do {
-      try self.implementation.callWithOptional(value: value.value, callback: { () -> ((Double?) -> Void) in
+      try self.__implementation.callWithOptional(value: value.value, callback: { () -> ((Double?) -> Void) in
         let __sharedClosure = bridge.share_Func_void_std__optional_double_(callback)
         return { (__maybe: Double?) -> Void in
           __sharedClosure.pointee.call({ () -> bridge.std__optional_double_ in
@@ -466,8 +466,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func getCar() -> Car {
     do {
-      let result = try self.implementation.getCar()
-      return result
+      let __result = try self.__implementation.getCar()
+      return __result
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -477,8 +477,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func isCarElectric(car: Car) -> Bool {
     do {
-      let result = try self.implementation.isCarElectric(car: car)
-      return result
+      let __result = try self.__implementation.isCarElectric(car: car)
+      return __result
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -488,9 +488,9 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func getDriver(car: Car) -> bridge.std__optional_Person_ {
     do {
-      let result = try self.implementation.getDriver(car: car)
+      let __result = try self.__implementation.getDriver(car: car)
       return { () -> bridge.std__optional_Person_ in
-        if let __unwrappedValue = result {
+        if let __unwrappedValue = __result {
           return bridge.create_std__optional_Person_(__unwrappedValue)
         } else {
           return .init()
@@ -505,8 +505,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func createArrayBuffer() -> ArrayBufferHolder {
     do {
-      let result = try self.implementation.createArrayBuffer()
-      return result
+      let __result = try self.__implementation.createArrayBuffer()
+      return __result
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -516,8 +516,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func getBufferLastItem(buffer: ArrayBufferHolder) -> Double {
     do {
-      let result = try self.implementation.getBufferLastItem(buffer: buffer)
-      return result
+      let __result = try self.__implementation.getBufferLastItem(buffer: buffer)
+      return __result
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -527,7 +527,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func setAllValuesTo(buffer: ArrayBufferHolder, value: Double) -> Void {
     do {
-      try self.implementation.setAllValuesTo(buffer: buffer, value: value)
+      try self.__implementation.setAllValuesTo(buffer: buffer, value: value)
       return 
     } catch {
       let message = "\(error.localizedDescription)"
@@ -538,8 +538,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func createChild() -> HybridChildSpecCxx {
     do {
-      let result = try self.implementation.createChild()
-      return result.createCxxBridge()
+      let __result = try self.__implementation.createChild()
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -549,8 +549,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func createBase() -> HybridBaseSpecCxx {
     do {
-      let result = try self.implementation.createBase()
-      return result.createCxxBridge()
+      let __result = try self.__implementation.createBase()
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -560,8 +560,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func createBaseActualChild() -> HybridBaseSpecCxx {
     do {
-      let result = try self.implementation.createBaseActualChild()
-      return result.createCxxBridge()
+      let __result = try self.__implementation.createBaseActualChild()
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -571,8 +571,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceChild(child: HybridChildSpecCxx) -> HybridChildSpecCxx {
     do {
-      let result = try self.implementation.bounceChild(child: child.getHybridChildSpec())
-      return result.createCxxBridge()
+      let __result = try self.__implementation.bounceChild(child: child.getHybridChildSpec())
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -582,8 +582,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceBase(base: HybridBaseSpecCxx) -> HybridBaseSpecCxx {
     do {
-      let result = try self.implementation.bounceBase(base: base.getHybridBaseSpec())
-      return result.createCxxBridge()
+      let __result = try self.__implementation.bounceBase(base: base.getHybridBaseSpec())
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -593,8 +593,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceChildBase(child: HybridChildSpecCxx) -> HybridBaseSpecCxx {
     do {
-      let result = try self.implementation.bounceChildBase(child: child.getHybridChildSpec())
-      return result.createCxxBridge()
+      let __result = try self.__implementation.bounceChildBase(child: child.getHybridChildSpec())
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")
@@ -604,8 +604,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func castBase(base: HybridBaseSpecCxx) -> HybridChildSpecCxx {
     do {
-      let result = try self.implementation.castBase(base: base.getHybridBaseSpec())
-      return result.createCxxBridge()
+      let __result = try self.__implementation.castBase(base: base.getHybridBaseSpec())
+      return __result.createCxxBridge()
     } catch {
       let message = "\(error.localizedDescription)"
       fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(message))")


### PR DESCRIPTION
Changes nitrogen to prefix all variables it allocates with a double underscore (`__`) to prevent accidental name-clashes.