### PR TITLE
fix: Manually convert C++ vector to Swift Array

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -77,7 +77,7 @@ jobs:
           -workspace NitroExample.xcworkspace \
           -scheme NitroExample \
           -sdk iphonesimulator \
-          -configuration Debug \
+          -configuration Release \
           -destination 'platform=iOS Simulator,name=iPhone 15' \
           build \
           CODE_SIGNING_ALLOWED=NO | xcpretty"

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -385,11 +385,12 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
       case 'array': {
         const array = getTypeAs(this.type, ArrayType)
         const wrapping = new SwiftCxxBridgedType(array.itemType, true)
+        const actualType = this.type.getCode(language)
         switch (language) {
           case 'swift':
             return `
-({
-  var __array: ${this.type.getCode('swift')} = []
+({ () -> ${actualType} in
+  var __array: ${actualType} = []
   __array.reserveCapacity(${cppParameterName}.count)
   for __i in 0...${cppParameterName}.count {
     __array.append(${indent(wrapping.parseFromCppToSwift(`${cppParameterName}[__i]`, 'swift'), '    ')})

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -389,7 +389,7 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
           case 'swift':
             return `
 ({
-  var __array: [${wrapping.getTypeCode('swift')}] = []
+  var __array: ${this.type.getCode('swift')} = []
   for __i in 0...${cppParameterName}.count {
     __array[__i] = ${indent(wrapping.parseFromCppToSwift(`${cppParameterName}[__i]`, 'swift'), '    ')}
   }

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -392,8 +392,8 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
 ({ () -> ${actualType} in
   var __array: ${actualType} = []
   __array.reserveCapacity(${cppParameterName}.count)
-  for __i in 0...${cppParameterName}.count {
-    __array.append(${indent(wrapping.parseFromCppToSwift(`${cppParameterName}[__i]`, 'swift'), '    ')})
+  for __item in ${cppParameterName} {
+    __array.append(${indent(wrapping.parseFromCppToSwift('__item', 'swift'), '    ')})
   }
   return __array
 }())`.trim()

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -390,8 +390,9 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
             return `
 ({
   var __array: ${this.type.getCode('swift')} = []
+  __array.reserveCapacity(${cppParameterName}.count)
   for __i in 0...${cppParameterName}.count {
-    __array[__i] = ${indent(wrapping.parseFromCppToSwift(`${cppParameterName}[__i]`, 'swift'), '    ')}
+    __array.append(${indent(wrapping.parseFromCppToSwift(`${cppParameterName}[__i]`, 'swift'), '    ')})
   }
   return __array
 }())`.trim()

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -387,7 +387,14 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
         const wrapping = new SwiftCxxBridgedType(array.itemType, true)
         switch (language) {
           case 'swift':
-            return `${cppParameterName}.map({ __item in ${wrapping.parseFromCppToSwift('__item', 'swift')} })`.trim()
+            return `
+({
+  var __array: [${wrapping.getTypeCode('swift')}] = []
+  for __i in 0...${cppParameterName}.count {
+    __array[__i] = ${indent(wrapping.parseFromCppToSwift(`${cppParameterName}[__i]`, 'swift'), '    ')}
+  }
+  return __array
+}())`.trim()
           default:
             return cppParameterName
         }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -279,7 +279,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceStrings(array: bridge.std__vector_std__string_) -> bridge.std__vector_std__string_ {
     do {
-      let __result = try self.__implementation.bounceStrings(array: ({
+      let __result = try self.__implementation.bounceStrings(array: ({ () -> [String] in
         var __array: [String] = []
         __array.reserveCapacity(array.count)
         for __i in 0...array.count {
@@ -303,7 +303,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceNumbers(array: bridge.std__vector_double_) -> bridge.std__vector_double_ {
     do {
-      let __result = try self.__implementation.bounceNumbers(array: ({
+      let __result = try self.__implementation.bounceNumbers(array: ({ () -> [Double] in
         var __array: [Double] = []
         __array.reserveCapacity(array.count)
         for __i in 0...array.count {
@@ -327,7 +327,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceStructs(array: bridge.std__vector_Person_) -> bridge.std__vector_Person_ {
     do {
-      let __result = try self.__implementation.bounceStructs(array: ({
+      let __result = try self.__implementation.bounceStructs(array: ({ () -> [Person] in
         var __array: [Person] = []
         __array.reserveCapacity(array.count)
         for __i in 0...array.count {
@@ -351,7 +351,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceEnums(array: bridge.std__vector_Powertrain_) -> bridge.std__vector_Powertrain_ {
     do {
-      let __result = try self.__implementation.bounceEnums(array: ({
+      let __result = try self.__implementation.bounceEnums(array: ({ () -> [Powertrain] in
         var __array: [Powertrain] = []
         __array.reserveCapacity(array.count)
         for __i in 0...array.count {
@@ -375,7 +375,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func complexEnumCallback(array: bridge.std__vector_Powertrain_, callback: bridge.Func_void_std__vector_Powertrain_) -> Void {
     do {
-      try self.__implementation.complexEnumCallback(array: ({
+      try self.__implementation.complexEnumCallback(array: ({ () -> [Powertrain] in
         var __array: [Powertrain] = []
         __array.reserveCapacity(array.count)
         for __i in 0...array.count {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -280,7 +280,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   public func bounceStrings(array: bridge.std__vector_std__string_) -> bridge.std__vector_std__string_ {
     do {
       let __result = try self.__implementation.bounceStrings(array: ({
-        var __array: [std.string] = []
+        var __array: [String] = []
         for __i in 0...array.count {
           __array[__i] = String(array[__i])
         }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -282,8 +282,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
       let __result = try self.__implementation.bounceStrings(array: ({ () -> [String] in
         var __array: [String] = []
         __array.reserveCapacity(array.count)
-        for __i in 0...array.count {
-          __array.append(String(array[__i]))
+        for __item in array {
+          __array.append(String(__item))
         }
         return __array
       }()))
@@ -306,8 +306,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
       let __result = try self.__implementation.bounceNumbers(array: ({ () -> [Double] in
         var __array: [Double] = []
         __array.reserveCapacity(array.count)
-        for __i in 0...array.count {
-          __array.append(array[__i])
+        for __item in array {
+          __array.append(__item)
         }
         return __array
       }()))
@@ -330,8 +330,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
       let __result = try self.__implementation.bounceStructs(array: ({ () -> [Person] in
         var __array: [Person] = []
         __array.reserveCapacity(array.count)
-        for __i in 0...array.count {
-          __array.append(array[__i])
+        for __item in array {
+          __array.append(__item)
         }
         return __array
       }()))
@@ -354,8 +354,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
       let __result = try self.__implementation.bounceEnums(array: ({ () -> [Powertrain] in
         var __array: [Powertrain] = []
         __array.reserveCapacity(array.count)
-        for __i in 0...array.count {
-          __array.append(array[__i])
+        for __item in array {
+          __array.append(__item)
         }
         return __array
       }()))
@@ -378,8 +378,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
       try self.__implementation.complexEnumCallback(array: ({ () -> [Powertrain] in
         var __array: [Powertrain] = []
         __array.reserveCapacity(array.count)
-        for __i in 0...array.count {
-          __array.append(array[__i])
+        for __item in array {
+          __array.append(__item)
         }
         return __array
       }()), callback: { () -> (([Powertrain]) -> Void) in

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -279,7 +279,13 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceStrings(array: bridge.std__vector_std__string_) -> bridge.std__vector_std__string_ {
     do {
-      let __result = try self.__implementation.bounceStrings(array: array.map({ __item in String(__item) }))
+      let __result = try self.__implementation.bounceStrings(array: ({
+        var __array: [std.string] = []
+        for __i in 0...array.count {
+          __array[__i] = String(array[__i])
+        }
+        return __array
+      }()))
       return { () -> bridge.std__vector_std__string_ in
         var __vector = bridge.create_std__vector_std__string_(__result.count)
         for __item in __result {
@@ -296,7 +302,13 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceNumbers(array: bridge.std__vector_double_) -> bridge.std__vector_double_ {
     do {
-      let __result = try self.__implementation.bounceNumbers(array: array.map({ __item in __item }))
+      let __result = try self.__implementation.bounceNumbers(array: ({
+        var __array: [Double] = []
+        for __i in 0...array.count {
+          __array[__i] = array[__i]
+        }
+        return __array
+      }()))
       return { () -> bridge.std__vector_double_ in
         var __vector = bridge.create_std__vector_double_(__result.count)
         for __item in __result {
@@ -313,7 +325,13 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceStructs(array: bridge.std__vector_Person_) -> bridge.std__vector_Person_ {
     do {
-      let __result = try self.__implementation.bounceStructs(array: array.map({ __item in __item }))
+      let __result = try self.__implementation.bounceStructs(array: ({
+        var __array: [Person] = []
+        for __i in 0...array.count {
+          __array[__i] = array[__i]
+        }
+        return __array
+      }()))
       return { () -> bridge.std__vector_Person_ in
         var __vector = bridge.create_std__vector_Person_(__result.count)
         for __item in __result {
@@ -330,7 +348,13 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func bounceEnums(array: bridge.std__vector_Powertrain_) -> bridge.std__vector_Powertrain_ {
     do {
-      let __result = try self.__implementation.bounceEnums(array: array.map({ __item in __item }))
+      let __result = try self.__implementation.bounceEnums(array: ({
+        var __array: [Powertrain] = []
+        for __i in 0...array.count {
+          __array[__i] = array[__i]
+        }
+        return __array
+      }()))
       return { () -> bridge.std__vector_Powertrain_ in
         var __vector = bridge.create_std__vector_Powertrain_(__result.count)
         for __item in __result {
@@ -347,7 +371,13 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func complexEnumCallback(array: bridge.std__vector_Powertrain_, callback: bridge.Func_void_std__vector_Powertrain_) -> Void {
     do {
-      try self.__implementation.complexEnumCallback(array: array.map({ __item in __item }), callback: { () -> (([Powertrain]) -> Void) in
+      try self.__implementation.complexEnumCallback(array: ({
+        var __array: [Powertrain] = []
+        for __i in 0...array.count {
+          __array[__i] = array[__i]
+        }
+        return __array
+      }()), callback: { () -> (([Powertrain]) -> Void) in
         let __sharedClosure = bridge.share_Func_void_std__vector_Powertrain_(callback)
         return { (__array: [Powertrain]) -> Void in
           __sharedClosure.pointee.call({ () -> bridge.std__vector_Powertrain_ in

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -281,8 +281,9 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       let __result = try self.__implementation.bounceStrings(array: ({
         var __array: [String] = []
+        __array.reserveCapacity(array.count)
         for __i in 0...array.count {
-          __array[__i] = String(array[__i])
+          __array.append(String(array[__i]))
         }
         return __array
       }()))
@@ -304,8 +305,9 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       let __result = try self.__implementation.bounceNumbers(array: ({
         var __array: [Double] = []
+        __array.reserveCapacity(array.count)
         for __i in 0...array.count {
-          __array[__i] = array[__i]
+          __array.append(array[__i])
         }
         return __array
       }()))
@@ -327,8 +329,9 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       let __result = try self.__implementation.bounceStructs(array: ({
         var __array: [Person] = []
+        __array.reserveCapacity(array.count)
         for __i in 0...array.count {
-          __array[__i] = array[__i]
+          __array.append(array[__i])
         }
         return __array
       }()))
@@ -350,8 +353,9 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       let __result = try self.__implementation.bounceEnums(array: ({
         var __array: [Powertrain] = []
+        __array.reserveCapacity(array.count)
         for __i in 0...array.count {
-          __array[__i] = array[__i]
+          __array.append(array[__i])
         }
         return __array
       }()))
@@ -373,8 +377,9 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     do {
       try self.__implementation.complexEnumCallback(array: ({
         var __array: [Powertrain] = []
+        __array.reserveCapacity(array.count)
         for __i in 0...array.count {
-          __array[__i] = array[__i]
+          __array.append(array[__i])
         }
         return __array
       }()), callback: { () -> (([Powertrain]) -> Void) in


### PR DESCRIPTION
Replaces 

```swift
array.map({ __item in String(__item) })
```

with

```swift
({
  var __array: [String] = []
  __array.reserveCapacity(array.count)
  for __i in 0...array.count {
    __array.append(String(array[__i]))
  }
  return __array
}())
```

to manually convert vectors from C++ to Swift.

`map` worked fine in Debug, but apparently broke in release. No idea why.

Created an issue for this bug in apple/swift compiler: https://github.com/swiftlang/swift/issues/76949