### PR TITLE
feat: Allow SwiftCxx wrappers to be bi-directional by using `unique_ptr`

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -298,7 +298,6 @@ public:
   explicit ${wrapperName}(${actualType}&& func);
 
   ${callFuncReturnType} call(${callCppFuncParamsSignature.join(', ')}) const;
-
   ${actualType} function;
 };
 ${name} create_${name}(void* closureHolder, ${functionPointerParam}, void(*destroy)(void*));
@@ -309,7 +308,6 @@ std::shared_ptr<${wrapperName}> share_${name}(const ${name}& value);
       cxxCode: `
 ${wrapperName}::${wrapperName}(const ${actualType}& func): function(func) {}
 ${wrapperName}::${wrapperName}(${actualType}&& func): function(std::move(func)) {}
-
 ${callFuncReturnType} ${wrapperName}::call(${callCppFuncParamsSignature.join(', ')}) const {
   ${indent(callCppFuncBody, '  ')}
 }

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -391,8 +391,8 @@ ${name}::operator ${actualType}() const {
   return variant;
 }
 size_t ${name}::index() const {
-    return variant.index();
-  }
+  return variant.index();
+}
 ${createFunctions.map((f) => f.cxxImplementationCode).join('\n')}
 ${getFunctions.map((f) => f.cxxImplementationCode).join('\n')}
       `.trim(),

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -258,8 +258,6 @@ ${extraIncludes.join('\n')}
 
 ${includeNitroHeader('HybridContext.hpp')}
 
-#include "${iosModuleName}-Swift-Cxx-Umbrella.hpp"
-
 namespace ${cxxNamespace} {
 
   /**
@@ -303,6 +301,9 @@ namespace ${cxxNamespace} {
 ${createFileMetadataString(`${name.HybridTSpecSwift}.cpp`)}
 
 #include "${name.HybridTSpecSwift}.hpp"
+
+// Include Swift types (especially the ${name.HybridTSpecSwift} Swift class)
+#include "${iosModuleName}-Swift-Cxx-Umbrella.hpp"
 
 namespace ${cxxNamespace} {
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
@@ -11,7 +11,6 @@ namespace margelo::nitro::image::bridge::swift {
 
   Func_void_std__string_Wrapper::Func_void_std__string_Wrapper(const std::function<void(const std::string& /* path */)>& func): function(func) {}
   Func_void_std__string_Wrapper::Func_void_std__string_Wrapper(std::function<void(const std::string& /* path */)>&& func): function(std::move(func)) {}
-  
   void Func_void_std__string_Wrapper::call(std::string path) const {
     function(path);
   }
@@ -201,7 +200,6 @@ namespace margelo::nitro::image::bridge::swift {
   
   Func_std__future_double__Wrapper::Func_std__future_double__Wrapper(const std::function<std::future<double>()>& func): function(func) {}
   Func_std__future_double__Wrapper::Func_std__future_double__Wrapper(std::function<std::future<double>()>&& func): function(std::move(func)) {}
-  
   PromiseHolder<double> Func_std__future_double__Wrapper::call() const {
     auto __result = function();
     return []() -> PromiseHolder<double> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
@@ -223,7 +221,6 @@ namespace margelo::nitro::image::bridge::swift {
   
   Func_std__future_std__string__Wrapper::Func_std__future_std__string__Wrapper(const std::function<std::future<std::string>()>& func): function(func) {}
   Func_std__future_std__string__Wrapper::Func_std__future_std__string__Wrapper(std::function<std::future<std::string>()>&& func): function(std::move(func)) {}
-  
   PromiseHolder<std::string> Func_std__future_std__string__Wrapper::call() const {
     auto __result = function();
     return []() -> PromiseHolder<std::string> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }();
@@ -261,7 +258,6 @@ namespace margelo::nitro::image::bridge::swift {
   
   Func_void_std__vector_Powertrain__Wrapper::Func_void_std__vector_Powertrain__Wrapper(const std::function<void(const std::vector<Powertrain>& /* array */)>& func): function(func) {}
   Func_void_std__vector_Powertrain__Wrapper::Func_void_std__vector_Powertrain__Wrapper(std::function<void(const std::vector<Powertrain>& /* array */)>&& func): function(std::move(func)) {}
-  
   void Func_void_std__vector_Powertrain__Wrapper::call(std::vector<Powertrain> array) const {
     function(array);
   }
@@ -289,7 +285,6 @@ namespace margelo::nitro::image::bridge::swift {
   
   Func_void_Wrapper::Func_void_Wrapper(const std::function<void()>& func): function(func) {}
   Func_void_Wrapper::Func_void_Wrapper(std::function<void()>&& func): function(std::move(func)) {}
-  
   void Func_void_Wrapper::call() const {
     function();
   }
@@ -309,7 +304,6 @@ namespace margelo::nitro::image::bridge::swift {
   
   Func_void_std__optional_double__Wrapper::Func_void_std__optional_double__Wrapper(const std::function<void(std::optional<double> /* maybe */)>& func): function(func) {}
   Func_void_std__optional_double__Wrapper::Func_void_std__optional_double__Wrapper(std::function<void(std::optional<double> /* maybe */)>&& func): function(std::move(func)) {}
-  
   void Func_void_std__optional_double__Wrapper::call(std::optional<double> maybe) const {
     function(maybe);
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
@@ -29,8 +29,8 @@ namespace margelo::nitro::image::bridge::swift {
     return variant;
   }
   size_t std__variant_std__string__double_::index() const {
-      return variant.index();
-    }
+    return variant.index();
+  }
   std__variant_std__string__double_ create_std__variant_std__string__double_(const std::string& value) {
     return std__variant_std__string__double_(value);
   }
@@ -61,8 +61,8 @@ namespace margelo::nitro::image::bridge::swift {
     return variant;
   }
   size_t std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__::index() const {
-      return variant.index();
-    }
+    return variant.index();
+  }
   std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::string& value) {
     return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
   }
@@ -99,8 +99,8 @@ namespace margelo::nitro::image::bridge::swift {
     return variant;
   }
   size_t std__variant_bool__OldEnum_::index() const {
-      return variant.index();
-    }
+    return variant.index();
+  }
   std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(bool value) {
     return std__variant_bool__OldEnum_(value);
   }
@@ -123,8 +123,8 @@ namespace margelo::nitro::image::bridge::swift {
     return variant;
   }
   size_t std__variant_Car__Person_::index() const {
-      return variant.index();
-    }
+    return variant.index();
+  }
   std__variant_Car__Person_ create_std__variant_Car__Person_(const Car& value) {
     return std__variant_Car__Person_(value);
   }
@@ -143,8 +143,8 @@ namespace margelo::nitro::image::bridge::swift {
     return variant;
   }
   size_t std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__::index() const {
-      return variant.index();
-    }
+    return variant.index();
+  }
   std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__ create_std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(const Person& value) {
     return std__variant_Person__std__shared_ptr_margelo__nitro__image__HybridTestObjectCppSpec__(value);
   }
@@ -171,8 +171,8 @@ namespace margelo::nitro::image::bridge::swift {
     return variant;
   }
   size_t std__variant_std__tuple_double__double___std__tuple_double__double__double__::index() const {
-      return variant.index();
-    }
+    return variant.index();
+  }
   std__variant_std__tuple_double__double___std__tuple_double__double__double__ create_std__variant_std__tuple_double__double___std__tuple_double__double__double__(const std::tuple<double, double>& value) {
     return std__variant_std__tuple_double__double___std__tuple_double__double__double__(value);
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -87,7 +87,6 @@ namespace margelo::nitro::image::bridge::swift {
     explicit Func_void_std__string_Wrapper(std::function<void(const std::string& /* path */)>&& func);
   
     void call(std::string path) const;
-  
     std::function<void(const std::string& /* path */)> function;
   };
   Func_void_std__string create_Func_void_std__string(void* closureHolder, void(*call)(void* /* closureHolder */, std::string), void(*destroy)(void*));
@@ -256,7 +255,6 @@ namespace margelo::nitro::image::bridge::swift {
     explicit Func_std__future_double__Wrapper(std::function<std::future<double>()>&& func);
   
     PromiseHolder<double> call() const;
-  
     std::function<std::future<double>()> function;
   };
   Func_std__future_double_ create_Func_std__future_double_(void* closureHolder, PromiseHolder<double>(*call)(void* /* closureHolder */), void(*destroy)(void*));
@@ -281,7 +279,6 @@ namespace margelo::nitro::image::bridge::swift {
     explicit Func_std__future_std__string__Wrapper(std::function<std::future<std::string>()>&& func);
   
     PromiseHolder<std::string> call() const;
-  
     std::function<std::future<std::string>()> function;
   };
   Func_std__future_std__string_ create_Func_std__future_std__string_(void* closureHolder, PromiseHolder<std::string>(*call)(void* /* closureHolder */), void(*destroy)(void*));
@@ -324,7 +321,6 @@ namespace margelo::nitro::image::bridge::swift {
     explicit Func_void_std__vector_Powertrain__Wrapper(std::function<void(const std::vector<Powertrain>& /* array */)>&& func);
   
     void call(std::vector<Powertrain> array) const;
-  
     std::function<void(const std::vector<Powertrain>& /* array */)> function;
   };
   Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* closureHolder, void(*call)(void* /* closureHolder */, std::vector<Powertrain>), void(*destroy)(void*));
@@ -361,7 +357,6 @@ namespace margelo::nitro::image::bridge::swift {
     explicit Func_void_Wrapper(std::function<void()>&& func);
   
     void call() const;
-  
     std::function<void()> function;
   };
   Func_void create_Func_void(void* closureHolder, void(*call)(void* /* closureHolder */), void(*destroy)(void*));
@@ -386,7 +381,6 @@ namespace margelo::nitro::image::bridge::swift {
     explicit Func_void_std__optional_double__Wrapper(std::function<void(std::optional<double> /* maybe */)>&& func);
   
     void call(std::optional<double> maybe) const;
-  
     std::function<void(std::optional<double> /* maybe */)> function;
   };
   Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* closureHolder, void(*call)(void* /* closureHolder */, std::optional<double>), void(*destroy)(void*));

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.cpp
@@ -7,6 +7,9 @@
 
 #include "HybridBaseSpecSwift.hpp"
 
+// Include Swift types (especially the HybridBaseSpecSwift Swift class)
+#include "NitroImage-Swift-Cxx-Umbrella.hpp"
+
 namespace margelo::nitro::image {
 
 HybridBaseSpecSwift::HybridBaseSpecSwift(const NitroImage::HybridBaseSpecCxx& swiftPart):

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.cpp
@@ -11,19 +11,19 @@ namespace margelo::nitro::image {
 
 HybridBaseSpecSwift::HybridBaseSpecSwift(const NitroImage::HybridBaseSpecCxx& swiftPart):
   HybridObject(HybridBaseSpec::TAG),
-  _swiftPart(swiftPart) { }
+  _swiftPart(std::make_unique<NitroImage::HybridBaseSpecCxx>(swiftPart)) { }
 
 NitroImage::HybridBaseSpecCxx HybridBaseSpecSwift::getSwiftPart() noexcept {
-  return _swiftPart;
+  return *_swiftPart;
 }
 
 size_t HybridBaseSpecSwift::getExternalMemorySize() noexcept {
-  return _swiftPart.getMemorySize();
+  return _swiftPart->getMemorySize();
 }
 
 // Properties
 double HybridBaseSpecSwift::getBaseValue() noexcept {
-  return _swiftPart.getBaseValue();
+  return _swiftPart->getBaseValue();
 }
 
 // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "HybridBaseSpec.hpp"
+#include <memory>
 
 // Forward declaration of `HybridBaseSpecCxx` to properly resolve imports.
 namespace NitroImage { class HybridBaseSpecCxx; }
@@ -58,7 +59,7 @@ namespace margelo::nitro::image {
     
 
   private:
-    NitroImage::HybridBaseSpecCxx _swiftPart;
+    std::unique_ptr<NitroImage::HybridBaseSpecCxx> _swiftPart;
   };
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridBaseSpecSwift.hpp
@@ -23,8 +23,6 @@ namespace NitroImage { class HybridBaseSpecCxx; }
 #error NitroModules cannot be found! Are you sure you installed NitroModules properly?
 #endif
 
-#include "NitroImage-Swift-Cxx-Umbrella.hpp"
-
 namespace margelo::nitro::image {
 
   /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.cpp
@@ -7,6 +7,9 @@
 
 #include "HybridChildSpecSwift.hpp"
 
+// Include Swift types (especially the HybridChildSpecSwift Swift class)
+#include "NitroImage-Swift-Cxx-Umbrella.hpp"
+
 namespace margelo::nitro::image {
 
 HybridChildSpecSwift::HybridChildSpecSwift(const NitroImage::HybridChildSpecCxx& swiftPart):

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.cpp
@@ -12,19 +12,19 @@ namespace margelo::nitro::image {
 HybridChildSpecSwift::HybridChildSpecSwift(const NitroImage::HybridChildSpecCxx& swiftPart):
   HybridObject(HybridChildSpec::TAG),
       HybridBaseSpecSwift(swiftPart),
-  _swiftPart(swiftPart) { }
+  _swiftPart(std::make_unique<NitroImage::HybridChildSpecCxx>(swiftPart)) { }
 
 NitroImage::HybridChildSpecCxx HybridChildSpecSwift::getSwiftPart() noexcept {
-  return _swiftPart;
+  return *_swiftPart;
 }
 
 size_t HybridChildSpecSwift::getExternalMemorySize() noexcept {
-  return _swiftPart.getMemorySize();
+  return _swiftPart->getMemorySize();
 }
 
 // Properties
 double HybridChildSpecSwift::getChildValue() noexcept {
-  return _swiftPart.getChildValue();
+  return _swiftPart->getChildValue();
 }
 
 // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
@@ -24,8 +24,6 @@ namespace margelo::nitro::image { class HybridBaseSpecSwift; }
 #error NitroModules cannot be found! Are you sure you installed NitroModules properly?
 #endif
 
-#include "NitroImage-Swift-Cxx-Umbrella.hpp"
-
 namespace margelo::nitro::image {
 
   /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "HybridChildSpec.hpp"
+#include <memory>
 
 // Forward declaration of `HybridChildSpecCxx` to properly resolve imports.
 namespace NitroImage { class HybridChildSpecCxx; }
@@ -59,7 +60,7 @@ namespace margelo::nitro::image {
     
 
   private:
-    NitroImage::HybridChildSpecCxx _swiftPart;
+    std::unique_ptr<NitroImage::HybridChildSpecCxx> _swiftPart;
   };
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.cpp
@@ -7,6 +7,9 @@
 
 #include "HybridImageFactorySpecSwift.hpp"
 
+// Include Swift types (especially the HybridImageFactorySpecSwift Swift class)
+#include "NitroImage-Swift-Cxx-Umbrella.hpp"
+
 namespace margelo::nitro::image {
 
 HybridImageFactorySpecSwift::HybridImageFactorySpecSwift(const NitroImage::HybridImageFactorySpecCxx& swiftPart):

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.cpp
@@ -11,14 +11,14 @@ namespace margelo::nitro::image {
 
 HybridImageFactorySpecSwift::HybridImageFactorySpecSwift(const NitroImage::HybridImageFactorySpecCxx& swiftPart):
   HybridObject(HybridImageFactorySpec::TAG),
-  _swiftPart(swiftPart) { }
+  _swiftPart(std::make_unique<NitroImage::HybridImageFactorySpecCxx>(swiftPart)) { }
 
 NitroImage::HybridImageFactorySpecCxx HybridImageFactorySpecSwift::getSwiftPart() noexcept {
-  return _swiftPart;
+  return *_swiftPart;
 }
 
 size_t HybridImageFactorySpecSwift::getExternalMemorySize() noexcept {
-  return _swiftPart.getMemorySize();
+  return _swiftPart->getMemorySize();
 }
 
 // Properties
@@ -26,19 +26,19 @@ size_t HybridImageFactorySpecSwift::getExternalMemorySize() noexcept {
 
 // Methods
 std::shared_ptr<margelo::nitro::image::HybridImageSpec> HybridImageFactorySpecSwift::loadImageFromFile(const std::string& path) {
-  auto __result = _swiftPart.loadImageFromFile(path);
+  auto __result = _swiftPart->loadImageFromFile(path);
   return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
 }
 std::shared_ptr<margelo::nitro::image::HybridImageSpec> HybridImageFactorySpecSwift::loadImageFromURL(const std::string& path) {
-  auto __result = _swiftPart.loadImageFromURL(path);
+  auto __result = _swiftPart->loadImageFromURL(path);
   return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
 }
 std::shared_ptr<margelo::nitro::image::HybridImageSpec> HybridImageFactorySpecSwift::loadImageFromSystemName(const std::string& path) {
-  auto __result = _swiftPart.loadImageFromSystemName(path);
+  auto __result = _swiftPart->loadImageFromSystemName(path);
   return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
 }
 std::shared_ptr<margelo::nitro::image::HybridImageSpec> HybridImageFactorySpecSwift::bounceBack(const std::shared_ptr<margelo::nitro::image::HybridImageSpec>& image) {
-  auto __result = _swiftPart.bounceBack(std::dynamic_pointer_cast<HybridImageSpecSwift>(image)->getSwiftPart());
+  auto __result = _swiftPart->bounceBack(std::dynamic_pointer_cast<HybridImageSpecSwift>(image)->getSwiftPart());
   return HybridContext::getOrCreate<HybridImageSpecSwift>(__result);
 }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "HybridImageFactorySpec.hpp"
+#include <memory>
 
 // Forward declaration of `HybridImageFactorySpecCxx` to properly resolve imports.
 namespace NitroImage { class HybridImageFactorySpecCxx; }
@@ -67,7 +68,7 @@ namespace margelo::nitro::image {
     std::shared_ptr<margelo::nitro::image::HybridImageSpec> bounceBack(const std::shared_ptr<margelo::nitro::image::HybridImageSpec>& image) override;
 
   private:
-    NitroImage::HybridImageFactorySpecCxx _swiftPart;
+    std::unique_ptr<NitroImage::HybridImageFactorySpecCxx> _swiftPart;
   };
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageFactorySpecSwift.hpp
@@ -29,8 +29,6 @@ namespace margelo::nitro::image { class HybridImageSpecSwift; }
 #error NitroModules cannot be found! Are you sure you installed NitroModules properly?
 #endif
 
-#include "NitroImage-Swift-Cxx-Umbrella.hpp"
-
 namespace margelo::nitro::image {
 
   /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.cpp
@@ -11,39 +11,39 @@ namespace margelo::nitro::image {
 
 HybridImageSpecSwift::HybridImageSpecSwift(const NitroImage::HybridImageSpecCxx& swiftPart):
   HybridObject(HybridImageSpec::TAG),
-  _swiftPart(swiftPart) { }
+  _swiftPart(std::make_unique<NitroImage::HybridImageSpecCxx>(swiftPart)) { }
 
 NitroImage::HybridImageSpecCxx HybridImageSpecSwift::getSwiftPart() noexcept {
-  return _swiftPart;
+  return *_swiftPart;
 }
 
 size_t HybridImageSpecSwift::getExternalMemorySize() noexcept {
-  return _swiftPart.getMemorySize();
+  return _swiftPart->getMemorySize();
 }
 
 // Properties
 ImageSize HybridImageSpecSwift::getSize() noexcept {
-  auto __result = _swiftPart.getSize();
+  auto __result = _swiftPart->getSize();
   return __result;
 }
 PixelFormat HybridImageSpecSwift::getPixelFormat() noexcept {
-  auto __result = _swiftPart.getPixelFormat();
+  auto __result = _swiftPart->getPixelFormat();
   return static_cast<PixelFormat>(__result);
 }
 double HybridImageSpecSwift::getSomeSettableProp() noexcept {
-  return _swiftPart.getSomeSettableProp();
+  return _swiftPart->getSomeSettableProp();
 }
 void HybridImageSpecSwift::setSomeSettableProp(double someSettableProp) noexcept {
-  _swiftPart.setSomeSettableProp(std::forward<decltype(someSettableProp)>(someSettableProp));
+  _swiftPart->setSomeSettableProp(std::forward<decltype(someSettableProp)>(someSettableProp));
 }
 
 // Methods
 double HybridImageSpecSwift::toArrayBuffer(ImageFormat format) {
-  auto __result = _swiftPart.toArrayBuffer(static_cast<int>(format));
+  auto __result = _swiftPart->toArrayBuffer(static_cast<int>(format));
   return __result;
 }
 void HybridImageSpecSwift::saveToFile(const std::string& path, const std::function<void(const std::string& /* path */)>& onFinished) {
-  _swiftPart.saveToFile(path, onFinished);
+  _swiftPart->saveToFile(path, onFinished);
 }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.cpp
@@ -7,6 +7,9 @@
 
 #include "HybridImageSpecSwift.hpp"
 
+// Include Swift types (especially the HybridImageSpecSwift Swift class)
+#include "NitroImage-Swift-Cxx-Umbrella.hpp"
+
 namespace margelo::nitro::image {
 
 HybridImageSpecSwift::HybridImageSpecSwift(const NitroImage::HybridImageSpecCxx& swiftPart):

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "HybridImageSpec.hpp"
+#include <memory>
 
 // Forward declaration of `HybridImageSpecCxx` to properly resolve imports.
 namespace NitroImage { class HybridImageSpecCxx; }
@@ -71,7 +72,7 @@ namespace margelo::nitro::image {
     void saveToFile(const std::string& path, const std::function<void(const std::string& /* path */)>& onFinished) override;
 
   private:
-    NitroImage::HybridImageSpecCxx _swiftPart;
+    std::unique_ptr<NitroImage::HybridImageSpecCxx> _swiftPart;
   };
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridImageSpecSwift.hpp
@@ -32,8 +32,6 @@ namespace margelo::nitro::image { enum class ImageFormat; }
 #error NitroModules cannot be found! Are you sure you installed NitroModules properly?
 #endif
 
-#include "NitroImage-Swift-Cxx-Umbrella.hpp"
-
 namespace margelo::nitro::image {
 
   /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.cpp
@@ -11,207 +11,207 @@ namespace margelo::nitro::image {
 
 HybridTestObjectSwiftKotlinSpecSwift::HybridTestObjectSwiftKotlinSpecSwift(const NitroImage::HybridTestObjectSwiftKotlinSpecCxx& swiftPart):
   HybridObject(HybridTestObjectSwiftKotlinSpec::TAG),
-  _swiftPart(swiftPart) { }
+  _swiftPart(std::make_unique<NitroImage::HybridTestObjectSwiftKotlinSpecCxx>(swiftPart)) { }
 
 NitroImage::HybridTestObjectSwiftKotlinSpecCxx HybridTestObjectSwiftKotlinSpecSwift::getSwiftPart() noexcept {
-  return _swiftPart;
+  return *_swiftPart;
 }
 
 size_t HybridTestObjectSwiftKotlinSpecSwift::getExternalMemorySize() noexcept {
-  return _swiftPart.getMemorySize();
+  return _swiftPart->getMemorySize();
 }
 
 // Properties
 std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> HybridTestObjectSwiftKotlinSpecSwift::getThisObject() noexcept {
-  auto __result = _swiftPart.getThisObject();
+  auto __result = _swiftPart->getThisObject();
   return HybridContext::getOrCreate<HybridTestObjectSwiftKotlinSpecSwift>(__result);
 }
 double HybridTestObjectSwiftKotlinSpecSwift::getNumberValue() noexcept {
-  return _swiftPart.getNumberValue();
+  return _swiftPart->getNumberValue();
 }
 void HybridTestObjectSwiftKotlinSpecSwift::setNumberValue(double numberValue) noexcept {
-  _swiftPart.setNumberValue(std::forward<decltype(numberValue)>(numberValue));
+  _swiftPart->setNumberValue(std::forward<decltype(numberValue)>(numberValue));
 }
 bool HybridTestObjectSwiftKotlinSpecSwift::getBoolValue() noexcept {
-  return _swiftPart.getBoolValue();
+  return _swiftPart->getBoolValue();
 }
 void HybridTestObjectSwiftKotlinSpecSwift::setBoolValue(bool boolValue) noexcept {
-  _swiftPart.setBoolValue(std::forward<decltype(boolValue)>(boolValue));
+  _swiftPart->setBoolValue(std::forward<decltype(boolValue)>(boolValue));
 }
 std::string HybridTestObjectSwiftKotlinSpecSwift::getStringValue() noexcept {
-  auto __result = _swiftPart.getStringValue();
+  auto __result = _swiftPart->getStringValue();
   return __result;
 }
 void HybridTestObjectSwiftKotlinSpecSwift::setStringValue(const std::string& stringValue) noexcept {
-  _swiftPart.setStringValue(stringValue);
+  _swiftPart->setStringValue(stringValue);
 }
 int64_t HybridTestObjectSwiftKotlinSpecSwift::getBigintValue() noexcept {
-  return _swiftPart.getBigintValue();
+  return _swiftPart->getBigintValue();
 }
 void HybridTestObjectSwiftKotlinSpecSwift::setBigintValue(int64_t bigintValue) noexcept {
-  _swiftPart.setBigintValue(std::forward<decltype(bigintValue)>(bigintValue));
+  _swiftPart->setBigintValue(std::forward<decltype(bigintValue)>(bigintValue));
 }
 std::optional<std::string> HybridTestObjectSwiftKotlinSpecSwift::getStringOrUndefined() noexcept {
-  auto __result = _swiftPart.getStringOrUndefined();
+  auto __result = _swiftPart->getStringOrUndefined();
   return __result;
 }
 void HybridTestObjectSwiftKotlinSpecSwift::setStringOrUndefined(const std::optional<std::string>& stringOrUndefined) noexcept {
-  _swiftPart.setStringOrUndefined(stringOrUndefined);
+  _swiftPart->setStringOrUndefined(stringOrUndefined);
 }
 std::optional<std::string> HybridTestObjectSwiftKotlinSpecSwift::getStringOrNull() noexcept {
-  auto __result = _swiftPart.getStringOrNull();
+  auto __result = _swiftPart->getStringOrNull();
   return __result;
 }
 void HybridTestObjectSwiftKotlinSpecSwift::setStringOrNull(const std::optional<std::string>& stringOrNull) noexcept {
-  _swiftPart.setStringOrNull(stringOrNull);
+  _swiftPart->setStringOrNull(stringOrNull);
 }
 std::optional<std::string> HybridTestObjectSwiftKotlinSpecSwift::getOptionalString() noexcept {
-  auto __result = _swiftPart.getOptionalString();
+  auto __result = _swiftPart->getOptionalString();
   return __result;
 }
 void HybridTestObjectSwiftKotlinSpecSwift::setOptionalString(const std::optional<std::string>& optionalString) noexcept {
-  _swiftPart.setOptionalString(optionalString);
+  _swiftPart->setOptionalString(optionalString);
 }
 std::variant<std::string, double> HybridTestObjectSwiftKotlinSpecSwift::getSomeVariant() noexcept {
-  auto __result = _swiftPart.getSomeVariant();
+  auto __result = _swiftPart->getSomeVariant();
   return __result;
 }
 void HybridTestObjectSwiftKotlinSpecSwift::setSomeVariant(const std::variant<std::string, double>& someVariant) noexcept {
-  _swiftPart.setSomeVariant(someVariant);
+  _swiftPart->setSomeVariant(someVariant);
 }
 
 // Methods
 std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> HybridTestObjectSwiftKotlinSpecSwift::newTestObject() {
-  auto __result = _swiftPart.newTestObject();
+  auto __result = _swiftPart->newTestObject();
   return HybridContext::getOrCreate<HybridTestObjectSwiftKotlinSpecSwift>(__result);
 }
 void HybridTestObjectSwiftKotlinSpecSwift::simpleFunc() {
-  _swiftPart.simpleFunc();
+  _swiftPart->simpleFunc();
 }
 double HybridTestObjectSwiftKotlinSpecSwift::addNumbers(double a, double b) {
-  auto __result = _swiftPart.addNumbers(std::forward<decltype(a)>(a), std::forward<decltype(b)>(b));
+  auto __result = _swiftPart->addNumbers(std::forward<decltype(a)>(a), std::forward<decltype(b)>(b));
   return __result;
 }
 std::string HybridTestObjectSwiftKotlinSpecSwift::addStrings(const std::string& a, const std::string& b) {
-  auto __result = _swiftPart.addStrings(a, b);
+  auto __result = _swiftPart->addStrings(a, b);
   return __result;
 }
 void HybridTestObjectSwiftKotlinSpecSwift::multipleArguments(double num, const std::string& str, bool boo) {
-  _swiftPart.multipleArguments(std::forward<decltype(num)>(num), str, std::forward<decltype(boo)>(boo));
+  _swiftPart->multipleArguments(std::forward<decltype(num)>(num), str, std::forward<decltype(boo)>(boo));
 }
 std::vector<std::string> HybridTestObjectSwiftKotlinSpecSwift::bounceStrings(const std::vector<std::string>& array) {
-  auto __result = _swiftPart.bounceStrings(array);
+  auto __result = _swiftPart->bounceStrings(array);
   return __result;
 }
 std::vector<double> HybridTestObjectSwiftKotlinSpecSwift::bounceNumbers(const std::vector<double>& array) {
-  auto __result = _swiftPart.bounceNumbers(array);
+  auto __result = _swiftPart->bounceNumbers(array);
   return __result;
 }
 std::vector<Person> HybridTestObjectSwiftKotlinSpecSwift::bounceStructs(const std::vector<Person>& array) {
-  auto __result = _swiftPart.bounceStructs(array);
+  auto __result = _swiftPart->bounceStructs(array);
   return __result;
 }
 std::vector<Powertrain> HybridTestObjectSwiftKotlinSpecSwift::bounceEnums(const std::vector<Powertrain>& array) {
-  auto __result = _swiftPart.bounceEnums(array);
+  auto __result = _swiftPart->bounceEnums(array);
   return __result;
 }
 void HybridTestObjectSwiftKotlinSpecSwift::complexEnumCallback(const std::vector<Powertrain>& array, const std::function<void(const std::vector<Powertrain>& /* array */)>& callback) {
-  _swiftPart.complexEnumCallback(array, callback);
+  _swiftPart->complexEnumCallback(array, callback);
 }
 std::shared_ptr<AnyMap> HybridTestObjectSwiftKotlinSpecSwift::createMap() {
-  auto __result = _swiftPart.createMap();
+  auto __result = _swiftPart->createMap();
   return __result;
 }
 std::shared_ptr<AnyMap> HybridTestObjectSwiftKotlinSpecSwift::mapRoundtrip(const std::shared_ptr<AnyMap>& map) {
-  auto __result = _swiftPart.mapRoundtrip(map);
+  auto __result = _swiftPart->mapRoundtrip(map);
   return __result;
 }
 double HybridTestObjectSwiftKotlinSpecSwift::funcThatThrows() {
-  auto __result = _swiftPart.funcThatThrows();
+  auto __result = _swiftPart->funcThatThrows();
   return __result;
 }
 std::string HybridTestObjectSwiftKotlinSpecSwift::tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) {
-  auto __result = _swiftPart.tryOptionalParams(std::forward<decltype(num)>(num), std::forward<decltype(boo)>(boo), str);
+  auto __result = _swiftPart->tryOptionalParams(std::forward<decltype(num)>(num), std::forward<decltype(boo)>(boo), str);
   return __result;
 }
 std::string HybridTestObjectSwiftKotlinSpecSwift::tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) {
-  auto __result = _swiftPart.tryMiddleParam(std::forward<decltype(num)>(num), boo, str);
+  auto __result = _swiftPart->tryMiddleParam(std::forward<decltype(num)>(num), boo, str);
   return __result;
 }
 std::optional<Powertrain> HybridTestObjectSwiftKotlinSpecSwift::tryOptionalEnum(std::optional<Powertrain> value) {
-  auto __result = _swiftPart.tryOptionalEnum(value);
+  auto __result = _swiftPart->tryOptionalEnum(value);
   return __result;
 }
 int64_t HybridTestObjectSwiftKotlinSpecSwift::calculateFibonacciSync(double value) {
-  auto __result = _swiftPart.calculateFibonacciSync(std::forward<decltype(value)>(value));
+  auto __result = _swiftPart->calculateFibonacciSync(std::forward<decltype(value)>(value));
   return __result;
 }
 std::future<int64_t> HybridTestObjectSwiftKotlinSpecSwift::calculateFibonacciAsync(double value) {
-  auto __result = _swiftPart.calculateFibonacciAsync(std::forward<decltype(value)>(value));
+  auto __result = _swiftPart->calculateFibonacciAsync(std::forward<decltype(value)>(value));
   return __result.getFuture();
 }
 std::future<void> HybridTestObjectSwiftKotlinSpecSwift::wait(double seconds) {
-  auto __result = _swiftPart.wait(std::forward<decltype(seconds)>(seconds));
+  auto __result = _swiftPart->wait(std::forward<decltype(seconds)>(seconds));
   return __result.getFuture();
 }
 void HybridTestObjectSwiftKotlinSpecSwift::callCallback(const std::function<void()>& callback) {
-  _swiftPart.callCallback(callback);
+  _swiftPart->callCallback(callback);
 }
 void HybridTestObjectSwiftKotlinSpecSwift::callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) {
-  _swiftPart.callAll(first, second, third);
+  _swiftPart->callAll(first, second, third);
 }
 void HybridTestObjectSwiftKotlinSpecSwift::callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) {
-  _swiftPart.callWithOptional(value, callback);
+  _swiftPart->callWithOptional(value, callback);
 }
 Car HybridTestObjectSwiftKotlinSpecSwift::getCar() {
-  auto __result = _swiftPart.getCar();
+  auto __result = _swiftPart->getCar();
   return __result;
 }
 bool HybridTestObjectSwiftKotlinSpecSwift::isCarElectric(const Car& car) {
-  auto __result = _swiftPart.isCarElectric(car);
+  auto __result = _swiftPart->isCarElectric(car);
   return __result;
 }
 std::optional<Person> HybridTestObjectSwiftKotlinSpecSwift::getDriver(const Car& car) {
-  auto __result = _swiftPart.getDriver(car);
+  auto __result = _swiftPart->getDriver(car);
   return __result;
 }
 std::shared_ptr<ArrayBuffer> HybridTestObjectSwiftKotlinSpecSwift::createArrayBuffer() {
-  auto __result = _swiftPart.createArrayBuffer();
+  auto __result = _swiftPart->createArrayBuffer();
   return __result.getArrayBuffer();
 }
 double HybridTestObjectSwiftKotlinSpecSwift::getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) {
-  auto __result = _swiftPart.getBufferLastItem(ArrayBufferHolder(buffer));
+  auto __result = _swiftPart->getBufferLastItem(ArrayBufferHolder(buffer));
   return __result;
 }
 void HybridTestObjectSwiftKotlinSpecSwift::setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) {
-  _swiftPart.setAllValuesTo(ArrayBufferHolder(buffer), std::forward<decltype(value)>(value));
+  _swiftPart->setAllValuesTo(ArrayBufferHolder(buffer), std::forward<decltype(value)>(value));
 }
 std::shared_ptr<margelo::nitro::image::HybridChildSpec> HybridTestObjectSwiftKotlinSpecSwift::createChild() {
-  auto __result = _swiftPart.createChild();
+  auto __result = _swiftPart->createChild();
   return HybridContext::getOrCreate<HybridChildSpecSwift>(__result);
 }
 std::shared_ptr<margelo::nitro::image::HybridBaseSpec> HybridTestObjectSwiftKotlinSpecSwift::createBase() {
-  auto __result = _swiftPart.createBase();
+  auto __result = _swiftPart->createBase();
   return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
 }
 std::shared_ptr<margelo::nitro::image::HybridBaseSpec> HybridTestObjectSwiftKotlinSpecSwift::createBaseActualChild() {
-  auto __result = _swiftPart.createBaseActualChild();
+  auto __result = _swiftPart->createBaseActualChild();
   return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
 }
 std::shared_ptr<margelo::nitro::image::HybridChildSpec> HybridTestObjectSwiftKotlinSpecSwift::bounceChild(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) {
-  auto __result = _swiftPart.bounceChild(std::dynamic_pointer_cast<HybridChildSpecSwift>(child)->getSwiftPart());
+  auto __result = _swiftPart->bounceChild(std::dynamic_pointer_cast<HybridChildSpecSwift>(child)->getSwiftPart());
   return HybridContext::getOrCreate<HybridChildSpecSwift>(__result);
 }
 std::shared_ptr<margelo::nitro::image::HybridBaseSpec> HybridTestObjectSwiftKotlinSpecSwift::bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) {
-  auto __result = _swiftPart.bounceBase(std::dynamic_pointer_cast<HybridBaseSpecSwift>(base)->getSwiftPart());
+  auto __result = _swiftPart->bounceBase(std::dynamic_pointer_cast<HybridBaseSpecSwift>(base)->getSwiftPart());
   return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
 }
 std::shared_ptr<margelo::nitro::image::HybridBaseSpec> HybridTestObjectSwiftKotlinSpecSwift::bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) {
-  auto __result = _swiftPart.bounceChildBase(std::dynamic_pointer_cast<HybridChildSpecSwift>(child)->getSwiftPart());
+  auto __result = _swiftPart->bounceChildBase(std::dynamic_pointer_cast<HybridChildSpecSwift>(child)->getSwiftPart());
   return HybridContext::getOrCreate<HybridBaseSpecSwift>(__result);
 }
 std::shared_ptr<margelo::nitro::image::HybridChildSpec> HybridTestObjectSwiftKotlinSpecSwift::castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) {
-  auto __result = _swiftPart.castBase(std::dynamic_pointer_cast<HybridBaseSpecSwift>(base)->getSwiftPart());
+  auto __result = _swiftPart->castBase(std::dynamic_pointer_cast<HybridBaseSpecSwift>(base)->getSwiftPart());
   return HybridContext::getOrCreate<HybridChildSpecSwift>(__result);
 }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.cpp
@@ -7,6 +7,9 @@
 
 #include "HybridTestObjectSwiftKotlinSpecSwift.hpp"
 
+// Include Swift types (especially the HybridTestObjectSwiftKotlinSpecSwift Swift class)
+#include "NitroImage-Swift-Cxx-Umbrella.hpp"
+
 namespace margelo::nitro::image {
 
 HybridTestObjectSwiftKotlinSpecSwift::HybridTestObjectSwiftKotlinSpecSwift(const NitroImage::HybridTestObjectSwiftKotlinSpecCxx& swiftPart):

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "HybridTestObjectSwiftKotlinSpec.hpp"
+#include <memory>
 
 // Forward declaration of `HybridTestObjectSwiftKotlinSpecCxx` to properly resolve imports.
 namespace NitroImage { class HybridTestObjectSwiftKotlinSpecCxx; }
@@ -150,7 +151,7 @@ namespace margelo::nitro::image {
     std::shared_ptr<margelo::nitro::image::HybridChildSpec> castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) override;
 
   private:
-    NitroImage::HybridTestObjectSwiftKotlinSpecCxx _swiftPart;
+    std::unique_ptr<NitroImage::HybridTestObjectSwiftKotlinSpecCxx> _swiftPart;
   };
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -65,8 +65,6 @@ namespace margelo::nitro::image { class HybridBaseSpecSwift; }
 #error NitroModules cannot be found! Are you sure you installed NitroModules properly?
 #endif
 
-#include "NitroImage-Swift-Cxx-Umbrella.hpp"
-
 namespace margelo::nitro::image {
 
   /**


### PR DESCRIPTION
Makes the memory layout of a SwiftCxx wrapper known at compile-time, without the need for forward-declaring anything.
