### PR TITLE
fix: Also run bridge conversion in `std::optional` type helper

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -211,6 +211,22 @@ export function getTests(
         .didNotThrow()
         .equals(undefined)
     ),
+    createTest('get optionalArray (== undefined)', () =>
+      it(() => {
+        testObject.optionalArray = undefined
+        return testObject.optionalArray
+      })
+        .didNotThrow()
+        .equals(undefined)
+    ),
+    createTest('get optionalArray (== ["hello", "world"])', () =>
+      it(() => {
+        testObject.optionalArray = ['hello', 'world']
+        return testObject.optionalArray
+      })
+        .didNotThrow()
+        .equals(['hello', 'world'])
+    ),
 
     // Test basic functions
     createTest('addNumbers(5, 13) = 18', () =>

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -46,7 +46,7 @@ export function createSwiftCxxHelpers(type: Type): SwiftCxxHelper | undefined {
  */
 function createCxxOptionalSwiftHelper(type: OptionalType): SwiftCxxHelper {
   const actualType = type.getCode('c++')
-  const bridgedType = new SwiftCxxBridgedType(type)
+  const wrappedBridge = new SwiftCxxBridgedType(type.wrappingType, true)
   const name = escapeCppName(actualType)
   return {
     cxxType: actualType,
@@ -58,15 +58,15 @@ function createCxxOptionalSwiftHelper(type: OptionalType): SwiftCxxHelper {
         space: 'system',
         language: 'c++',
       },
-      ...bridgedType.getRequiredImports(),
+      ...wrappedBridge.getRequiredImports(),
     ],
     cxxCode: `
 /**
  * Specialized version of \`${escapeComments(actualType)}\`.
  */
 using ${name} = ${actualType};
-inline ${actualType} create_${name}(const ${type.wrappingType.getCode('c++')}& value) {
-  return ${actualType}(value);
+inline ${actualType} create_${name}(const ${wrappedBridge.getTypeCode('c++')}& value) {
+  return ${actualType}(${indent(wrappedBridge.parseFromSwiftToCpp('value', 'c++'), '    ')});
 }
     `.trim(),
   }

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -20,6 +20,7 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
     override val thisObject: HybridTestObjectSwiftKotlinSpec
         get() = this
     override var someVariant: Variant_String_Double = Variant_String_Double.create(55.05)
+    override var optionalArray: Array<String>? = null
 
     override fun simpleFunc() {
         // do nothing

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -73,6 +73,14 @@ void HybridTestObjectCpp::setOptionalString(const std::optional<std::string>& op
   _optionalString = optionalString;
 }
 
+std::optional<std::vector<std::string>> HybridTestObjectCpp::getOptionalArray() {
+  return _optionalArray;
+}
+
+void HybridTestObjectCpp::setOptionalArray(const std::optional<std::vector<std::string>>& optionalArray) {
+  _optionalArray = optionalArray;
+}
+
 std::variant<std::string, double> HybridTestObjectCpp::getSomeVariant() {
   return _variant;
 }

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -26,6 +26,7 @@ private:
   std::optional<std::string> _optionalString;
   std::variant<std::string, double> _variant;
   std::tuple<double, std::string> _tuple;
+  std::optional<std::vector<std::string>> _optionalArray;
 
 private:
   static inline uint64_t calculateFibonacci(int count) noexcept {
@@ -53,6 +54,8 @@ public:
   void setStringOrNull(const std::optional<std::string>& stringOrNull) override;
   std::optional<std::string> getOptionalString() override;
   void setOptionalString(const std::optional<std::string>& optionalString) override;
+  std::optional<std::vector<std::string>> getOptionalArray() override;
+  void setOptionalArray(const std::optional<std::vector<std::string>>& optionalArray) override;
   std::variant<std::string, double> getSomeVariant() override;
   void setSomeVariant(const std::variant<std::string, double>& variant) override;
   std::tuple<double, std::string> getSomeTuple() override;

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -9,6 +9,8 @@ import Foundation
 import NitroModules
 
 class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
+  var optionalArray: [String]? = []
+  
   var hybridContext: margelo.nitro.HybridContext = .init()
   var memorySize: Int {
     return 0

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -30,9 +30,9 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include <NitroModules/JNISharedPtr.hpp>
 #include <string>
 #include <optional>
+#include <vector>
 #include <variant>
 #include "JVariant_String_Double.hpp"
-#include <vector>
 #include "Person.hpp"
 #include "JPerson.hpp"
 #include "Powertrain.hpp"
@@ -139,6 +139,32 @@ namespace margelo::nitro::image {
   void JHybridTestObjectSwiftKotlinSpec::setOptionalString(const std::optional<std::string>& optionalString) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* optionalString */)>("setOptionalString");
     method(_javaPart, optionalString.has_value() ? jni::make_jstring(optionalString.value()) : nullptr);
+  }
+  std::optional<std::vector<std::string>> JHybridTestObjectSwiftKotlinSpec::getOptionalArray() {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>()>("getOptionalArray");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional([&]() {
+      size_t __size = __result->size();
+      std::vector<std::string> __vector;
+      __vector.reserve(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        auto __element = __result->getElement(__i);
+        __vector.push_back(__element->toStdString());
+      }
+      return __vector;
+    }()) : std::nullopt;
+  }
+  void JHybridTestObjectSwiftKotlinSpec::setOptionalArray(const std::optional<std::vector<std::string>>& optionalArray) {
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<jni::JString>> /* optionalArray */)>("setOptionalArray");
+    method(_javaPart, optionalArray.has_value() ? [&]() {
+      size_t __size = optionalArray.value().size();
+      jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        const auto& __element = optionalArray.value()[__i];
+        __array->setElement(__i, *jni::make_jstring(__element));
+      }
+      return __array;
+    }() : nullptr);
   }
   std::variant<std::string, double> JHybridTestObjectSwiftKotlinSpec::getSomeVariant() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JVariant_String_Double>()>("getSomeVariant");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -56,6 +56,8 @@ namespace margelo::nitro::image {
     void setStringOrNull(const std::optional<std::string>& stringOrNull) override;
     std::optional<std::string> getOptionalString() override;
     void setOptionalString(const std::optional<std::string>& optionalString) override;
+    std::optional<std::vector<std::string>> getOptionalArray() override;
+    void setOptionalArray(const std::optional<std::vector<std::string>>& optionalArray) override;
     std::variant<std::string, double> getSomeVariant() override;
     void setSomeVariant(const std::variant<std::string, double>& someVariant) override;
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -88,6 +88,12 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @get:Keep
   @set:DoNotStrip
   @set:Keep
+  abstract var optionalArray: Array<String>?
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
   abstract var someVariant: Variant_String_Double
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -441,6 +441,14 @@ namespace margelo::nitro::image::bridge::swift {
   }
   
   /**
+   * Specialized version of `std::optional<std::vector<std::string>>`.
+   */
+  using std__optional_std__vector_std__string__ = std::optional<std::vector<std::string>>;
+  inline std::optional<std::vector<std::string>> create_std__optional_std__vector_std__string__(const std::vector<std::string>& value) {
+    return std::optional<std::vector<std::string>>(value);
+  }
+  
+  /**
    * Specialized version of `std::vector<Person>`.
    */
   using std__vector_Person_ = std::vector<Person>;

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -42,8 +42,8 @@ namespace margelo::nitro::image { class HybridBaseSpecSwift; }
 #include "HybridTestObjectSwiftKotlinSpecSwift.hpp"
 #include <string>
 #include <optional>
-#include <variant>
 #include <vector>
+#include <variant>
 #include "Person.hpp"
 #include "Powertrain.hpp"
 #include <functional>
@@ -146,6 +146,13 @@ namespace margelo::nitro::image {
     }
     inline void setOptionalString(const std::optional<std::string>& optionalString) noexcept override {
       _swiftPart.setOptionalString(optionalString);
+    }
+    inline std::optional<std::vector<std::string>> getOptionalArray() noexcept override {
+      auto __result = _swiftPart.getOptionalArray();
+      return __result;
+    }
+    inline void setOptionalArray(const std::optional<std::vector<std::string>>& optionalArray) noexcept override {
+      _swiftPart.setOptionalArray(optionalArray);
     }
     inline std::variant<std::string, double> getSomeVariant() noexcept override {
       auto __result = _swiftPart.getSomeVariant();

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -37,6 +37,7 @@ public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
   var stringOrUndefined: String? { get set }
   var stringOrNull: String? { get set }
   var optionalString: String? { get set }
+  var optionalArray: [String]? { get set }
   var someVariant: Variant_String_Double { get set }
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -191,6 +191,35 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
     }
   }
   
+  public var optionalArray: bridge.std__optional_std__vector_std__string__ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_std__vector_std__string__ in
+        if let __unwrappedValue = self.__implementation.optionalArray {
+          return bridge.create_std__optional_std__vector_std__string__({ () -> bridge.std__vector_std__string_ in
+            var __vector = bridge.create_std__vector_std__string_(__unwrappedValue.count)
+            for __item in __unwrappedValue {
+              __vector.push_back(std.string(__item))
+            }
+            return __vector
+          }())
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.optionalArray = { () -> [String]? in
+        if let __unwrapped = newValue.value {
+          return __unwrapped.map({ __item in String(__item) })
+        } else {
+          return nil
+        }
+      }()
+    }
+  }
+  
   public var someVariant: bridge.std__variant_std__string__double_ {
     @inline(__always)
     get {

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -31,6 +31,8 @@ namespace margelo::nitro::image {
       prototype.registerHybridSetter("stringOrNull", &HybridTestObjectCppSpec::setStringOrNull);
       prototype.registerHybridGetter("optionalString", &HybridTestObjectCppSpec::getOptionalString);
       prototype.registerHybridSetter("optionalString", &HybridTestObjectCppSpec::setOptionalString);
+      prototype.registerHybridGetter("optionalArray", &HybridTestObjectCppSpec::getOptionalArray);
+      prototype.registerHybridSetter("optionalArray", &HybridTestObjectCppSpec::setOptionalArray);
       prototype.registerHybridGetter("someVariant", &HybridTestObjectCppSpec::getSomeVariant);
       prototype.registerHybridSetter("someVariant", &HybridTestObjectCppSpec::setSomeVariant);
       prototype.registerHybridMethod("passVariant", &HybridTestObjectCppSpec::passVariant);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -37,8 +37,8 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include <memory>
 #include "HybridTestObjectCppSpec.hpp"
 #include <optional>
-#include <variant>
 #include <vector>
+#include <variant>
 #include "OldEnum.hpp"
 #include "Car.hpp"
 #include "Person.hpp"
@@ -94,6 +94,8 @@ namespace margelo::nitro::image {
       virtual void setStringOrNull(const std::optional<std::string>& stringOrNull) = 0;
       virtual std::optional<std::string> getOptionalString() = 0;
       virtual void setOptionalString(const std::optional<std::string>& optionalString) = 0;
+      virtual std::optional<std::vector<std::string>> getOptionalArray() = 0;
+      virtual void setOptionalArray(const std::optional<std::vector<std::string>>& optionalArray) = 0;
       virtual std::variant<std::string, double> getSomeVariant() = 0;
       virtual void setSomeVariant(const std::variant<std::string, double>& someVariant) = 0;
 

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -29,6 +29,8 @@ namespace margelo::nitro::image {
       prototype.registerHybridSetter("stringOrNull", &HybridTestObjectSwiftKotlinSpec::setStringOrNull);
       prototype.registerHybridGetter("optionalString", &HybridTestObjectSwiftKotlinSpec::getOptionalString);
       prototype.registerHybridSetter("optionalString", &HybridTestObjectSwiftKotlinSpec::setOptionalString);
+      prototype.registerHybridGetter("optionalArray", &HybridTestObjectSwiftKotlinSpec::getOptionalArray);
+      prototype.registerHybridSetter("optionalArray", &HybridTestObjectSwiftKotlinSpec::setOptionalArray);
       prototype.registerHybridGetter("someVariant", &HybridTestObjectSwiftKotlinSpec::getSomeVariant);
       prototype.registerHybridSetter("someVariant", &HybridTestObjectSwiftKotlinSpec::setSomeVariant);
       prototype.registerHybridMethod("newTestObject", &HybridTestObjectSwiftKotlinSpec::newTestObject);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -34,8 +34,8 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include "HybridTestObjectSwiftKotlinSpec.hpp"
 #include <string>
 #include <optional>
-#include <variant>
 #include <vector>
+#include <variant>
 #include "Person.hpp"
 #include "Powertrain.hpp"
 #include <functional>
@@ -88,6 +88,8 @@ namespace margelo::nitro::image {
       virtual void setStringOrNull(const std::optional<std::string>& stringOrNull) = 0;
       virtual std::optional<std::string> getOptionalString() = 0;
       virtual void setOptionalString(const std::optional<std::string>& optionalString) = 0;
+      virtual std::optional<std::vector<std::string>> getOptionalArray() = 0;
+      virtual void setOptionalArray(const std::optional<std::vector<std::string>>& optionalArray) = 0;
       virtual std::variant<std::string, double> getSomeVariant() = 0;
       virtual void setSomeVariant(const std::variant<std::string, double>& someVariant) = 0;
 

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -35,6 +35,7 @@ interface SharedTestObjectProps {
   stringOrUndefined: string | undefined
   stringOrNull: string | null
   optionalString?: string
+  optionalArray?: string[]
 
   // Basic function tests
   simpleFunc(): void


### PR DESCRIPTION
Before, `create_std__optional_Whatever__(...)` did not use the SwiftCxxBridgedType at all. Now it does.

Added a use-case / test-case for this in `getTests()` as well: `optionalArray?: string[]`