### PR TITLE
Fix Hermes location detection for Android example app

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -45,7 +45,7 @@ react {
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
-    // hermesCommand = "$rootDir/my-custom-hermesc/bin/hermesc"
+    hermesCommand = "$rootDir/../../node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]


### PR DESCRIPTION
This PR addresses the build failure occurring during the creation of the release bundle for Android. The error was caused by the inability to determine the Hermes location.