### PR TITLE
feat: Prettify Prototype names

### DIFF
--- a/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
+++ b/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
@@ -31,7 +31,8 @@ jsi::Value HybridObjectPrototype::createPrototype(jsi::Runtime& runtime, const s
 
   // 2. We didn't find the given prototype in cache (either it's a new prototype, or a new runtime),
   //    so we need to create it. First, we need some helper methods from JS
-  Logger::log(LogLevel::Info, TAG, "Creating new JS prototype for C++ instance type \"%s\"...", prototype->getNativeInstanceId().name());
+  std::string typeName = TypeInfo::getFriendlyTypename(prototype->getNativeInstanceId(), true);
+  Logger::log(LogLevel::Info, TAG, "Creating new JS prototype for C++ instance type \"%s\"...", typeName.c_str());
   jsi::Object objectConstructor = runtime.global().getPropertyAsObject(runtime, "Object");
   jsi::Function objectCreate = objectConstructor.getPropertyAsFunction(runtime, "create");
   jsi::Function objectDefineProperty = objectConstructor.getPropertyAsFunction(runtime, "defineProperty");
@@ -71,8 +72,8 @@ jsi::Value HybridObjectPrototype::createPrototype(jsi::Runtime& runtime, const s
 
   // 7. In DEBUG, add a __type info to the prototype object.
 #ifdef NITRO_DEBUG
-  auto typeName = "Prototype<" + std::string(prototype->getNativeInstanceId().name()) + ">";
-  cachedObject->setProperty(runtime, "__type", jsi::String::createFromUtf8(runtime, typeName));
+  auto prototypeName = "Prototype<" + typeName + ">";
+  cachedObject->setProperty(runtime, "__type", jsi::String::createFromUtf8(runtime, prototypeName));
 #endif
 
   // 8. Return it!


### PR DESCRIPTION
Before:

```
 (NOBRIDGE) LOG  Prototype chain of Child:
 (NOBRIDGE) LOG    NativeState<Child> (1 props)
 (NOBRIDGE) LOG     ∟ Prototype<margelo::nitro::image::HybridChildSpec> (2 props)
 (NOBRIDGE) LOG        ∟ Prototype<margelo::nitro::image::HybridBaseSpec> (2 props)
 (NOBRIDGE) LOG           ∟ Prototype<margelo::nitro::HybridObject> (5 props)
 (NOBRIDGE) LOG              ∟ {} (0 props)
 (NOBRIDGE) LOG                 ∟ {} (0 props)
```

After:

```
 (NOBRIDGE) LOG  Prototype chain of Child:
 (NOBRIDGE) LOG    NativeState<Child> (1 props)
 (NOBRIDGE) LOG     ∟ Prototype<HybridChildSpec> (2 props)
 (NOBRIDGE) LOG        ∟ Prototype<HybridBaseSpec> (2 props)
 (NOBRIDGE) LOG           ∟ Prototype<HybridObject> (5 props)
 (NOBRIDGE) LOG              ∟ {} (0 props)
 (NOBRIDGE) LOG                 ∟ {} (0 props)
```