### PR TITLE
feat: Separate SwiftCxx bridge `.hpp` from `.cpp`

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -316,7 +316,7 @@ ${callFuncReturnType} ${wrapperName}::call(${callCppFuncParamsSignature.join(', 
 ${name} create_${name}(void* closureHolder, ${functionPointerParam}, void(*destroy)(void*)) {
   std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
   return ${name}([sharedClosureHolder, call](${paramsSignature.join(', ')}) -> ${type.returnType.getCode('c++')} {
-    ${callSwiftFuncBody}
+    ${indent(callSwiftFuncBody, '    ')}
   });
 }
 std::shared_ptr<${wrapperName}> share_${name}(const ${name}& value) {

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -85,11 +85,11 @@ function createCxxOptionalSwiftHelper(type: OptionalType): SwiftCxxHelper {
     specializationName: name,
     header: {
       cxxCode: `
-  /**
-   * Specialized version of \`${escapeComments(actualType)}\`.
-   */
-  using ${name} = ${actualType};
-  ${actualType} create_${name}(const ${type.wrappingType.getCode('c++')}& value);
+/**
+ * Specialized version of \`${escapeComments(actualType)}\`.
+ */
+using ${name} = ${actualType};
+${actualType} create_${name}(const ${type.wrappingType.getCode('c++')}& value);
       `.trim(),
     },
     implementation: {
@@ -245,8 +245,8 @@ function createCxxFunctionSwiftHelper(type: FunctionType): SwiftCxxHelper {
   let callCppFuncBody: string
   if (returnBridge.hasType) {
     callCppFuncBody = `
-    auto __result = function(${indent(callParamsForward.join(', '), '    ')});
-    return ${indent(returnBridge.parseFromCppToSwift('__result', 'c++'), '    ')};
+auto __result = function(${indent(callParamsForward.join(', '), '    ')});
+return ${indent(returnBridge.parseFromCppToSwift('__result', 'c++'), '    ')};
     `.trim()
   } else {
     callCppFuncBody = `function(${indent(callParamsForward.join(', '), '    ')});`
@@ -255,8 +255,8 @@ function createCxxFunctionSwiftHelper(type: FunctionType): SwiftCxxHelper {
   let callSwiftFuncBody: string
   if (returnBridge.hasType) {
     callSwiftFuncBody = `
-    auto __result = call(${indent(paramsForward.join(', '), '    ')});
-    return ${indent(returnBridge.parseFromSwiftToCpp('__result', 'c++'), '    ')};
+auto __result = call(${indent(paramsForward.join(', '), '    ')});
+return ${indent(returnBridge.parseFromSwiftToCpp('__result', 'c++'), '    ')};
     `.trim()
   } else {
     callSwiftFuncBody = `call(${indent(paramsForward.join(', '), '    ')});`
@@ -311,7 +311,7 @@ ${wrapperName}::${wrapperName}(const ${actualType}& func): function(func) {}
 ${wrapperName}::${wrapperName}(${actualType}&& func): function(std::move(func)) {}
 
 ${callFuncReturnType} ${wrapperName}::call(${callCppFuncParamsSignature.join(', ')}) const {
-  ${callCppFuncBody}
+  ${indent(callCppFuncBody, '  ')}
 }
 ${name} create_${name}(void* closureHolder, ${functionPointerParam}, void(*destroy)(void*)) {
   std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -122,6 +122,7 @@ ${hasBase ? `public class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : 
   const cppPropertiesHeader = spec.properties
     .map((p) =>
       p.getCode('c++', {
+        override: true,
         noexcept: true,
       })
     )

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
@@ -204,13 +204,13 @@ namespace margelo::nitro::image::bridge::swift {
   
   PromiseHolder<double> Func_std__future_double__Wrapper::call() const {
     auto __result = function();
-      return []() -> PromiseHolder<double> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
+    return []() -> PromiseHolder<double> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
   }
   Func_std__future_double_ create_Func_std__future_double_(void* closureHolder, PromiseHolder<double>(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__future_double_([sharedClosureHolder, call]() -> std::future<double> {
       auto __result = call(sharedClosureHolder.get());
-      return __result.getFuture();
+  return __result.getFuture();
     });
   }
   std::shared_ptr<Func_std__future_double__Wrapper> share_Func_std__future_double_(const Func_std__future_double_& value) {
@@ -226,13 +226,13 @@ namespace margelo::nitro::image::bridge::swift {
   
   PromiseHolder<std::string> Func_std__future_std__string__Wrapper::call() const {
     auto __result = function();
-      return []() -> PromiseHolder<std::string> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
+    return []() -> PromiseHolder<std::string> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
   }
   Func_std__future_std__string_ create_Func_std__future_std__string_(void* closureHolder, PromiseHolder<std::string>(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__future_std__string_([sharedClosureHolder, call]() -> std::future<std::string> {
       auto __result = call(sharedClosureHolder.get());
-      return __result.getFuture();
+  return __result.getFuture();
     });
   }
   std::shared_ptr<Func_std__future_std__string__Wrapper> share_Func_std__future_std__string_(const Func_std__future_std__string_& value) {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
@@ -6,3 +6,321 @@
 ///
 
 #include "NitroImage-Swift-Cxx-Bridge.hpp"
+
+namespace margelo::nitro::image::bridge::swift {
+
+  Func_void_std__string_Wrapper::Func_void_std__string_Wrapper(const std::function<void(const std::string& /* path */)>& func): function(func) {}
+  Func_void_std__string_Wrapper::Func_void_std__string_Wrapper(std::function<void(const std::string& /* path */)>&& func): function(std::move(func)) {}
+  
+  void Func_void_std__string_Wrapper::call(std::string path) const {
+    function(path);
+  }
+  Func_void_std__string create_Func_void_std__string(void* closureHolder, void(*call)(void* /* closureHolder */, std::string), void(*destroy)(void*)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_void_std__string([sharedClosureHolder, call](const std::string& path) -> void {
+      call(sharedClosureHolder.get(), path);
+    });
+  }
+  std::shared_ptr<Func_void_std__string_Wrapper> share_Func_void_std__string(const Func_void_std__string& value) {
+    return std::make_shared<Func_void_std__string_Wrapper>(value);
+  }
+  
+  std__variant_std__string__double_::std__variant_std__string__double_(std::variant<std::string, double> variant): variant(variant) { }
+  std__variant_std__string__double_::operator std::variant<std::string, double>() const {
+    return variant;
+  }
+  size_t std__variant_std__string__double_::index() const {
+      return variant.index();
+    }
+  std__variant_std__string__double_ create_std__variant_std__string__double_(const std::string& value) {
+    return std__variant_std__string__double_(value);
+  }
+  std__variant_std__string__double_ create_std__variant_std__string__double_(double value) {
+    return std__variant_std__string__double_(value);
+  }
+  std::string get_std__variant_std__string__double__0(const std__variant_std__string__double_& variantWrapper) {
+    return std::get<0>(variantWrapper.variant);
+  }
+  double get_std__variant_std__string__double__1(const std__variant_std__string__double_& variantWrapper) {
+    return std::get<1>(variantWrapper.variant);
+  }
+  
+  std::vector<double> create_std__vector_double_(size_t size) {
+    std::vector<double> vector;
+    vector.reserve(size);
+    return vector;
+  }
+  
+  std::vector<std::string> create_std__vector_std__string_(size_t size) {
+    std::vector<std::string> vector;
+    vector.reserve(size);
+    return vector;
+  }
+  
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__::std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>> variant): variant(variant) { }
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__::operator std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>() const {
+    return variant;
+  }
+  size_t std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__::index() const {
+      return variant.index();
+    }
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::string& value) {
+    return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
+  }
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(double value) {
+    return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
+  }
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(bool value) {
+    return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
+  }
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<double>& value) {
+    return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
+  }
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<std::string>& value) {
+    return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
+  }
+  std::string get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___0(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper) {
+    return std::get<0>(variantWrapper.variant);
+  }
+  double get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___1(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper) {
+    return std::get<1>(variantWrapper.variant);
+  }
+  bool get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___2(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper) {
+    return std::get<2>(variantWrapper.variant);
+  }
+  std::vector<double> get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___3(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper) {
+    return std::get<3>(variantWrapper.variant);
+  }
+  std::vector<std::string> get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___4(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper) {
+    return std::get<4>(variantWrapper.variant);
+  }
+  
+  std__variant_bool__OldEnum_::std__variant_bool__OldEnum_(std::variant<bool, OldEnum> variant): variant(variant) { }
+  std__variant_bool__OldEnum_::operator std::variant<bool, OldEnum>() const {
+    return variant;
+  }
+  size_t std__variant_bool__OldEnum_::index() const {
+      return variant.index();
+    }
+  std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(bool value) {
+    return std__variant_bool__OldEnum_(value);
+  }
+  std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(OldEnum value) {
+    return std__variant_bool__OldEnum_(value);
+  }
+  bool get_std__variant_bool__OldEnum__0(const std__variant_bool__OldEnum_& variantWrapper) {
+    return std::get<0>(variantWrapper.variant);
+  }
+  OldEnum get_std__variant_bool__OldEnum__1(const std__variant_bool__OldEnum_& variantWrapper) {
+    return std::get<1>(variantWrapper.variant);
+  }
+  
+  std::optional<Person> create_std__optional_Person_(const Person& value) {
+    return std::optional<Person>(value);
+  }
+  
+  std__variant_Car__Person_::std__variant_Car__Person_(std::variant<Car, Person> variant): variant(variant) { }
+  std__variant_Car__Person_::operator std::variant<Car, Person>() const {
+    return variant;
+  }
+  size_t std__variant_Car__Person_::index() const {
+      return variant.index();
+    }
+  std__variant_Car__Person_ create_std__variant_Car__Person_(const Car& value) {
+    return std__variant_Car__Person_(value);
+  }
+  std__variant_Car__Person_ create_std__variant_Car__Person_(const Person& value) {
+    return std__variant_Car__Person_(value);
+  }
+  Car get_std__variant_Car__Person__0(const std__variant_Car__Person_& variantWrapper) {
+    return std::get<0>(variantWrapper.variant);
+  }
+  Person get_std__variant_Car__Person__1(const std__variant_Car__Person_& variantWrapper) {
+    return std::get<1>(variantWrapper.variant);
+  }
+  
+  std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__::std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>> variant): variant(variant) { }
+  std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__::operator std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>>() const {
+    return variant;
+  }
+  size_t std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__::index() const {
+      return variant.index();
+    }
+  std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__ create_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(const Person& value) {
+    return std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(value);
+  }
+  std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__ create_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(const std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>& value) {
+    return std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(value);
+  }
+  Person get_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec___0(const std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__& variantWrapper) {
+    return std::get<0>(variantWrapper.variant);
+  }
+  std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec> get_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec___1(const std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__& variantWrapper) {
+    return std::get<1>(variantWrapper.variant);
+  }
+  
+  std::tuple<double, double> create_std__tuple_double__double_(double arg0, double arg1) {
+    return std::tuple<double, double> { arg0, arg1 };
+  }
+  
+  std::tuple<double, double, double> create_std__tuple_double__double__double_(double arg0, double arg1, double arg2) {
+    return std::tuple<double, double, double> { arg0, arg1, arg2 };
+  }
+  
+  std__variant_std__tuple_double__double___std__tuple_double__double__double__::std__variant_std__tuple_double__double___std__tuple_double__double__double__(std::variant<std::tuple<double, double>, std::tuple<double, double, double>> variant): variant(variant) { }
+  std__variant_std__tuple_double__double___std__tuple_double__double__double__::operator std::variant<std::tuple<double, double>, std::tuple<double, double, double>>() const {
+    return variant;
+  }
+  size_t std__variant_std__tuple_double__double___std__tuple_double__double__double__::index() const {
+      return variant.index();
+    }
+  std__variant_std__tuple_double__double___std__tuple_double__double__double__ create_std__variant_std__tuple_double__double___std__tuple_double__double__double__(const std::tuple<double, double>& value) {
+    return std__variant_std__tuple_double__double___std__tuple_double__double__double__(value);
+  }
+  std__variant_std__tuple_double__double___std__tuple_double__double__double__ create_std__variant_std__tuple_double__double___std__tuple_double__double__double__(const std::tuple<double, double, double>& value) {
+    return std__variant_std__tuple_double__double___std__tuple_double__double__double__(value);
+  }
+  std::tuple<double, double> get_std__variant_std__tuple_double__double___std__tuple_double__double__double___0(const std__variant_std__tuple_double__double___std__tuple_double__double__double__& variantWrapper) {
+    return std::get<0>(variantWrapper.variant);
+  }
+  std::tuple<double, double, double> get_std__variant_std__tuple_double__double___std__tuple_double__double__double___1(const std__variant_std__tuple_double__double___std__tuple_double__double__double__& variantWrapper) {
+    return std::get<1>(variantWrapper.variant);
+  }
+  
+  std::tuple<double, std::string> create_std__tuple_double__std__string_(double arg0, const std::string& arg1) {
+    return std::tuple<double, std::string> { arg0, arg1 };
+  }
+  
+  std::tuple<double, std::string, bool> create_std__tuple_double__std__string__bool_(double arg0, const std::string& arg1, bool arg2) {
+    return std::tuple<double, std::string, bool> { arg0, arg1, arg2 };
+  }
+  
+  PromiseHolder<double> create_PromiseHolder_double_() {
+    return PromiseHolder<double>();
+  }
+  
+  Func_std__future_double__Wrapper::Func_std__future_double__Wrapper(const std::function<std::future<double>()>& func): function(func) {}
+  Func_std__future_double__Wrapper::Func_std__future_double__Wrapper(std::function<std::future<double>()>&& func): function(std::move(func)) {}
+  
+  PromiseHolder<double> Func_std__future_double__Wrapper::call() const {
+    auto __result = function();
+      return []() -> PromiseHolder<double> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
+  }
+  Func_std__future_double_ create_Func_std__future_double_(void* closureHolder, PromiseHolder<double>(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_std__future_double_([sharedClosureHolder, call]() -> std::future<double> {
+      auto __result = call(sharedClosureHolder.get());
+      return __result.getFuture();
+    });
+  }
+  std::shared_ptr<Func_std__future_double__Wrapper> share_Func_std__future_double_(const Func_std__future_double_& value) {
+    return std::make_shared<Func_std__future_double__Wrapper>(value);
+  }
+  
+  PromiseHolder<void> create_PromiseHolder_void_() {
+    return PromiseHolder<void>();
+  }
+  
+  Func_std__future_std__string__Wrapper::Func_std__future_std__string__Wrapper(const std::function<std::future<std::string>()>& func): function(func) {}
+  Func_std__future_std__string__Wrapper::Func_std__future_std__string__Wrapper(std::function<std::future<std::string>()>&& func): function(std::move(func)) {}
+  
+  PromiseHolder<std::string> Func_std__future_std__string__Wrapper::call() const {
+    auto __result = function();
+      return []() -> PromiseHolder<std::string> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
+  }
+  Func_std__future_std__string_ create_Func_std__future_std__string_(void* closureHolder, PromiseHolder<std::string>(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_std__future_std__string_([sharedClosureHolder, call]() -> std::future<std::string> {
+      auto __result = call(sharedClosureHolder.get());
+      return __result.getFuture();
+    });
+  }
+  std::shared_ptr<Func_std__future_std__string__Wrapper> share_Func_std__future_std__string_(const Func_std__future_std__string_& value) {
+    return std::make_shared<Func_std__future_std__string__Wrapper>(value);
+  }
+  
+  PromiseHolder<std::string> create_PromiseHolder_std__string_() {
+    return PromiseHolder<std::string>();
+  }
+  
+  std::optional<std::string> create_std__optional_std__string_(const std::string& value) {
+    return std::optional<std::string>(value);
+  }
+  
+  std::vector<Person> create_std__vector_Person_(size_t size) {
+    std::vector<Person> vector;
+    vector.reserve(size);
+    return vector;
+  }
+  
+  std::vector<Powertrain> create_std__vector_Powertrain_(size_t size) {
+    std::vector<Powertrain> vector;
+    vector.reserve(size);
+    return vector;
+  }
+  
+  Func_void_std__vector_Powertrain__Wrapper::Func_void_std__vector_Powertrain__Wrapper(const std::function<void(const std::vector<Powertrain>& /* array */)>& func): function(func) {}
+  Func_void_std__vector_Powertrain__Wrapper::Func_void_std__vector_Powertrain__Wrapper(std::function<void(const std::vector<Powertrain>& /* array */)>&& func): function(std::move(func)) {}
+  
+  void Func_void_std__vector_Powertrain__Wrapper::call(std::vector<Powertrain> array) const {
+    function(array);
+  }
+  Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* closureHolder, void(*call)(void* /* closureHolder */, std::vector<Powertrain>), void(*destroy)(void*)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_void_std__vector_Powertrain_([sharedClosureHolder, call](const std::vector<Powertrain>& array) -> void {
+      call(sharedClosureHolder.get(), array);
+    });
+  }
+  std::shared_ptr<Func_void_std__vector_Powertrain__Wrapper> share_Func_void_std__vector_Powertrain_(const Func_void_std__vector_Powertrain_& value) {
+    return std::make_shared<Func_void_std__vector_Powertrain__Wrapper>(value);
+  }
+  
+  std::optional<bool> create_std__optional_bool_(const bool& value) {
+    return std::optional<bool>(value);
+  }
+  
+  std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value) {
+    return std::optional<Powertrain>(value);
+  }
+  
+  PromiseHolder<int64_t> create_PromiseHolder_int64_t_() {
+    return PromiseHolder<int64_t>();
+  }
+  
+  Func_void_Wrapper::Func_void_Wrapper(const std::function<void()>& func): function(func) {}
+  Func_void_Wrapper::Func_void_Wrapper(std::function<void()>&& func): function(std::move(func)) {}
+  
+  void Func_void_Wrapper::call() const {
+    function();
+  }
+  Func_void create_Func_void(void* closureHolder, void(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_void([sharedClosureHolder, call]() -> void {
+      call(sharedClosureHolder.get());
+    });
+  }
+  std::shared_ptr<Func_void_Wrapper> share_Func_void(const Func_void& value) {
+    return std::make_shared<Func_void_Wrapper>(value);
+  }
+  
+  std::optional<double> create_std__optional_double_(const double& value) {
+    return std::optional<double>(value);
+  }
+  
+  Func_void_std__optional_double__Wrapper::Func_void_std__optional_double__Wrapper(const std::function<void(std::optional<double> /* maybe */)>& func): function(func) {}
+  Func_void_std__optional_double__Wrapper::Func_void_std__optional_double__Wrapper(std::function<void(std::optional<double> /* maybe */)>&& func): function(std::move(func)) {}
+  
+  void Func_void_std__optional_double__Wrapper::call(std::optional<double> maybe) const {
+    function(maybe);
+  }
+  Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* closureHolder, void(*call)(void* /* closureHolder */, std::optional<double>), void(*destroy)(void*)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_void_std__optional_double_([sharedClosureHolder, call](std::optional<double> maybe) -> void {
+      call(sharedClosureHolder.get(), maybe);
+    });
+  }
+  std::shared_ptr<Func_void_std__optional_double__Wrapper> share_Func_void_std__optional_double_(const Func_void_std__optional_double_& value) {
+    return std::make_shared<Func_void_std__optional_double__Wrapper>(value);
+  }
+
+} // namespace margelo::nitro::image::bridge::swift

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
@@ -210,7 +210,7 @@ namespace margelo::nitro::image::bridge::swift {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__future_double_([sharedClosureHolder, call]() -> std::future<double> {
       auto __result = call(sharedClosureHolder.get());
-  return __result.getFuture();
+      return __result.getFuture();
     });
   }
   std::shared_ptr<Func_std__future_double__Wrapper> share_Func_std__future_double_(const Func_std__future_double_& value) {
@@ -232,7 +232,7 @@ namespace margelo::nitro::image::bridge::swift {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__future_std__string_([sharedClosureHolder, call]() -> std::future<std::string> {
       auto __result = call(sharedClosureHolder.get());
-  return __result.getFuture();
+      return __result.getFuture();
     });
   }
   std::shared_ptr<Func_std__future_std__string__Wrapper> share_Func_std__future_std__string_(const Func_std__future_std__string_& value) {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -160,10 +160,10 @@ namespace margelo::nitro::image::bridge::swift {
   OldEnum get_std__variant_bool__OldEnum__1(const std__variant_bool__OldEnum_& variantWrapper);
   
   /**
-     * Specialized version of `std::optional<Person>`.
-     */
-    using std__optional_Person_ = std::optional<Person>;
-    std::optional<Person> create_std__optional_Person_(const Person& value);
+   * Specialized version of `std::optional<Person>`.
+   */
+  using std__optional_Person_ = std::optional<Person>;
+  std::optional<Person> create_std__optional_Person_(const Person& value);
   
   /**
    * Wrapper struct for `std::variant<Car, Person>`.
@@ -294,10 +294,10 @@ namespace margelo::nitro::image::bridge::swift {
   PromiseHolder<std::string> create_PromiseHolder_std__string_();
   
   /**
-     * Specialized version of `std::optional<std::string>`.
-     */
-    using std__optional_std__string_ = std::optional<std::string>;
-    std::optional<std::string> create_std__optional_std__string_(const std::string& value);
+   * Specialized version of `std::optional<std::string>`.
+   */
+  using std__optional_std__string_ = std::optional<std::string>;
+  std::optional<std::string> create_std__optional_std__string_(const std::string& value);
   
   /**
    * Specialized version of `std::vector<Person>`.
@@ -331,16 +331,16 @@ namespace margelo::nitro::image::bridge::swift {
   std::shared_ptr<Func_void_std__vector_Powertrain__Wrapper> share_Func_void_std__vector_Powertrain_(const Func_void_std__vector_Powertrain_& value);
   
   /**
-     * Specialized version of `std::optional<bool>`.
-     */
-    using std__optional_bool_ = std::optional<bool>;
-    std::optional<bool> create_std__optional_bool_(const bool& value);
+   * Specialized version of `std::optional<bool>`.
+   */
+  using std__optional_bool_ = std::optional<bool>;
+  std::optional<bool> create_std__optional_bool_(const bool& value);
   
   /**
-     * Specialized version of `std::optional<Powertrain>`.
-     */
-    using std__optional_Powertrain_ = std::optional<Powertrain>;
-    std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value);
+   * Specialized version of `std::optional<Powertrain>`.
+   */
+  using std__optional_Powertrain_ = std::optional<Powertrain>;
+  std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value);
   
   /**
    * Specialized version of `PromiseHolder<int64_t>`.
@@ -368,10 +368,10 @@ namespace margelo::nitro::image::bridge::swift {
   std::shared_ptr<Func_void_Wrapper> share_Func_void(const Func_void& value);
   
   /**
-     * Specialized version of `std::optional<double>`.
-     */
-    using std__optional_double_ = std::optional<double>;
-    std::optional<double> create_std__optional_double_(const double& value);
+   * Specialized version of `std::optional<double>`.
+   */
+  using std__optional_double_ = std::optional<double>;
+  std::optional<double> create_std__optional_double_(const double& value);
   
   /**
    * Specialized version of `std::function<void(std::optional<double>)>`.

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -21,7 +21,7 @@ namespace margelo::nitro::image { struct Person; }
 // Forward declaration of `Powertrain` to properly resolve imports.
 namespace margelo::nitro::image { enum class Powertrain; }
 
-// Include C++ defined types
+// Include C++ defined types that cannot be forward-declared
 #if __has_include("Car.hpp")
  #include "Car.hpp"
 #endif
@@ -83,24 +83,15 @@ namespace margelo::nitro::image::bridge::swift {
    */
   class Func_void_std__string_Wrapper {
   public:
-    explicit Func_void_std__string_Wrapper(const std::function<void(const std::string& /* path */)>& func): function(func) {}
-    explicit Func_void_std__string_Wrapper(std::function<void(const std::string& /* path */)>&& func): function(std::move(func)) {}
+    explicit Func_void_std__string_Wrapper(const std::function<void(const std::string& /* path */)>& func);
+    explicit Func_void_std__string_Wrapper(std::function<void(const std::string& /* path */)>&& func);
   
-    void call(std::string path) const {
-      function(path);
-    }
+    void call(std::string path) const;
   
     std::function<void(const std::string& /* path */)> function;
   };
-  inline Func_void_std__string create_Func_void_std__string(void* closureHolder, void(*call)(void* /* closureHolder */, std::string), void(*destroy)(void*)) {
-    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
-    return Func_void_std__string([sharedClosureHolder, call](const std::string& path) -> void {
-      call(sharedClosureHolder.get(), path);
-    });
-  }
-  inline std::shared_ptr<Func_void_std__string_Wrapper> share_Func_void_std__string(const Func_void_std__string& value) {
-    return std::make_shared<Func_void_std__string_Wrapper>(value);
-  }
+  Func_void_std__string create_Func_void_std__string(void* closureHolder, void(*call)(void* /* closureHolder */, std::string), void(*destroy)(void*));
+  std::shared_ptr<Func_void_std__string_Wrapper> share_Func_void_std__string(const Func_void_std__string& value);
   
   /**
    * Wrapper struct for `std::variant<std::string, double>`.
@@ -109,46 +100,26 @@ namespace margelo::nitro::image::bridge::swift {
    */
   struct std__variant_std__string__double_ {
     std::variant<std::string, double> variant;
-    std__variant_std__string__double_(std::variant<std::string, double> variant): variant(variant) { }
-    operator std::variant<std::string, double>() const {
-      return variant;
-    }
-    inline size_t index() const {
-      return variant.index();
-    }
+    std__variant_std__string__double_(std::variant<std::string, double> variant);
+    operator std::variant<std::string, double>() const;
+    size_t index() const;
   };
-  inline std__variant_std__string__double_ create_std__variant_std__string__double_(const std::string& value) {
-    return std__variant_std__string__double_(value);
-  }
-  inline std__variant_std__string__double_ create_std__variant_std__string__double_(double value) {
-    return std__variant_std__string__double_(value);
-  }
-  inline std::string get_std__variant_std__string__double__0(const std__variant_std__string__double_& variantWrapper) {
-    return std::get<0>(variantWrapper.variant);
-  }
-  inline double get_std__variant_std__string__double__1(const std__variant_std__string__double_& variantWrapper) {
-    return std::get<1>(variantWrapper.variant);
-  }
+  std__variant_std__string__double_ create_std__variant_std__string__double_(const std::string& value);
+  std__variant_std__string__double_ create_std__variant_std__string__double_(double value);
+  std::string get_std__variant_std__string__double__0(const std__variant_std__string__double_& variantWrapper);
+  double get_std__variant_std__string__double__1(const std__variant_std__string__double_& variantWrapper);
   
   /**
    * Specialized version of `std::vector<double>`.
    */
   using std__vector_double_ = std::vector<double>;
-  inline std::vector<double> create_std__vector_double_(size_t size) {
-    std::vector<double> vector;
-    vector.reserve(size);
-    return vector;
-  }
+  std::vector<double> create_std__vector_double_(size_t size);
   
   /**
    * Specialized version of `std::vector<std::string>`.
    */
   using std__vector_std__string_ = std::vector<std::string>;
-  inline std::vector<std::string> create_std__vector_std__string_(size_t size) {
-    std::vector<std::string> vector;
-    vector.reserve(size);
-    return vector;
-  }
+  std::vector<std::string> create_std__vector_std__string_(size_t size);
   
   /**
    * Wrapper struct for `std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>`.
@@ -157,44 +128,20 @@ namespace margelo::nitro::image::bridge::swift {
    */
   struct std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ {
     std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>> variant;
-    std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>> variant): variant(variant) { }
-    operator std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>() const {
-      return variant;
-    }
-    inline size_t index() const {
-      return variant.index();
-    }
+    std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>> variant);
+    operator std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>() const;
+    size_t index() const;
   };
-  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::string& value) {
-    return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
-  }
-  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(double value) {
-    return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
-  }
-  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(bool value) {
-    return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
-  }
-  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<double>& value) {
-    return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
-  }
-  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<std::string>& value) {
-    return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
-  }
-  inline std::string get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___0(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper) {
-    return std::get<0>(variantWrapper.variant);
-  }
-  inline double get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___1(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper) {
-    return std::get<1>(variantWrapper.variant);
-  }
-  inline bool get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___2(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper) {
-    return std::get<2>(variantWrapper.variant);
-  }
-  inline std::vector<double> get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___3(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper) {
-    return std::get<3>(variantWrapper.variant);
-  }
-  inline std::vector<std::string> get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___4(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper) {
-    return std::get<4>(variantWrapper.variant);
-  }
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::string& value);
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(double value);
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(bool value);
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<double>& value);
+  std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<std::string>& value);
+  std::string get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___0(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper);
+  double get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___1(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper);
+  bool get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___2(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper);
+  std::vector<double> get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___3(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper);
+  std::vector<std::string> get_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string___4(const std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__& variantWrapper);
   
   /**
    * Wrapper struct for `std::variant<bool, OldEnum>`.
@@ -203,34 +150,20 @@ namespace margelo::nitro::image::bridge::swift {
    */
   struct std__variant_bool__OldEnum_ {
     std::variant<bool, OldEnum> variant;
-    std__variant_bool__OldEnum_(std::variant<bool, OldEnum> variant): variant(variant) { }
-    operator std::variant<bool, OldEnum>() const {
-      return variant;
-    }
-    inline size_t index() const {
-      return variant.index();
-    }
+    std__variant_bool__OldEnum_(std::variant<bool, OldEnum> variant);
+    operator std::variant<bool, OldEnum>() const;
+    size_t index() const;
   };
-  inline std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(bool value) {
-    return std__variant_bool__OldEnum_(value);
-  }
-  inline std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(OldEnum value) {
-    return std__variant_bool__OldEnum_(value);
-  }
-  inline bool get_std__variant_bool__OldEnum__0(const std__variant_bool__OldEnum_& variantWrapper) {
-    return std::get<0>(variantWrapper.variant);
-  }
-  inline OldEnum get_std__variant_bool__OldEnum__1(const std__variant_bool__OldEnum_& variantWrapper) {
-    return std::get<1>(variantWrapper.variant);
-  }
+  std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(bool value);
+  std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(OldEnum value);
+  bool get_std__variant_bool__OldEnum__0(const std__variant_bool__OldEnum_& variantWrapper);
+  OldEnum get_std__variant_bool__OldEnum__1(const std__variant_bool__OldEnum_& variantWrapper);
   
   /**
-   * Specialized version of `std::optional<Person>`.
-   */
-  using std__optional_Person_ = std::optional<Person>;
-  inline std::optional<Person> create_std__optional_Person_(const Person& value) {
-    return std::optional<Person>(value);
-  }
+     * Specialized version of `std::optional<Person>`.
+     */
+    using std__optional_Person_ = std::optional<Person>;
+    std::optional<Person> create_std__optional_Person_(const Person& value);
   
   /**
    * Wrapper struct for `std::variant<Car, Person>`.
@@ -239,26 +172,14 @@ namespace margelo::nitro::image::bridge::swift {
    */
   struct std__variant_Car__Person_ {
     std::variant<Car, Person> variant;
-    std__variant_Car__Person_(std::variant<Car, Person> variant): variant(variant) { }
-    operator std::variant<Car, Person>() const {
-      return variant;
-    }
-    inline size_t index() const {
-      return variant.index();
-    }
+    std__variant_Car__Person_(std::variant<Car, Person> variant);
+    operator std::variant<Car, Person>() const;
+    size_t index() const;
   };
-  inline std__variant_Car__Person_ create_std__variant_Car__Person_(const Car& value) {
-    return std__variant_Car__Person_(value);
-  }
-  inline std__variant_Car__Person_ create_std__variant_Car__Person_(const Person& value) {
-    return std__variant_Car__Person_(value);
-  }
-  inline Car get_std__variant_Car__Person__0(const std__variant_Car__Person_& variantWrapper) {
-    return std::get<0>(variantWrapper.variant);
-  }
-  inline Person get_std__variant_Car__Person__1(const std__variant_Car__Person_& variantWrapper) {
-    return std::get<1>(variantWrapper.variant);
-  }
+  std__variant_Car__Person_ create_std__variant_Car__Person_(const Car& value);
+  std__variant_Car__Person_ create_std__variant_Car__Person_(const Person& value);
+  Car get_std__variant_Car__Person__0(const std__variant_Car__Person_& variantWrapper);
+  Person get_std__variant_Car__Person__1(const std__variant_Car__Person_& variantWrapper);
   
   /**
    * Wrapper struct for `std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>>`.
@@ -267,42 +188,26 @@ namespace margelo::nitro::image::bridge::swift {
    */
   struct std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__ {
     std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>> variant;
-    std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>> variant): variant(variant) { }
-    operator std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>>() const {
-      return variant;
-    }
-    inline size_t index() const {
-      return variant.index();
-    }
+    std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>> variant);
+    operator std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>>() const;
+    size_t index() const;
   };
-  inline std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__ create_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(const Person& value) {
-    return std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(value);
-  }
-  inline std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__ create_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(const std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>& value) {
-    return std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(value);
-  }
-  inline Person get_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec___0(const std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__& variantWrapper) {
-    return std::get<0>(variantWrapper.variant);
-  }
-  inline std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec> get_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec___1(const std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__& variantWrapper) {
-    return std::get<1>(variantWrapper.variant);
-  }
+  std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__ create_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(const Person& value);
+  std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__ create_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(const std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>& value);
+  Person get_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec___0(const std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__& variantWrapper);
+  std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec> get_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec___1(const std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__& variantWrapper);
   
   /**
    * Specialized version of `std::tuple<double, double>`.
    */
   using std__tuple_double__double_ = std::tuple<double, double>;
-  inline std::tuple<double, double> create_std__tuple_double__double_(double arg0, double arg1) {
-    return std::tuple<double, double> { arg0, arg1 };
-  }
+  std::tuple<double, double> create_std__tuple_double__double_(double arg0, double arg1);
   
   /**
    * Specialized version of `std::tuple<double, double, double>`.
    */
   using std__tuple_double__double__double_ = std::tuple<double, double, double>;
-  inline std::tuple<double, double, double> create_std__tuple_double__double__double_(double arg0, double arg1, double arg2) {
-    return std::tuple<double, double, double> { arg0, arg1, arg2 };
-  }
+  std::tuple<double, double, double> create_std__tuple_double__double__double_(double arg0, double arg1, double arg2);
   
   /**
    * Wrapper struct for `std::variant<std::tuple<double, double>, std::tuple<double, double, double>>`.
@@ -311,50 +216,32 @@ namespace margelo::nitro::image::bridge::swift {
    */
   struct std__variant_std__tuple_double__double___std__tuple_double__double__double__ {
     std::variant<std::tuple<double, double>, std::tuple<double, double, double>> variant;
-    std__variant_std__tuple_double__double___std__tuple_double__double__double__(std::variant<std::tuple<double, double>, std::tuple<double, double, double>> variant): variant(variant) { }
-    operator std::variant<std::tuple<double, double>, std::tuple<double, double, double>>() const {
-      return variant;
-    }
-    inline size_t index() const {
-      return variant.index();
-    }
+    std__variant_std__tuple_double__double___std__tuple_double__double__double__(std::variant<std::tuple<double, double>, std::tuple<double, double, double>> variant);
+    operator std::variant<std::tuple<double, double>, std::tuple<double, double, double>>() const;
+    size_t index() const;
   };
-  inline std__variant_std__tuple_double__double___std__tuple_double__double__double__ create_std__variant_std__tuple_double__double___std__tuple_double__double__double__(const std::tuple<double, double>& value) {
-    return std__variant_std__tuple_double__double___std__tuple_double__double__double__(value);
-  }
-  inline std__variant_std__tuple_double__double___std__tuple_double__double__double__ create_std__variant_std__tuple_double__double___std__tuple_double__double__double__(const std::tuple<double, double, double>& value) {
-    return std__variant_std__tuple_double__double___std__tuple_double__double__double__(value);
-  }
-  inline std::tuple<double, double> get_std__variant_std__tuple_double__double___std__tuple_double__double__double___0(const std__variant_std__tuple_double__double___std__tuple_double__double__double__& variantWrapper) {
-    return std::get<0>(variantWrapper.variant);
-  }
-  inline std::tuple<double, double, double> get_std__variant_std__tuple_double__double___std__tuple_double__double__double___1(const std__variant_std__tuple_double__double___std__tuple_double__double__double__& variantWrapper) {
-    return std::get<1>(variantWrapper.variant);
-  }
+  std__variant_std__tuple_double__double___std__tuple_double__double__double__ create_std__variant_std__tuple_double__double___std__tuple_double__double__double__(const std::tuple<double, double>& value);
+  std__variant_std__tuple_double__double___std__tuple_double__double__double__ create_std__variant_std__tuple_double__double___std__tuple_double__double__double__(const std::tuple<double, double, double>& value);
+  std::tuple<double, double> get_std__variant_std__tuple_double__double___std__tuple_double__double__double___0(const std__variant_std__tuple_double__double___std__tuple_double__double__double__& variantWrapper);
+  std::tuple<double, double, double> get_std__variant_std__tuple_double__double___std__tuple_double__double__double___1(const std__variant_std__tuple_double__double___std__tuple_double__double__double__& variantWrapper);
   
   /**
    * Specialized version of `std::tuple<double, std::string>`.
    */
   using std__tuple_double__std__string_ = std::tuple<double, std::string>;
-  inline std::tuple<double, std::string> create_std__tuple_double__std__string_(double arg0, const std::string& arg1) {
-    return std::tuple<double, std::string> { arg0, arg1 };
-  }
+  std::tuple<double, std::string> create_std__tuple_double__std__string_(double arg0, const std::string& arg1);
   
   /**
    * Specialized version of `std::tuple<double, std::string, bool>`.
    */
   using std__tuple_double__std__string__bool_ = std::tuple<double, std::string, bool>;
-  inline std::tuple<double, std::string, bool> create_std__tuple_double__std__string__bool_(double arg0, const std::string& arg1, bool arg2) {
-    return std::tuple<double, std::string, bool> { arg0, arg1, arg2 };
-  }
+  std::tuple<double, std::string, bool> create_std__tuple_double__std__string__bool_(double arg0, const std::string& arg1, bool arg2);
   
   /**
    * Specialized version of `PromiseHolder<double>`.
    */
   using PromiseHolder_double_ = PromiseHolder<double>;
-  inline PromiseHolder<double> create_PromiseHolder_double_() {
-    return PromiseHolder<double>();
-  }
+  PromiseHolder<double> create_PromiseHolder_double_();
   
   /**
    * Specialized version of `std::function<std::future<double>()>`.
@@ -365,34 +252,21 @@ namespace margelo::nitro::image::bridge::swift {
    */
   class Func_std__future_double__Wrapper {
   public:
-    explicit Func_std__future_double__Wrapper(const std::function<std::future<double>()>& func): function(func) {}
-    explicit Func_std__future_double__Wrapper(std::function<std::future<double>()>&& func): function(std::move(func)) {}
+    explicit Func_std__future_double__Wrapper(const std::function<std::future<double>()>& func);
+    explicit Func_std__future_double__Wrapper(std::function<std::future<double>()>&& func);
   
-    PromiseHolder<double> call() const {
-      auto __result = function();
-      return []() -> PromiseHolder<double> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
-    }
+    PromiseHolder<double> call() const;
   
     std::function<std::future<double>()> function;
   };
-  inline Func_std__future_double_ create_Func_std__future_double_(void* closureHolder, PromiseHolder<double>(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
-    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
-    return Func_std__future_double_([sharedClosureHolder, call]() -> std::future<double> {
-      auto __result = call(sharedClosureHolder.get());
-      return __result.getFuture();
-    });
-  }
-  inline std::shared_ptr<Func_std__future_double__Wrapper> share_Func_std__future_double_(const Func_std__future_double_& value) {
-    return std::make_shared<Func_std__future_double__Wrapper>(value);
-  }
+  Func_std__future_double_ create_Func_std__future_double_(void* closureHolder, PromiseHolder<double>(*call)(void* /* closureHolder */), void(*destroy)(void*));
+  std::shared_ptr<Func_std__future_double__Wrapper> share_Func_std__future_double_(const Func_std__future_double_& value);
   
   /**
    * Specialized version of `PromiseHolder<void>`.
    */
   using PromiseHolder_void_ = PromiseHolder<void>;
-  inline PromiseHolder<void> create_PromiseHolder_void_() {
-    return PromiseHolder<void>();
-  }
+  PromiseHolder<void> create_PromiseHolder_void_();
   
   /**
    * Specialized version of `std::function<std::future<std::string>()>`.
@@ -403,62 +277,39 @@ namespace margelo::nitro::image::bridge::swift {
    */
   class Func_std__future_std__string__Wrapper {
   public:
-    explicit Func_std__future_std__string__Wrapper(const std::function<std::future<std::string>()>& func): function(func) {}
-    explicit Func_std__future_std__string__Wrapper(std::function<std::future<std::string>()>&& func): function(std::move(func)) {}
+    explicit Func_std__future_std__string__Wrapper(const std::function<std::future<std::string>()>& func);
+    explicit Func_std__future_std__string__Wrapper(std::function<std::future<std::string>()>&& func);
   
-    PromiseHolder<std::string> call() const {
-      auto __result = function();
-      return []() -> PromiseHolder<std::string> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
-    }
+    PromiseHolder<std::string> call() const;
   
     std::function<std::future<std::string>()> function;
   };
-  inline Func_std__future_std__string_ create_Func_std__future_std__string_(void* closureHolder, PromiseHolder<std::string>(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
-    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
-    return Func_std__future_std__string_([sharedClosureHolder, call]() -> std::future<std::string> {
-      auto __result = call(sharedClosureHolder.get());
-      return __result.getFuture();
-    });
-  }
-  inline std::shared_ptr<Func_std__future_std__string__Wrapper> share_Func_std__future_std__string_(const Func_std__future_std__string_& value) {
-    return std::make_shared<Func_std__future_std__string__Wrapper>(value);
-  }
+  Func_std__future_std__string_ create_Func_std__future_std__string_(void* closureHolder, PromiseHolder<std::string>(*call)(void* /* closureHolder */), void(*destroy)(void*));
+  std::shared_ptr<Func_std__future_std__string__Wrapper> share_Func_std__future_std__string_(const Func_std__future_std__string_& value);
   
   /**
    * Specialized version of `PromiseHolder<std::string>`.
    */
   using PromiseHolder_std__string_ = PromiseHolder<std::string>;
-  inline PromiseHolder<std::string> create_PromiseHolder_std__string_() {
-    return PromiseHolder<std::string>();
-  }
+  PromiseHolder<std::string> create_PromiseHolder_std__string_();
   
   /**
-   * Specialized version of `std::optional<std::string>`.
-   */
-  using std__optional_std__string_ = std::optional<std::string>;
-  inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) {
-    return std::optional<std::string>(value);
-  }
+     * Specialized version of `std::optional<std::string>`.
+     */
+    using std__optional_std__string_ = std::optional<std::string>;
+    std::optional<std::string> create_std__optional_std__string_(const std::string& value);
   
   /**
    * Specialized version of `std::vector<Person>`.
    */
   using std__vector_Person_ = std::vector<Person>;
-  inline std::vector<Person> create_std__vector_Person_(size_t size) {
-    std::vector<Person> vector;
-    vector.reserve(size);
-    return vector;
-  }
+  std::vector<Person> create_std__vector_Person_(size_t size);
   
   /**
    * Specialized version of `std::vector<Powertrain>`.
    */
   using std__vector_Powertrain_ = std::vector<Powertrain>;
-  inline std::vector<Powertrain> create_std__vector_Powertrain_(size_t size) {
-    std::vector<Powertrain> vector;
-    vector.reserve(size);
-    return vector;
-  }
+  std::vector<Powertrain> create_std__vector_Powertrain_(size_t size);
   
   /**
    * Specialized version of `std::function<void(const std::vector<Powertrain>&)>`.
@@ -469,48 +320,33 @@ namespace margelo::nitro::image::bridge::swift {
    */
   class Func_void_std__vector_Powertrain__Wrapper {
   public:
-    explicit Func_void_std__vector_Powertrain__Wrapper(const std::function<void(const std::vector<Powertrain>& /* array */)>& func): function(func) {}
-    explicit Func_void_std__vector_Powertrain__Wrapper(std::function<void(const std::vector<Powertrain>& /* array */)>&& func): function(std::move(func)) {}
+    explicit Func_void_std__vector_Powertrain__Wrapper(const std::function<void(const std::vector<Powertrain>& /* array */)>& func);
+    explicit Func_void_std__vector_Powertrain__Wrapper(std::function<void(const std::vector<Powertrain>& /* array */)>&& func);
   
-    void call(std::vector<Powertrain> array) const {
-      function(array);
-    }
+    void call(std::vector<Powertrain> array) const;
   
     std::function<void(const std::vector<Powertrain>& /* array */)> function;
   };
-  inline Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* closureHolder, void(*call)(void* /* closureHolder */, std::vector<Powertrain>), void(*destroy)(void*)) {
-    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
-    return Func_void_std__vector_Powertrain_([sharedClosureHolder, call](const std::vector<Powertrain>& array) -> void {
-      call(sharedClosureHolder.get(), array);
-    });
-  }
-  inline std::shared_ptr<Func_void_std__vector_Powertrain__Wrapper> share_Func_void_std__vector_Powertrain_(const Func_void_std__vector_Powertrain_& value) {
-    return std::make_shared<Func_void_std__vector_Powertrain__Wrapper>(value);
-  }
+  Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* closureHolder, void(*call)(void* /* closureHolder */, std::vector<Powertrain>), void(*destroy)(void*));
+  std::shared_ptr<Func_void_std__vector_Powertrain__Wrapper> share_Func_void_std__vector_Powertrain_(const Func_void_std__vector_Powertrain_& value);
   
   /**
-   * Specialized version of `std::optional<bool>`.
-   */
-  using std__optional_bool_ = std::optional<bool>;
-  inline std::optional<bool> create_std__optional_bool_(const bool& value) {
-    return std::optional<bool>(value);
-  }
+     * Specialized version of `std::optional<bool>`.
+     */
+    using std__optional_bool_ = std::optional<bool>;
+    std::optional<bool> create_std__optional_bool_(const bool& value);
   
   /**
-   * Specialized version of `std::optional<Powertrain>`.
-   */
-  using std__optional_Powertrain_ = std::optional<Powertrain>;
-  inline std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value) {
-    return std::optional<Powertrain>(value);
-  }
+     * Specialized version of `std::optional<Powertrain>`.
+     */
+    using std__optional_Powertrain_ = std::optional<Powertrain>;
+    std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value);
   
   /**
    * Specialized version of `PromiseHolder<int64_t>`.
    */
   using PromiseHolder_int64_t_ = PromiseHolder<int64_t>;
-  inline PromiseHolder<int64_t> create_PromiseHolder_int64_t_() {
-    return PromiseHolder<int64_t>();
-  }
+  PromiseHolder<int64_t> create_PromiseHolder_int64_t_();
   
   /**
    * Specialized version of `std::function<void()>`.
@@ -521,32 +357,21 @@ namespace margelo::nitro::image::bridge::swift {
    */
   class Func_void_Wrapper {
   public:
-    explicit Func_void_Wrapper(const std::function<void()>& func): function(func) {}
-    explicit Func_void_Wrapper(std::function<void()>&& func): function(std::move(func)) {}
+    explicit Func_void_Wrapper(const std::function<void()>& func);
+    explicit Func_void_Wrapper(std::function<void()>&& func);
   
-    void call() const {
-      function();
-    }
+    void call() const;
   
     std::function<void()> function;
   };
-  inline Func_void create_Func_void(void* closureHolder, void(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
-    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
-    return Func_void([sharedClosureHolder, call]() -> void {
-      call(sharedClosureHolder.get());
-    });
-  }
-  inline std::shared_ptr<Func_void_Wrapper> share_Func_void(const Func_void& value) {
-    return std::make_shared<Func_void_Wrapper>(value);
-  }
+  Func_void create_Func_void(void* closureHolder, void(*call)(void* /* closureHolder */), void(*destroy)(void*));
+  std::shared_ptr<Func_void_Wrapper> share_Func_void(const Func_void& value);
   
   /**
-   * Specialized version of `std::optional<double>`.
-   */
-  using std__optional_double_ = std::optional<double>;
-  inline std::optional<double> create_std__optional_double_(const double& value) {
-    return std::optional<double>(value);
-  }
+     * Specialized version of `std::optional<double>`.
+     */
+    using std__optional_double_ = std::optional<double>;
+    std::optional<double> create_std__optional_double_(const double& value);
   
   /**
    * Specialized version of `std::function<void(std::optional<double>)>`.
@@ -557,23 +382,14 @@ namespace margelo::nitro::image::bridge::swift {
    */
   class Func_void_std__optional_double__Wrapper {
   public:
-    explicit Func_void_std__optional_double__Wrapper(const std::function<void(std::optional<double> /* maybe */)>& func): function(func) {}
-    explicit Func_void_std__optional_double__Wrapper(std::function<void(std::optional<double> /* maybe */)>&& func): function(std::move(func)) {}
+    explicit Func_void_std__optional_double__Wrapper(const std::function<void(std::optional<double> /* maybe */)>& func);
+    explicit Func_void_std__optional_double__Wrapper(std::function<void(std::optional<double> /* maybe */)>&& func);
   
-    void call(std::optional<double> maybe) const {
-      function(maybe);
-    }
+    void call(std::optional<double> maybe) const;
   
     std::function<void(std::optional<double> /* maybe */)> function;
   };
-  inline Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* closureHolder, void(*call)(void* /* closureHolder */, std::optional<double>), void(*destroy)(void*)) {
-    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
-    return Func_void_std__optional_double_([sharedClosureHolder, call](std::optional<double> maybe) -> void {
-      call(sharedClosureHolder.get(), maybe);
-    });
-  }
-  inline std::shared_ptr<Func_void_std__optional_double__Wrapper> share_Func_void_std__optional_double_(const Func_void_std__optional_double_& value) {
-    return std::make_shared<Func_void_std__optional_double__Wrapper>(value);
-  }
+  Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* closureHolder, void(*call)(void* /* closureHolder */, std::optional<double>), void(*destroy)(void*));
+  std::shared_ptr<Func_void_std__optional_double__Wrapper> share_Func_void_std__optional_double_(const Func_void_std__optional_double_& value);
 
 } // namespace margelo::nitro::image::bridge::swift

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.cpp
@@ -8,4 +8,25 @@
 #include "HybridBaseSpecSwift.hpp"
 
 namespace margelo::nitro::image {
+
+HybridBaseSpecSwift::HybridBaseSpecSwift(const NitroImage::HybridBaseSpecCxx& swiftPart):
+  HybridObject(HybridBaseSpec::TAG),
+  _swiftPart(swiftPart) { }
+
+NitroImage::HybridBaseSpecCxx HybridBaseSpecSwift::getSwiftPart() noexcept {
+  return _swiftPart;
+}
+
+size_t HybridBaseSpecSwift::getExternalMemorySize() noexcept {
+  return _swiftPart.getMemorySize();
+}
+
+// Properties
+double HybridBaseSpecSwift::getBaseValue() noexcept {
+  return _swiftPart.getBaseValue();
+}
+
+// Methods
+
+
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.hpp
@@ -39,25 +39,19 @@ namespace margelo::nitro::image {
   class HybridBaseSpecSwift: public virtual HybridBaseSpec {
   public:
     // Constructor from a Swift instance
-    explicit HybridBaseSpecSwift(const NitroImage::HybridBaseSpecCxx& swiftPart):
-      HybridObject(HybridBaseSpec::TAG),
-      _swiftPart(swiftPart) { }
+    explicit HybridBaseSpecSwift(const NitroImage::HybridBaseSpecCxx& swiftPart);
 
   public:
     // Get the Swift part
-    inline NitroImage::HybridBaseSpecCxx getSwiftPart() noexcept { return _swiftPart; }
+    NitroImage::HybridBaseSpecCxx getSwiftPart() noexcept;
 
   public:
     // Get memory pressure
-    inline size_t getExternalMemorySize() noexcept override {
-      return _swiftPart.getMemorySize();
-    }
+    size_t getExternalMemorySize() noexcept override;
 
   public:
     // Properties
-    inline double getBaseValue() noexcept override {
-      return _swiftPart.getBaseValue();
-    }
+    double getBaseValue() noexcept;
 
   public:
     // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.hpp
@@ -51,7 +51,7 @@ namespace margelo::nitro::image {
 
   public:
     // Properties
-    double getBaseValue() noexcept;
+    double getBaseValue() noexcept override;
 
   public:
     // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.cpp
@@ -8,4 +8,26 @@
 #include "HybridChildSpecSwift.hpp"
 
 namespace margelo::nitro::image {
+
+HybridChildSpecSwift::HybridChildSpecSwift(const NitroImage::HybridChildSpecCxx& swiftPart):
+  HybridObject(HybridChildSpec::TAG),
+      HybridBaseSpecSwift(swiftPart),
+  _swiftPart(swiftPart) { }
+
+NitroImage::HybridChildSpecCxx HybridChildSpecSwift::getSwiftPart() noexcept {
+  return _swiftPart;
+}
+
+size_t HybridChildSpecSwift::getExternalMemorySize() noexcept {
+  return _swiftPart.getMemorySize();
+}
+
+// Properties
+double HybridChildSpecSwift::getChildValue() noexcept {
+  return _swiftPart.getChildValue();
+}
+
+// Methods
+
+
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
@@ -52,7 +52,7 @@ namespace margelo::nitro::image {
 
   public:
     // Properties
-    double getChildValue() noexcept;
+    double getChildValue() noexcept override;
 
   public:
     // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
@@ -40,26 +40,19 @@ namespace margelo::nitro::image {
   class HybridChildSpecSwift: public virtual HybridChildSpec, public virtual HybridBaseSpecSwift {
   public:
     // Constructor from a Swift instance
-    explicit HybridChildSpecSwift(const NitroImage::HybridChildSpecCxx& swiftPart):
-      HybridObject(HybridChildSpec::TAG),
-      HybridBaseSpecSwift(swiftPart),
-      _swiftPart(swiftPart) { }
+    explicit HybridChildSpecSwift(const NitroImage::HybridChildSpecCxx& swiftPart);
 
   public:
     // Get the Swift part
-    inline NitroImage::HybridChildSpecCxx getSwiftPart() noexcept { return _swiftPart; }
+    NitroImage::HybridChildSpecCxx getSwiftPart() noexcept;
 
   public:
     // Get memory pressure
-    inline size_t getExternalMemorySize() noexcept override {
-      return _swiftPart.getMemorySize();
-    }
+    size_t getExternalMemorySize() noexcept override;
 
   public:
     // Properties
-    inline double getChildValue() noexcept override {
-      return _swiftPart.getChildValue();
-    }
+    double getChildValue() noexcept;
 
   public:
     // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.cpp
@@ -8,4 +8,38 @@
 #include "HybridImageFactorySpecSwift.hpp"
 
 namespace margelo::nitro::image {
+
+HybridImageFactorySpecSwift::HybridImageFactorySpecSwift(const NitroImage::HybridImageFactorySpecCxx& swiftPart):
+  HybridObject(HybridImageFactorySpec::TAG),
+  _swiftPart(swiftPart) { }
+
+NitroImage::HybridImageFactorySpecCxx HybridImageFactorySpecSwift::getSwiftPart() noexcept {
+  return _swiftPart;
+}
+
+size_t HybridImageFactorySpecSwift::getExternalMemorySize() noexcept {
+  return _swiftPart.getMemorySize();
+}
+
+// Properties
+
+
+// Methods
+std::shared_ptr<margelo::nitro::image::HybridImageSpec> HybridImageFactorySpecSwift::loadImageFromFile(const std::string& path) {
+  auto __result = _swiftPart.loadImageFromFile(path);
+  return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
+}
+std::shared_ptr<margelo::nitro::image::HybridImageSpec> HybridImageFactorySpecSwift::loadImageFromURL(const std::string& path) {
+  auto __result = _swiftPart.loadImageFromURL(path);
+  return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
+}
+std::shared_ptr<margelo::nitro::image::HybridImageSpec> HybridImageFactorySpecSwift::loadImageFromSystemName(const std::string& path) {
+  auto __result = _swiftPart.loadImageFromSystemName(path);
+  return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
+}
+std::shared_ptr<margelo::nitro::image::HybridImageSpec> HybridImageFactorySpecSwift::bounceBack(const std::shared_ptr<margelo::nitro::image::HybridImageSpec>& image) {
+  auto __result = _swiftPart.bounceBack(std::dynamic_pointer_cast<HybridImageSpecSwift>(image)->getSwiftPart());
+  return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
+}
+
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.hpp
@@ -45,19 +45,15 @@ namespace margelo::nitro::image {
   class HybridImageFactorySpecSwift: public virtual HybridImageFactorySpec {
   public:
     // Constructor from a Swift instance
-    explicit HybridImageFactorySpecSwift(const NitroImage::HybridImageFactorySpecCxx& swiftPart):
-      HybridObject(HybridImageFactorySpec::TAG),
-      _swiftPart(swiftPart) { }
+    explicit HybridImageFactorySpecSwift(const NitroImage::HybridImageFactorySpecCxx& swiftPart);
 
   public:
     // Get the Swift part
-    inline NitroImage::HybridImageFactorySpecCxx getSwiftPart() noexcept { return _swiftPart; }
+    NitroImage::HybridImageFactorySpecCxx getSwiftPart() noexcept;
 
   public:
     // Get memory pressure
-    inline size_t getExternalMemorySize() noexcept override {
-      return _swiftPart.getMemorySize();
-    }
+    size_t getExternalMemorySize() noexcept override;
 
   public:
     // Properties
@@ -65,22 +61,10 @@ namespace margelo::nitro::image {
 
   public:
     // Methods
-    inline std::shared_ptr<margelo::nitro::image::HybridImageSpec> loadImageFromFile(const std::string& path) override {
-      auto __result = _swiftPart.loadImageFromFile(path);
-      return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
-    }
-    inline std::shared_ptr<margelo::nitro::image::HybridImageSpec> loadImageFromURL(const std::string& path) override {
-      auto __result = _swiftPart.loadImageFromURL(path);
-      return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
-    }
-    inline std::shared_ptr<margelo::nitro::image::HybridImageSpec> loadImageFromSystemName(const std::string& path) override {
-      auto __result = _swiftPart.loadImageFromSystemName(path);
-      return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
-    }
-    inline std::shared_ptr<margelo::nitro::image::HybridImageSpec> bounceBack(const std::shared_ptr<margelo::nitro::image::HybridImageSpec>& image) override {
-      auto __result = _swiftPart.bounceBack(std::dynamic_pointer_cast<HybridImageSpecSwift>(image)->getSwiftPart());
-      return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
-    }
+    std::shared_ptr<margelo::nitro::image::HybridImageSpec> loadImageFromFile(const std::string& path) override;
+    std::shared_ptr<margelo::nitro::image::HybridImageSpec> loadImageFromURL(const std::string& path) override;
+    std::shared_ptr<margelo::nitro::image::HybridImageSpec> loadImageFromSystemName(const std::string& path) override;
+    std::shared_ptr<margelo::nitro::image::HybridImageSpec> bounceBack(const std::shared_ptr<margelo::nitro::image::HybridImageSpec>& image) override;
 
   private:
     NitroImage::HybridImageFactorySpecCxx _swiftPart;

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.cpp
@@ -8,4 +8,42 @@
 #include "HybridImageSpecSwift.hpp"
 
 namespace margelo::nitro::image {
+
+HybridImageSpecSwift::HybridImageSpecSwift(const NitroImage::HybridImageSpecCxx& swiftPart):
+  HybridObject(HybridImageSpec::TAG),
+  _swiftPart(swiftPart) { }
+
+NitroImage::HybridImageSpecCxx HybridImageSpecSwift::getSwiftPart() noexcept {
+  return _swiftPart;
+}
+
+size_t HybridImageSpecSwift::getExternalMemorySize() noexcept {
+  return _swiftPart.getMemorySize();
+}
+
+// Properties
+ImageSize HybridImageSpecSwift::getSize() noexcept {
+  auto __result = _swiftPart.getSize();
+  return __result;
+}
+PixelFormat HybridImageSpecSwift::getPixelFormat() noexcept {
+  auto __result = _swiftPart.getPixelFormat();
+  return static_cast<PixelFormat>(__result);
+}
+double HybridImageSpecSwift::getSomeSettableProp() noexcept {
+  return _swiftPart.getSomeSettableProp();
+}
+void HybridImageSpecSwift::setSomeSettableProp(double someSettableProp) noexcept {
+  _swiftPart.setSomeSettableProp(std::forward<decltype(someSettableProp)>(someSettableProp));
+}
+
+// Methods
+double HybridImageSpecSwift::toArrayBuffer(ImageFormat format) {
+  auto __result = _swiftPart.toArrayBuffer(static_cast<int>(format));
+  return __result;
+}
+void HybridImageSpecSwift::saveToFile(const std::string& path, const std::function<void(const std::string& /* path */)>& onFinished) {
+  _swiftPart.saveToFile(path, onFinished);
+}
+
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
@@ -60,10 +60,10 @@ namespace margelo::nitro::image {
 
   public:
     // Properties
-    ImageSize getSize() noexcept;
-    PixelFormat getPixelFormat() noexcept;
-    double getSomeSettableProp() noexcept;
-    void setSomeSettableProp(double someSettableProp) noexcept;
+    ImageSize getSize() noexcept override;
+    PixelFormat getPixelFormat() noexcept override;
+    double getSomeSettableProp() noexcept override;
+    void setSomeSettableProp(double someSettableProp) noexcept override;
 
   public:
     // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
@@ -48,46 +48,27 @@ namespace margelo::nitro::image {
   class HybridImageSpecSwift: public virtual HybridImageSpec {
   public:
     // Constructor from a Swift instance
-    explicit HybridImageSpecSwift(const NitroImage::HybridImageSpecCxx& swiftPart):
-      HybridObject(HybridImageSpec::TAG),
-      _swiftPart(swiftPart) { }
+    explicit HybridImageSpecSwift(const NitroImage::HybridImageSpecCxx& swiftPart);
 
   public:
     // Get the Swift part
-    inline NitroImage::HybridImageSpecCxx getSwiftPart() noexcept { return _swiftPart; }
+    NitroImage::HybridImageSpecCxx getSwiftPart() noexcept;
 
   public:
     // Get memory pressure
-    inline size_t getExternalMemorySize() noexcept override {
-      return _swiftPart.getMemorySize();
-    }
+    size_t getExternalMemorySize() noexcept override;
 
   public:
     // Properties
-    inline ImageSize getSize() noexcept override {
-      auto __result = _swiftPart.getSize();
-      return __result;
-    }
-    inline PixelFormat getPixelFormat() noexcept override {
-      auto __result = _swiftPart.getPixelFormat();
-      return static_cast<PixelFormat>(__result);
-    }
-    inline double getSomeSettableProp() noexcept override {
-      return _swiftPart.getSomeSettableProp();
-    }
-    inline void setSomeSettableProp(double someSettableProp) noexcept override {
-      _swiftPart.setSomeSettableProp(std::forward<decltype(someSettableProp)>(someSettableProp));
-    }
+    ImageSize getSize() noexcept;
+    PixelFormat getPixelFormat() noexcept;
+    double getSomeSettableProp() noexcept;
+    void setSomeSettableProp(double someSettableProp) noexcept;
 
   public:
     // Methods
-    inline double toArrayBuffer(ImageFormat format) override {
-      auto __result = _swiftPart.toArrayBuffer(static_cast<int>(format));
-      return __result;
-    }
-    inline void saveToFile(const std::string& path, const std::function<void(const std::string& /* path */)>& onFinished) override {
-      _swiftPart.saveToFile(path, onFinished);
-    }
+    double toArrayBuffer(ImageFormat format) override;
+    void saveToFile(const std::string& path, const std::function<void(const std::string& /* path */)>& onFinished) override;
 
   private:
     NitroImage::HybridImageSpecCxx _swiftPart;

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.cpp
@@ -8,4 +8,211 @@
 #include "HybridTestObjectSwiftKotlinSpecSwift.hpp"
 
 namespace margelo::nitro::image {
+
+HybridTestObjectSwiftKotlinSpecSwift::HybridTestObjectSwiftKotlinSpecSwift(const NitroImage::HybridTestObjectSwiftKotlinSpecCxx& swiftPart):
+  HybridObject(HybridTestObjectSwiftKotlinSpec::TAG),
+  _swiftPart(swiftPart) { }
+
+NitroImage::HybridTestObjectSwiftKotlinSpecCxx HybridTestObjectSwiftKotlinSpecSwift::getSwiftPart() noexcept {
+  return _swiftPart;
+}
+
+size_t HybridTestObjectSwiftKotlinSpecSwift::getExternalMemorySize() noexcept {
+  return _swiftPart.getMemorySize();
+}
+
+// Properties
+std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> HybridTestObjectSwiftKotlinSpecSwift::getThisObject() noexcept {
+  auto __result = _swiftPart.getThisObject();
+  return HybridContext::getOrCreate<HybridTestObjectSwiftKotlinSpecSwift>(__result);
+}
+double HybridTestObjectSwiftKotlinSpecSwift::getNumberValue() noexcept {
+  return _swiftPart.getNumberValue();
+}
+void HybridTestObjectSwiftKotlinSpecSwift::setNumberValue(double numberValue) noexcept {
+  _swiftPart.setNumberValue(std::forward<decltype(numberValue)>(numberValue));
+}
+bool HybridTestObjectSwiftKotlinSpecSwift::getBoolValue() noexcept {
+  return _swiftPart.getBoolValue();
+}
+void HybridTestObjectSwiftKotlinSpecSwift::setBoolValue(bool boolValue) noexcept {
+  _swiftPart.setBoolValue(std::forward<decltype(boolValue)>(boolValue));
+}
+std::string HybridTestObjectSwiftKotlinSpecSwift::getStringValue() noexcept {
+  auto __result = _swiftPart.getStringValue();
+  return __result;
+}
+void HybridTestObjectSwiftKotlinSpecSwift::setStringValue(const std::string& stringValue) noexcept {
+  _swiftPart.setStringValue(stringValue);
+}
+int64_t HybridTestObjectSwiftKotlinSpecSwift::getBigintValue() noexcept {
+  return _swiftPart.getBigintValue();
+}
+void HybridTestObjectSwiftKotlinSpecSwift::setBigintValue(int64_t bigintValue) noexcept {
+  _swiftPart.setBigintValue(std::forward<decltype(bigintValue)>(bigintValue));
+}
+std::optional<std::string> HybridTestObjectSwiftKotlinSpecSwift::getStringOrUndefined() noexcept {
+  auto __result = _swiftPart.getStringOrUndefined();
+  return __result;
+}
+void HybridTestObjectSwiftKotlinSpecSwift::setStringOrUndefined(const std::optional<std::string>& stringOrUndefined) noexcept {
+  _swiftPart.setStringOrUndefined(stringOrUndefined);
+}
+std::optional<std::string> HybridTestObjectSwiftKotlinSpecSwift::getStringOrNull() noexcept {
+  auto __result = _swiftPart.getStringOrNull();
+  return __result;
+}
+void HybridTestObjectSwiftKotlinSpecSwift::setStringOrNull(const std::optional<std::string>& stringOrNull) noexcept {
+  _swiftPart.setStringOrNull(stringOrNull);
+}
+std::optional<std::string> HybridTestObjectSwiftKotlinSpecSwift::getOptionalString() noexcept {
+  auto __result = _swiftPart.getOptionalString();
+  return __result;
+}
+void HybridTestObjectSwiftKotlinSpecSwift::setOptionalString(const std::optional<std::string>& optionalString) noexcept {
+  _swiftPart.setOptionalString(optionalString);
+}
+std::variant<std::string, double> HybridTestObjectSwiftKotlinSpecSwift::getSomeVariant() noexcept {
+  auto __result = _swiftPart.getSomeVariant();
+  return __result;
+}
+void HybridTestObjectSwiftKotlinSpecSwift::setSomeVariant(const std::variant<std::string, double>& someVariant) noexcept {
+  _swiftPart.setSomeVariant(someVariant);
+}
+
+// Methods
+std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> HybridTestObjectSwiftKotlinSpecSwift::newTestObject() {
+  auto __result = _swiftPart.newTestObject();
+  return HybridContext::getOrCreate<HybridTestObjectSwiftKotlinSpecSwift>(__result);
+}
+void HybridTestObjectSwiftKotlinSpecSwift::simpleFunc() {
+  _swiftPart.simpleFunc();
+}
+double HybridTestObjectSwiftKotlinSpecSwift::addNumbers(double a, double b) {
+  auto __result = _swiftPart.addNumbers(std::forward<decltype(a)>(a), std::forward<decltype(b)>(b));
+  return __result;
+}
+std::string HybridTestObjectSwiftKotlinSpecSwift::addStrings(const std::string& a, const std::string& b) {
+  auto __result = _swiftPart.addStrings(a, b);
+  return __result;
+}
+void HybridTestObjectSwiftKotlinSpecSwift::multipleArguments(double num, const std::string& str, bool boo) {
+  _swiftPart.multipleArguments(std::forward<decltype(num)>(num), str, std::forward<decltype(boo)>(boo));
+}
+std::vector<std::string> HybridTestObjectSwiftKotlinSpecSwift::bounceStrings(const std::vector<std::string>& array) {
+  auto __result = _swiftPart.bounceStrings(array);
+  return __result;
+}
+std::vector<double> HybridTestObjectSwiftKotlinSpecSwift::bounceNumbers(const std::vector<double>& array) {
+  auto __result = _swiftPart.bounceNumbers(array);
+  return __result;
+}
+std::vector<Person> HybridTestObjectSwiftKotlinSpecSwift::bounceStructs(const std::vector<Person>& array) {
+  auto __result = _swiftPart.bounceStructs(array);
+  return __result;
+}
+std::vector<Powertrain> HybridTestObjectSwiftKotlinSpecSwift::bounceEnums(const std::vector<Powertrain>& array) {
+  auto __result = _swiftPart.bounceEnums(array);
+  return __result;
+}
+void HybridTestObjectSwiftKotlinSpecSwift::complexEnumCallback(const std::vector<Powertrain>& array, const std::function<void(const std::vector<Powertrain>& /* array */)>& callback) {
+  _swiftPart.complexEnumCallback(array, callback);
+}
+std::shared_ptr<AnyMap> HybridTestObjectSwiftKotlinSpecSwift::createMap() {
+  auto __result = _swiftPart.createMap();
+  return __result;
+}
+std::shared_ptr<AnyMap> HybridTestObjectSwiftKotlinSpecSwift::mapRoundtrip(const std::shared_ptr<AnyMap>& map) {
+  auto __result = _swiftPart.mapRoundtrip(map);
+  return __result;
+}
+double HybridTestObjectSwiftKotlinSpecSwift::funcThatThrows() {
+  auto __result = _swiftPart.funcThatThrows();
+  return __result;
+}
+std::string HybridTestObjectSwiftKotlinSpecSwift::tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) {
+  auto __result = _swiftPart.tryOptionalParams(std::forward<decltype(num)>(num), std::forward<decltype(boo)>(boo), str);
+  return __result;
+}
+std::string HybridTestObjectSwiftKotlinSpecSwift::tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) {
+  auto __result = _swiftPart.tryMiddleParam(std::forward<decltype(num)>(num), boo, str);
+  return __result;
+}
+std::optional<Powertrain> HybridTestObjectSwiftKotlinSpecSwift::tryOptionalEnum(std::optional<Powertrain> value) {
+  auto __result = _swiftPart.tryOptionalEnum(value);
+  return __result;
+}
+int64_t HybridTestObjectSwiftKotlinSpecSwift::calculateFibonacciSync(double value) {
+  auto __result = _swiftPart.calculateFibonacciSync(std::forward<decltype(value)>(value));
+  return __result;
+}
+std::future<int64_t> HybridTestObjectSwiftKotlinSpecSwift::calculateFibonacciAsync(double value) {
+  auto __result = _swiftPart.calculateFibonacciAsync(std::forward<decltype(value)>(value));
+  return __result.getFuture();
+}
+std::future<void> HybridTestObjectSwiftKotlinSpecSwift::wait(double seconds) {
+  auto __result = _swiftPart.wait(std::forward<decltype(seconds)>(seconds));
+  return __result.getFuture();
+}
+void HybridTestObjectSwiftKotlinSpecSwift::callCallback(const std::function<void()>& callback) {
+  _swiftPart.callCallback(callback);
+}
+void HybridTestObjectSwiftKotlinSpecSwift::callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) {
+  _swiftPart.callAll(first, second, third);
+}
+void HybridTestObjectSwiftKotlinSpecSwift::callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) {
+  _swiftPart.callWithOptional(value, callback);
+}
+Car HybridTestObjectSwiftKotlinSpecSwift::getCar() {
+  auto __result = _swiftPart.getCar();
+  return __result;
+}
+bool HybridTestObjectSwiftKotlinSpecSwift::isCarElectric(const Car& car) {
+  auto __result = _swiftPart.isCarElectric(car);
+  return __result;
+}
+std::optional<Person> HybridTestObjectSwiftKotlinSpecSwift::getDriver(const Car& car) {
+  auto __result = _swiftPart.getDriver(car);
+  return __result;
+}
+std::shared_ptr<ArrayBuffer> HybridTestObjectSwiftKotlinSpecSwift::createArrayBuffer() {
+  auto __result = _swiftPart.createArrayBuffer();
+  return __result.getArrayBuffer();
+}
+double HybridTestObjectSwiftKotlinSpecSwift::getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) {
+  auto __result = _swiftPart.getBufferLastItem(ArrayBufferHolder(buffer));
+  return __result;
+}
+void HybridTestObjectSwiftKotlinSpecSwift::setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) {
+  _swiftPart.setAllValuesTo(ArrayBufferHolder(buffer), std::forward<decltype(value)>(value));
+}
+std::shared_ptr<margelo::nitro::image::HybridChildSpec> HybridTestObjectSwiftKotlinSpecSwift::createChild() {
+  auto __result = _swiftPart.createChild();
+  return HybridContext::getOrCreate<HybridChildSpecSwift>(__result);
+}
+std::shared_ptr<margelo::nitro::image::HybridBaseSpec> HybridTestObjectSwiftKotlinSpecSwift::createBase() {
+  auto __result = _swiftPart.createBase();
+  return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
+}
+std::shared_ptr<margelo::nitro::image::HybridBaseSpec> HybridTestObjectSwiftKotlinSpecSwift::createBaseActualChild() {
+  auto __result = _swiftPart.createBaseActualChild();
+  return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
+}
+std::shared_ptr<margelo::nitro::image::HybridChildSpec> HybridTestObjectSwiftKotlinSpecSwift::bounceChild(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) {
+  auto __result = _swiftPart.bounceChild(std::dynamic_pointer_cast<HybridChildSpecSwift>(child)->getSwiftPart());
+  return HybridContext::getOrCreate<HybridChildSpecSwift>(__result);
+}
+std::shared_ptr<margelo::nitro::image::HybridBaseSpec> HybridTestObjectSwiftKotlinSpecSwift::bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) {
+  auto __result = _swiftPart.bounceBase(std::dynamic_pointer_cast<HybridBaseSpecSwift>(base)->getSwiftPart());
+  return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
+}
+std::shared_ptr<margelo::nitro::image::HybridBaseSpec> HybridTestObjectSwiftKotlinSpecSwift::bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) {
+  auto __result = _swiftPart.bounceChildBase(std::dynamic_pointer_cast<HybridChildSpecSwift>(child)->getSwiftPart());
+  return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
+}
+std::shared_ptr<margelo::nitro::image::HybridChildSpec> HybridTestObjectSwiftKotlinSpecSwift::castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) {
+  auto __result = _swiftPart.castBase(std::dynamic_pointer_cast<HybridBaseSpecSwift>(base)->getSwiftPart());
+  return HybridContext::getOrCreate<HybridChildSpecSwift>(__result);
+}
+
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -93,23 +93,23 @@ namespace margelo::nitro::image {
 
   public:
     // Properties
-    std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> getThisObject() noexcept;
-    double getNumberValue() noexcept;
-    void setNumberValue(double numberValue) noexcept;
-    bool getBoolValue() noexcept;
-    void setBoolValue(bool boolValue) noexcept;
-    std::string getStringValue() noexcept;
-    void setStringValue(const std::string& stringValue) noexcept;
-    int64_t getBigintValue() noexcept;
-    void setBigintValue(int64_t bigintValue) noexcept;
-    std::optional<std::string> getStringOrUndefined() noexcept;
-    void setStringOrUndefined(const std::optional<std::string>& stringOrUndefined) noexcept;
-    std::optional<std::string> getStringOrNull() noexcept;
-    void setStringOrNull(const std::optional<std::string>& stringOrNull) noexcept;
-    std::optional<std::string> getOptionalString() noexcept;
-    void setOptionalString(const std::optional<std::string>& optionalString) noexcept;
-    std::variant<std::string, double> getSomeVariant() noexcept;
-    void setSomeVariant(const std::variant<std::string, double>& someVariant) noexcept;
+    std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> getThisObject() noexcept override;
+    double getNumberValue() noexcept override;
+    void setNumberValue(double numberValue) noexcept override;
+    bool getBoolValue() noexcept override;
+    void setBoolValue(bool boolValue) noexcept override;
+    std::string getStringValue() noexcept override;
+    void setStringValue(const std::string& stringValue) noexcept override;
+    int64_t getBigintValue() noexcept override;
+    void setBigintValue(int64_t bigintValue) noexcept override;
+    std::optional<std::string> getStringOrUndefined() noexcept override;
+    void setStringOrUndefined(const std::optional<std::string>& stringOrUndefined) noexcept override;
+    std::optional<std::string> getStringOrNull() noexcept override;
+    void setStringOrNull(const std::optional<std::string>& stringOrNull) noexcept override;
+    std::optional<std::string> getOptionalString() noexcept override;
+    void setOptionalString(const std::optional<std::string>& optionalString) noexcept override;
+    std::variant<std::string, double> getSomeVariant() noexcept override;
+    void setSomeVariant(const std::variant<std::string, double>& someVariant) noexcept override;
 
   public:
     // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -81,215 +81,73 @@ namespace margelo::nitro::image {
   class HybridTestObjectSwiftKotlinSpecSwift: public virtual HybridTestObjectSwiftKotlinSpec {
   public:
     // Constructor from a Swift instance
-    explicit HybridTestObjectSwiftKotlinSpecSwift(const NitroImage::HybridTestObjectSwiftKotlinSpecCxx& swiftPart):
-      HybridObject(HybridTestObjectSwiftKotlinSpec::TAG),
-      _swiftPart(swiftPart) { }
+    explicit HybridTestObjectSwiftKotlinSpecSwift(const NitroImage::HybridTestObjectSwiftKotlinSpecCxx& swiftPart);
 
   public:
     // Get the Swift part
-    inline NitroImage::HybridTestObjectSwiftKotlinSpecCxx getSwiftPart() noexcept { return _swiftPart; }
+    NitroImage::HybridTestObjectSwiftKotlinSpecCxx getSwiftPart() noexcept;
 
   public:
     // Get memory pressure
-    inline size_t getExternalMemorySize() noexcept override {
-      return _swiftPart.getMemorySize();
-    }
+    size_t getExternalMemorySize() noexcept override;
 
   public:
     // Properties
-    inline std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> getThisObject() noexcept override {
-      auto __result = _swiftPart.getThisObject();
-      return HybridContext::getOrCreate<HybridTestObjectSwiftKotlinSpecSwift>(__result);
-    }
-    inline double getNumberValue() noexcept override {
-      return _swiftPart.getNumberValue();
-    }
-    inline void setNumberValue(double numberValue) noexcept override {
-      _swiftPart.setNumberValue(std::forward<decltype(numberValue)>(numberValue));
-    }
-    inline bool getBoolValue() noexcept override {
-      return _swiftPart.getBoolValue();
-    }
-    inline void setBoolValue(bool boolValue) noexcept override {
-      _swiftPart.setBoolValue(std::forward<decltype(boolValue)>(boolValue));
-    }
-    inline std::string getStringValue() noexcept override {
-      auto __result = _swiftPart.getStringValue();
-      return __result;
-    }
-    inline void setStringValue(const std::string& stringValue) noexcept override {
-      _swiftPart.setStringValue(stringValue);
-    }
-    inline int64_t getBigintValue() noexcept override {
-      return _swiftPart.getBigintValue();
-    }
-    inline void setBigintValue(int64_t bigintValue) noexcept override {
-      _swiftPart.setBigintValue(std::forward<decltype(bigintValue)>(bigintValue));
-    }
-    inline std::optional<std::string> getStringOrUndefined() noexcept override {
-      auto __result = _swiftPart.getStringOrUndefined();
-      return __result;
-    }
-    inline void setStringOrUndefined(const std::optional<std::string>& stringOrUndefined) noexcept override {
-      _swiftPart.setStringOrUndefined(stringOrUndefined);
-    }
-    inline std::optional<std::string> getStringOrNull() noexcept override {
-      auto __result = _swiftPart.getStringOrNull();
-      return __result;
-    }
-    inline void setStringOrNull(const std::optional<std::string>& stringOrNull) noexcept override {
-      _swiftPart.setStringOrNull(stringOrNull);
-    }
-    inline std::optional<std::string> getOptionalString() noexcept override {
-      auto __result = _swiftPart.getOptionalString();
-      return __result;
-    }
-    inline void setOptionalString(const std::optional<std::string>& optionalString) noexcept override {
-      _swiftPart.setOptionalString(optionalString);
-    }
-    inline std::variant<std::string, double> getSomeVariant() noexcept override {
-      auto __result = _swiftPart.getSomeVariant();
-      return __result;
-    }
-    inline void setSomeVariant(const std::variant<std::string, double>& someVariant) noexcept override {
-      _swiftPart.setSomeVariant(someVariant);
-    }
+    std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> getThisObject() noexcept;
+    double getNumberValue() noexcept;
+    void setNumberValue(double numberValue) noexcept;
+    bool getBoolValue() noexcept;
+    void setBoolValue(bool boolValue) noexcept;
+    std::string getStringValue() noexcept;
+    void setStringValue(const std::string& stringValue) noexcept;
+    int64_t getBigintValue() noexcept;
+    void setBigintValue(int64_t bigintValue) noexcept;
+    std::optional<std::string> getStringOrUndefined() noexcept;
+    void setStringOrUndefined(const std::optional<std::string>& stringOrUndefined) noexcept;
+    std::optional<std::string> getStringOrNull() noexcept;
+    void setStringOrNull(const std::optional<std::string>& stringOrNull) noexcept;
+    std::optional<std::string> getOptionalString() noexcept;
+    void setOptionalString(const std::optional<std::string>& optionalString) noexcept;
+    std::variant<std::string, double> getSomeVariant() noexcept;
+    void setSomeVariant(const std::variant<std::string, double>& someVariant) noexcept;
 
   public:
     // Methods
-    inline std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> newTestObject() override {
-      auto __result = _swiftPart.newTestObject();
-      return HybridContext::getOrCreate<HybridTestObjectSwiftKotlinSpecSwift>(__result);
-    }
-    inline void simpleFunc() override {
-      _swiftPart.simpleFunc();
-    }
-    inline double addNumbers(double a, double b) override {
-      auto __result = _swiftPart.addNumbers(std::forward<decltype(a)>(a), std::forward<decltype(b)>(b));
-      return __result;
-    }
-    inline std::string addStrings(const std::string& a, const std::string& b) override {
-      auto __result = _swiftPart.addStrings(a, b);
-      return __result;
-    }
-    inline void multipleArguments(double num, const std::string& str, bool boo) override {
-      _swiftPart.multipleArguments(std::forward<decltype(num)>(num), str, std::forward<decltype(boo)>(boo));
-    }
-    inline std::vector<std::string> bounceStrings(const std::vector<std::string>& array) override {
-      auto __result = _swiftPart.bounceStrings(array);
-      return __result;
-    }
-    inline std::vector<double> bounceNumbers(const std::vector<double>& array) override {
-      auto __result = _swiftPart.bounceNumbers(array);
-      return __result;
-    }
-    inline std::vector<Person> bounceStructs(const std::vector<Person>& array) override {
-      auto __result = _swiftPart.bounceStructs(array);
-      return __result;
-    }
-    inline std::vector<Powertrain> bounceEnums(const std::vector<Powertrain>& array) override {
-      auto __result = _swiftPart.bounceEnums(array);
-      return __result;
-    }
-    inline void complexEnumCallback(const std::vector<Powertrain>& array, const std::function<void(const std::vector<Powertrain>& /* array */)>& callback) override {
-      _swiftPart.complexEnumCallback(array, callback);
-    }
-    inline std::shared_ptr<AnyMap> createMap() override {
-      auto __result = _swiftPart.createMap();
-      return __result;
-    }
-    inline std::shared_ptr<AnyMap> mapRoundtrip(const std::shared_ptr<AnyMap>& map) override {
-      auto __result = _swiftPart.mapRoundtrip(map);
-      return __result;
-    }
-    inline double funcThatThrows() override {
-      auto __result = _swiftPart.funcThatThrows();
-      return __result;
-    }
-    inline std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) override {
-      auto __result = _swiftPart.tryOptionalParams(std::forward<decltype(num)>(num), std::forward<decltype(boo)>(boo), str);
-      return __result;
-    }
-    inline std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) override {
-      auto __result = _swiftPart.tryMiddleParam(std::forward<decltype(num)>(num), boo, str);
-      return __result;
-    }
-    inline std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) override {
-      auto __result = _swiftPart.tryOptionalEnum(value);
-      return __result;
-    }
-    inline int64_t calculateFibonacciSync(double value) override {
-      auto __result = _swiftPart.calculateFibonacciSync(std::forward<decltype(value)>(value));
-      return __result;
-    }
-    inline std::future<int64_t> calculateFibonacciAsync(double value) override {
-      auto __result = _swiftPart.calculateFibonacciAsync(std::forward<decltype(value)>(value));
-      return __result.getFuture();
-    }
-    inline std::future<void> wait(double seconds) override {
-      auto __result = _swiftPart.wait(std::forward<decltype(seconds)>(seconds));
-      return __result.getFuture();
-    }
-    inline void callCallback(const std::function<void()>& callback) override {
-      _swiftPart.callCallback(callback);
-    }
-    inline void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) override {
-      _swiftPart.callAll(first, second, third);
-    }
-    inline void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) override {
-      _swiftPart.callWithOptional(value, callback);
-    }
-    inline Car getCar() override {
-      auto __result = _swiftPart.getCar();
-      return __result;
-    }
-    inline bool isCarElectric(const Car& car) override {
-      auto __result = _swiftPart.isCarElectric(car);
-      return __result;
-    }
-    inline std::optional<Person> getDriver(const Car& car) override {
-      auto __result = _swiftPart.getDriver(car);
-      return __result;
-    }
-    inline std::shared_ptr<ArrayBuffer> createArrayBuffer() override {
-      auto __result = _swiftPart.createArrayBuffer();
-      return __result.getArrayBuffer();
-    }
-    inline double getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) override {
-      auto __result = _swiftPart.getBufferLastItem(ArrayBufferHolder(buffer));
-      return __result;
-    }
-    inline void setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) override {
-      _swiftPart.setAllValuesTo(ArrayBufferHolder(buffer), std::forward<decltype(value)>(value));
-    }
-    inline std::shared_ptr<margelo::nitro::image::HybridChildSpec> createChild() override {
-      auto __result = _swiftPart.createChild();
-      return HybridContext::getOrCreate<HybridChildSpecSwift>(__result);
-    }
-    inline std::shared_ptr<margelo::nitro::image::HybridBaseSpec> createBase() override {
-      auto __result = _swiftPart.createBase();
-      return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
-    }
-    inline std::shared_ptr<margelo::nitro::image::HybridBaseSpec> createBaseActualChild() override {
-      auto __result = _swiftPart.createBaseActualChild();
-      return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
-    }
-    inline std::shared_ptr<margelo::nitro::image::HybridChildSpec> bounceChild(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) override {
-      auto __result = _swiftPart.bounceChild(std::dynamic_pointer_cast<HybridChildSpecSwift>(child)->getSwiftPart());
-      return HybridContext::getOrCreate<HybridChildSpecSwift>(__result);
-    }
-    inline std::shared_ptr<margelo::nitro::image::HybridBaseSpec> bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) override {
-      auto __result = _swiftPart.bounceBase(std::dynamic_pointer_cast<HybridBaseSpecSwift>(base)->getSwiftPart());
-      return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
-    }
-    inline std::shared_ptr<margelo::nitro::image::HybridBaseSpec> bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) override {
-      auto __result = _swiftPart.bounceChildBase(std::dynamic_pointer_cast<HybridChildSpecSwift>(child)->getSwiftPart());
-      return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
-    }
-    inline std::shared_ptr<margelo::nitro::image::HybridChildSpec> castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) override {
-      auto __result = _swiftPart.castBase(std::dynamic_pointer_cast<HybridBaseSpecSwift>(base)->getSwiftPart());
-      return HybridContext::getOrCreate<HybridChildSpecSwift>(__result);
-    }
+    std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> newTestObject() override;
+    void simpleFunc() override;
+    double addNumbers(double a, double b) override;
+    std::string addStrings(const std::string& a, const std::string& b) override;
+    void multipleArguments(double num, const std::string& str, bool boo) override;
+    std::vector<std::string> bounceStrings(const std::vector<std::string>& array) override;
+    std::vector<double> bounceNumbers(const std::vector<double>& array) override;
+    std::vector<Person> bounceStructs(const std::vector<Person>& array) override;
+    std::vector<Powertrain> bounceEnums(const std::vector<Powertrain>& array) override;
+    void complexEnumCallback(const std::vector<Powertrain>& array, const std::function<void(const std::vector<Powertrain>& /* array */)>& callback) override;
+    std::shared_ptr<AnyMap> createMap() override;
+    std::shared_ptr<AnyMap> mapRoundtrip(const std::shared_ptr<AnyMap>& map) override;
+    double funcThatThrows() override;
+    std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) override;
+    std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) override;
+    std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) override;
+    int64_t calculateFibonacciSync(double value) override;
+    std::future<int64_t> calculateFibonacciAsync(double value) override;
+    std::future<void> wait(double seconds) override;
+    void callCallback(const std::function<void()>& callback) override;
+    void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) override;
+    void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) override;
+    Car getCar() override;
+    bool isCarElectric(const Car& car) override;
+    std::optional<Person> getDriver(const Car& car) override;
+    std::shared_ptr<ArrayBuffer> createArrayBuffer() override;
+    double getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) override;
+    void setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) override;
+    std::shared_ptr<margelo::nitro::image::HybridChildSpec> createChild() override;
+    std::shared_ptr<margelo::nitro::image::HybridBaseSpec> createBase() override;
+    std::shared_ptr<margelo::nitro::image::HybridBaseSpec> createBaseActualChild() override;
+    std::shared_ptr<margelo::nitro::image::HybridChildSpec> bounceChild(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) override;
+    std::shared_ptr<margelo::nitro::image::HybridBaseSpec> bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) override;
+    std::shared_ptr<margelo::nitro::image::HybridBaseSpec> bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) override;
+    std::shared_ptr<margelo::nitro::image::HybridChildSpec> castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) override;
 
   private:
     NitroImage::HybridTestObjectSwiftKotlinSpecCxx _swiftPart;


### PR DESCRIPTION
Separates implementation and header declaration in the Swift Cxx bridge.

This should fix recursive include issues.