### PR TITLE
fix: Add more guards to nitrogen

### DIFF
--- a/packages/nitrogen/src/syntax/Method.ts
+++ b/packages/nitrogen/src/syntax/Method.ts
@@ -62,6 +62,17 @@ export class Method implements CodeNode {
       this.returnType = createType(returnType, returnType.isNullable())
       this.parameters = method.getParameters().map((p) => new Parameter(p))
     }
+    if (this.name.startsWith('__')) {
+      throw new Error(
+        `Method names are not allowed to start with two underscores (__)! (In ${this.jsSignature})`
+      )
+    }
+  }
+
+  get jsSignature(): string {
+    const returnType = this.returnType.kind
+    const params = this.parameters.map((p) => `${p.name}: ${p.type.kind}`)
+    return `${this.name}(${params.join(', ')}): ${returnType}`
   }
 
   getCode(

--- a/packages/nitrogen/src/syntax/Parameter.ts
+++ b/packages/nitrogen/src/syntax/Parameter.ts
@@ -28,6 +28,15 @@ export class Parameter implements CodeNode {
         param.hasQuestionToken() || param.isOptional() || type.isNullable()
       this.type = createNamedType(name, type, isOptional)
     }
+    if (this.type.name.startsWith('__')) {
+      throw new Error(
+        `Parameter names are not allowed to start with two underscores (__)! (In ${this.jsSignature})`
+      )
+    }
+  }
+
+  get jsSignature(): string {
+    return `${this.type.name}: ${this.type.kind}`
   }
 
   get name(): string {

--- a/packages/nitrogen/src/syntax/Property.ts
+++ b/packages/nitrogen/src/syntax/Property.ts
@@ -65,6 +65,15 @@ export class Property implements CodeNode {
       const isOptional = prop.hasQuestionToken() || type.isNullable()
       this.type = createType(type, isOptional)
     }
+    if (this.name.startsWith('__')) {
+      throw new Error(
+        `Property names are not allowed to start with two underscores (__)! (In ${this.jsSignature})`
+      )
+    }
+  }
+
+  get jsSignature(): string {
+    return `${this.name}: ${this.type.kind}`
   }
 
   getExtraFiles(): SourceFile[] {

--- a/packages/nitrogen/src/syntax/createType.ts
+++ b/packages/nitrogen/src/syntax/createType.ts
@@ -103,6 +103,11 @@ export function createNamedType(
   type: TSMorphType,
   isOptional: boolean
 ) {
+  if (name.startsWith('__')) {
+    throw new Error(
+      `Name cannot start with two underscores (__) as this is reserved syntax for Nitrogen! (In ${type.getText()})`
+    )
+  }
   return new NamedWrappingType(name, createType(type, isOptional))
 }
 

--- a/packages/nitrogen/src/syntax/types/EnumType.ts
+++ b/packages/nitrogen/src/syntax/types/EnumType.ts
@@ -73,6 +73,11 @@ export class EnumType implements Type {
         })
       this.declarationFile = createCppUnion(enumName, this.enumMembers)
     }
+    if (this.enumName.startsWith('__')) {
+      throw new Error(
+        `Enum name cannot start with two underscores (__) as this is reserved syntax for Nitrogen! (In ${this.enumName}: ${this.enumMembers.map((m) => m.name).join(' | ')})`
+      )
+    }
   }
 
   get canBePassedByReference(): boolean {

--- a/packages/nitrogen/src/syntax/types/HybridObjectType.ts
+++ b/packages/nitrogen/src/syntax/types/HybridObjectType.ts
@@ -10,6 +10,12 @@ export class HybridObjectType implements Type {
 
   constructor(hybridObjectName: string) {
     this.hybridObjectName = hybridObjectName
+
+    if (this.hybridObjectName.startsWith('__')) {
+      throw new Error(
+        `HybridObject name cannot start with two underscores (__)! (In ${this.hybridObjectName})`
+      )
+    }
   }
 
   get canBePassedByReference(): boolean {

--- a/packages/nitrogen/src/syntax/types/StructType.ts
+++ b/packages/nitrogen/src/syntax/types/StructType.ts
@@ -18,6 +18,17 @@ export class StructType implements Type {
     this.structName = structName
     this.properties = properties
     this.declarationFile = createCppStruct(structName, properties)
+
+    if (this.structName.startsWith('__')) {
+      throw new Error(
+        `Struct name cannot start with two underscores (__) as this is reserved syntax for Nitrogen! (In ${this.structName})`
+      )
+    }
+    if (this.properties.length === 0) {
+      throw new Error(
+        `Empty structs are not supported in Nitrogen! Add at least one property to ${this.structName}.`
+      )
+    }
   }
 
   get canBePassedByReference(): boolean {


### PR DESCRIPTION
Checks if parameter names start with two underscores (`__`), and if structs are empty.