### PR TITLE
fix: Use `any` for protocol conformance in Swift

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -69,13 +69,13 @@ ${hasBase ? `public class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : 
   /**
    * Holds an instance of the \`${name.HybridTSpec}\` Swift protocol.
    */
-  private var __implementation: ${name.HybridTSpec}
+  private var __implementation: any ${name.HybridTSpec}
 
   /**
    * Get the actual \`${name.HybridTSpec}\` instance this class wraps.
    */
   @inline(__always)
-  public func get${name.HybridTSpec}() -> ${name.HybridTSpec} {
+  public func get${name.HybridTSpec}() -> any ${name.HybridTSpec} {
     return __implementation
   }
 
@@ -83,7 +83,7 @@ ${hasBase ? `public class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : 
    * Create a new \`${name.HybridTSpecCxx}\` that wraps the given \`${name.HybridTSpec}\`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: ${name.HybridTSpec}) {
+  public init(_ implementation: any ${name.HybridTSpec}) {
     self.__implementation = implementation
     ${hasBase ? 'super.init(implementation)' : '/* no base class */'}
   }

--- a/packages/nitrogen/src/syntax/types/HybridObjectType.ts
+++ b/packages/nitrogen/src/syntax/types/HybridObjectType.ts
@@ -30,7 +30,7 @@ export class HybridObjectType implements Type {
         return `std::shared_ptr<${fullName}>`
       }
       case 'swift': {
-        return name.HybridTSpec
+        return `any ${name.HybridTSpec}`
       }
       case 'kotlin': {
         return name.HybridTSpec

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpecCxx.swift
@@ -28,13 +28,13 @@ public class HybridBaseSpecCxx {
   /**
    * Holds an instance of the `HybridBaseSpec` Swift protocol.
    */
-  private var __implementation: HybridBaseSpec
+  private var __implementation: any HybridBaseSpec
 
   /**
    * Get the actual `HybridBaseSpec` instance this class wraps.
    */
   @inline(__always)
-  public func getHybridBaseSpec() -> HybridBaseSpec {
+  public func getHybridBaseSpec() -> any HybridBaseSpec {
     return __implementation
   }
 
@@ -42,7 +42,7 @@ public class HybridBaseSpecCxx {
    * Create a new `HybridBaseSpecCxx` that wraps the given `HybridBaseSpec`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: HybridBaseSpec) {
+  public init(_ implementation: any HybridBaseSpec) {
     self.__implementation = implementation
     /* no base class */
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpecCxx.swift
@@ -28,13 +28,13 @@ public class HybridChildSpecCxx : HybridBaseSpecCxx {
   /**
    * Holds an instance of the `HybridChildSpec` Swift protocol.
    */
-  private var __implementation: HybridChildSpec
+  private var __implementation: any HybridChildSpec
 
   /**
    * Get the actual `HybridChildSpec` instance this class wraps.
    */
   @inline(__always)
-  public func getHybridChildSpec() -> HybridChildSpec {
+  public func getHybridChildSpec() -> any HybridChildSpec {
     return __implementation
   }
 
@@ -42,7 +42,7 @@ public class HybridChildSpecCxx : HybridBaseSpecCxx {
    * Create a new `HybridChildSpecCxx` that wraps the given `HybridChildSpec`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: HybridChildSpec) {
+  public init(_ implementation: any HybridChildSpec) {
     self.__implementation = implementation
     super.init(implementation)
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -32,10 +32,10 @@ public protocol HybridImageFactorySpec: AnyObject, HybridObjectSpec {
   
 
   // Methods
-  func loadImageFromFile(path: String) throws -> HybridImageSpec
-  func loadImageFromURL(path: String) throws -> HybridImageSpec
-  func loadImageFromSystemName(path: String) throws -> HybridImageSpec
-  func bounceBack(image: HybridImageSpec) throws -> HybridImageSpec
+  func loadImageFromFile(path: String) throws -> any HybridImageSpec
+  func loadImageFromURL(path: String) throws -> any HybridImageSpec
+  func loadImageFromSystemName(path: String) throws -> any HybridImageSpec
+  func bounceBack(image: any HybridImageSpec) throws -> any HybridImageSpec
 }
 
 public extension HybridImageFactorySpec {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpecCxx.swift
@@ -28,13 +28,13 @@ public class HybridImageFactorySpecCxx {
   /**
    * Holds an instance of the `HybridImageFactorySpec` Swift protocol.
    */
-  private var __implementation: HybridImageFactorySpec
+  private var __implementation: any HybridImageFactorySpec
 
   /**
    * Get the actual `HybridImageFactorySpec` instance this class wraps.
    */
   @inline(__always)
-  public func getHybridImageFactorySpec() -> HybridImageFactorySpec {
+  public func getHybridImageFactorySpec() -> any HybridImageFactorySpec {
     return __implementation
   }
 
@@ -42,7 +42,7 @@ public class HybridImageFactorySpecCxx {
    * Create a new `HybridImageFactorySpecCxx` that wraps the given `HybridImageFactorySpec`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: HybridImageFactorySpec) {
+  public init(_ implementation: any HybridImageFactorySpec) {
     self.__implementation = implementation
     /* no base class */
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpecCxx.swift
@@ -28,13 +28,13 @@ public class HybridImageSpecCxx {
   /**
    * Holds an instance of the `HybridImageSpec` Swift protocol.
    */
-  private var __implementation: HybridImageSpec
+  private var __implementation: any HybridImageSpec
 
   /**
    * Get the actual `HybridImageSpec` instance this class wraps.
    */
   @inline(__always)
-  public func getHybridImageSpec() -> HybridImageSpec {
+  public func getHybridImageSpec() -> any HybridImageSpec {
     return __implementation
   }
 
@@ -42,7 +42,7 @@ public class HybridImageSpecCxx {
    * Create a new `HybridImageSpecCxx` that wraps the given `HybridImageSpec`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: HybridImageSpec) {
+  public init(_ implementation: any HybridImageSpec) {
     self.__implementation = implementation
     /* no base class */
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -29,7 +29,7 @@ import NitroModules
  */
 public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
   // Properties
-  var thisObject: HybridTestObjectSwiftKotlinSpec { get }
+  var thisObject: any HybridTestObjectSwiftKotlinSpec { get }
   var numberValue: Double { get set }
   var boolValue: Bool { get set }
   var stringValue: String { get set }
@@ -40,7 +40,7 @@ public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
   var someVariant: Variant_String_Double { get set }
 
   // Methods
-  func newTestObject() throws -> HybridTestObjectSwiftKotlinSpec
+  func newTestObject() throws -> any HybridTestObjectSwiftKotlinSpec
   func simpleFunc() throws -> Void
   func addNumbers(a: Double, b: Double) throws -> Double
   func addStrings(a: String, b: String) throws -> String
@@ -63,13 +63,13 @@ public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
   func createArrayBuffer() throws -> ArrayBufferHolder
   func getBufferLastItem(buffer: ArrayBufferHolder) throws -> Double
   func setAllValuesTo(buffer: ArrayBufferHolder, value: Double) throws -> Void
-  func createChild() throws -> HybridChildSpec
-  func createBase() throws -> HybridBaseSpec
-  func createBaseActualChild() throws -> HybridBaseSpec
-  func bounceChild(child: HybridChildSpec) throws -> HybridChildSpec
-  func bounceBase(base: HybridBaseSpec) throws -> HybridBaseSpec
-  func bounceChildBase(child: HybridChildSpec) throws -> HybridBaseSpec
-  func castBase(base: HybridBaseSpec) throws -> HybridChildSpec
+  func createChild() throws -> any HybridChildSpec
+  func createBase() throws -> any HybridBaseSpec
+  func createBaseActualChild() throws -> any HybridBaseSpec
+  func bounceChild(child: any HybridChildSpec) throws -> any HybridChildSpec
+  func bounceBase(base: any HybridBaseSpec) throws -> any HybridBaseSpec
+  func bounceChildBase(child: any HybridChildSpec) throws -> any HybridBaseSpec
+  func castBase(base: any HybridBaseSpec) throws -> any HybridChildSpec
 }
 
 public extension HybridTestObjectSwiftKotlinSpec {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -28,13 +28,13 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   /**
    * Holds an instance of the `HybridTestObjectSwiftKotlinSpec` Swift protocol.
    */
-  private var __implementation: HybridTestObjectSwiftKotlinSpec
+  private var __implementation: any HybridTestObjectSwiftKotlinSpec
 
   /**
    * Get the actual `HybridTestObjectSwiftKotlinSpec` instance this class wraps.
    */
   @inline(__always)
-  public func getHybridTestObjectSwiftKotlinSpec() -> HybridTestObjectSwiftKotlinSpec {
+  public func getHybridTestObjectSwiftKotlinSpec() -> any HybridTestObjectSwiftKotlinSpec {
     return __implementation
   }
 
@@ -42,7 +42,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
    * Create a new `HybridTestObjectSwiftKotlinSpecCxx` that wraps the given `HybridTestObjectSwiftKotlinSpec`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: HybridTestObjectSwiftKotlinSpec) {
+  public init(_ implementation: any HybridTestObjectSwiftKotlinSpec) {
     self.__implementation = implementation
     /* no base class */
   }


### PR DESCRIPTION
Replaces

```swift
var something: Something
```

with

```swift
var something: any Something
```

if `Something` is a protocol