### PR TITLE
fix: Add `_Nonnull` modifier to `void*` types for Swift

### DIFF
--- a/packages/nitrogen/src/autolinking/ios/createSwiftCxxBridge.ts
+++ b/packages/nitrogen/src/autolinking/ios/createSwiftCxxBridge.ts
@@ -1,5 +1,8 @@
 import { NitroConfig } from '../../config/NitroConfig.js'
-import { includeHeader } from '../../syntax/c++/includeNitroHeader.js'
+import {
+  includeHeader,
+  includeNitroHeader,
+} from '../../syntax/c++/includeNitroHeader.js'
 import { getAllKnownTypes } from '../../syntax/createType.js'
 import {
   createFileMetadataString,
@@ -50,6 +53,8 @@ export function createSwiftCxxBridge(): SourceFile[] {
 ${createFileMetadataString(`${bridgeName}.hpp`)}
 
 #pragma once
+
+${includeNitroHeader('NitroDefines.hpp')}
 
 // Forward declarations of C++ defined types
 ${forwardDeclarations.sort().join('\n')}

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -179,13 +179,13 @@ function createCxxFunctionSwiftHelper(type: FunctionType): SwiftCxxHelper {
   ]
   const callFuncReturnType = returnBridge.getTypeCode('c++')
   const callFuncParams = [
-    'void* /* closureHolder */',
+    'void* NONNULL /* closureHolder */',
     ...type.parameters.map((p) => {
       const bridge = new SwiftCxxBridgedType(p)
       return bridge.getTypeCode('c++')
     }),
   ]
-  const functionPointerParam = `${callFuncReturnType}(*call)(${callFuncParams.join(', ')})`
+  const functionPointerParam = `${callFuncReturnType}(* NONNULL call)(${callFuncParams.join(', ')})`
   const name = type.specializationName
   const wrapperName = `${name}_Wrapper`
 
@@ -249,7 +249,7 @@ public:
 
   ${actualType} function;
 };
-inline ${name} create_${name}(void* _Nonnull closureHolder, ${functionPointerParam}, void(*destroy)(void*)) {
+inline ${name} create_${name}(void* NONNULL closureHolder, ${functionPointerParam}, void(* NONNULL destroy)(void* NONNULL)) {
   std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
   return ${name}([sharedClosureHolder, call](${paramsSignature.join(', ')}) -> ${type.returnType.getCode('c++')} {
     ${callSwiftFuncBody}

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -7,6 +7,12 @@
 
 #pragma once
 
+#if __has_include(<NitroModules/NitroDefines.hpp>)
+#include <NitroModules/NitroDefines.hpp>
+#else
+#error NitroModules cannot be found! Are you sure you installed NitroModules properly?
+#endif
+
 // Forward declarations of C++ defined types
 // Forward declaration of `Car` to properly resolve imports.
 namespace margelo::nitro::image { struct Car; }
@@ -92,7 +98,7 @@ namespace margelo::nitro::image::bridge::swift {
   
     std::function<void(const std::string& /* path */)> function;
   };
-  inline Func_void_std__string create_Func_void_std__string(void* _Nonnull closureHolder, void(*call)(void* /* closureHolder */, std::string), void(*destroy)(void*)) {
+  inline Func_void_std__string create_Func_void_std__string(void* NONNULL closureHolder, void(* NONNULL call)(void* NONNULL /* closureHolder */, std::string), void(* NONNULL destroy)(void* NONNULL)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__string([sharedClosureHolder, call](const std::string& path) -> void {
       call(sharedClosureHolder.get(), path);
@@ -375,7 +381,7 @@ namespace margelo::nitro::image::bridge::swift {
   
     std::function<std::future<double>()> function;
   };
-  inline Func_std__future_double_ create_Func_std__future_double_(void* _Nonnull closureHolder, PromiseHolder<double>(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
+  inline Func_std__future_double_ create_Func_std__future_double_(void* NONNULL closureHolder, PromiseHolder<double>(* NONNULL call)(void* NONNULL /* closureHolder */), void(* NONNULL destroy)(void* NONNULL)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__future_double_([sharedClosureHolder, call]() -> std::future<double> {
       auto __result = call(sharedClosureHolder.get());
@@ -413,7 +419,7 @@ namespace margelo::nitro::image::bridge::swift {
   
     std::function<std::future<std::string>()> function;
   };
-  inline Func_std__future_std__string_ create_Func_std__future_std__string_(void* _Nonnull closureHolder, PromiseHolder<std::string>(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
+  inline Func_std__future_std__string_ create_Func_std__future_std__string_(void* NONNULL closureHolder, PromiseHolder<std::string>(* NONNULL call)(void* NONNULL /* closureHolder */), void(* NONNULL destroy)(void* NONNULL)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__future_std__string_([sharedClosureHolder, call]() -> std::future<std::string> {
       auto __result = call(sharedClosureHolder.get());
@@ -486,7 +492,7 @@ namespace margelo::nitro::image::bridge::swift {
   
     std::function<void(const std::vector<Powertrain>& /* array */)> function;
   };
-  inline Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* _Nonnull closureHolder, void(*call)(void* /* closureHolder */, std::vector<Powertrain>), void(*destroy)(void*)) {
+  inline Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* NONNULL closureHolder, void(* NONNULL call)(void* NONNULL /* closureHolder */, std::vector<Powertrain>), void(* NONNULL destroy)(void* NONNULL)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__vector_Powertrain_([sharedClosureHolder, call](const std::vector<Powertrain>& array) -> void {
       call(sharedClosureHolder.get(), array);
@@ -538,7 +544,7 @@ namespace margelo::nitro::image::bridge::swift {
   
     std::function<void()> function;
   };
-  inline Func_void create_Func_void(void* _Nonnull closureHolder, void(*call)(void* /* closureHolder */), void(*destroy)(void*)) {
+  inline Func_void create_Func_void(void* NONNULL closureHolder, void(* NONNULL call)(void* NONNULL /* closureHolder */), void(* NONNULL destroy)(void* NONNULL)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void([sharedClosureHolder, call]() -> void {
       call(sharedClosureHolder.get());
@@ -574,7 +580,7 @@ namespace margelo::nitro::image::bridge::swift {
   
     std::function<void(std::optional<double> /* maybe */)> function;
   };
-  inline Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* _Nonnull closureHolder, void(*call)(void* /* closureHolder */, std::optional<double>), void(*destroy)(void*)) {
+  inline Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* NONNULL closureHolder, void(* NONNULL call)(void* NONNULL /* closureHolder */, std::optional<double>), void(* NONNULL destroy)(void* NONNULL)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__optional_double_([sharedClosureHolder, call](std::optional<double> maybe) -> void {
       call(sharedClosureHolder.get(), maybe);

--- a/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
@@ -48,4 +48,12 @@
 #define CLOSED_ENUM
 #endif
 
+#ifdef __APPLE__
+#define NONNULL _Nonnull
+#define NULLABLE _Nullable
+#else
+#define NONNULL
+#define NULLABLE
+#endif
+
 #endif /* NitroDefines_h */


### PR DESCRIPTION
Adds `_Nonnull` (or `NONNULL`, which is just an alias) to all `void*` types