### PR TITLE
feat: Allow `type T = {...}` definition for structs

### DIFF
--- a/packages/nitrogen/src/syntax/getInterfaceProperties.ts
+++ b/packages/nitrogen/src/syntax/getInterfaceProperties.ts
@@ -5,7 +5,7 @@ import type { Language } from '../getPlatformSpecs.js'
 
 export function getInterfaceProperties(
   language: Language,
-  interfaceType: Type<ts.InterfaceType>
+  interfaceType: Type<ts.ObjectType>
 ): NamedType[] {
   return interfaceType.getProperties().map((prop) => {
     const declaration = prop.getValueDeclarationOrThrow()

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -209,8 +209,8 @@ std::variant<Car, Person> HybridTestObjectCpp::getVariantObjects(const std::vari
   return variant;
 }
 
-std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>> HybridTestObjectCpp::getVariantHybrid(
-    const std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>>& variant) {
+std::variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, Person> HybridTestObjectCpp::getVariantHybrid(
+    const std::variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, Person>& variant) {
   return variant;
 }
 

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -209,8 +209,8 @@ std::variant<Car, Person> HybridTestObjectCpp::getVariantObjects(const std::vari
   return variant;
 }
 
-std::variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, Person> HybridTestObjectCpp::getVariantHybrid(
-    const std::variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, Person>& variant) {
+std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person>
+HybridTestObjectCpp::getVariantHybrid(const std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person>& variant) {
   return variant;
 }
 

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -89,8 +89,8 @@ public:
 
   std::variant<bool, OldEnum> getVariantEnum(const std::variant<bool, OldEnum>& variant) override;
   std::variant<Car, Person> getVariantObjects(const std::variant<Car, Person>& variant) override;
-  std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>>
-  getVariantHybrid(const std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>>& variant) override;
+  std::variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, Person>
+  getVariantHybrid(const std::variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, Person>& variant) override;
   std::variant<std::tuple<double, double>, std::tuple<double, double, double>>
   getVariantTuple(const std::variant<std::tuple<double, double>, std::tuple<double, double, double>>& variant) override;
 

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -89,8 +89,8 @@ public:
 
   std::variant<bool, OldEnum> getVariantEnum(const std::variant<bool, OldEnum>& variant) override;
   std::variant<Car, Person> getVariantObjects(const std::variant<Car, Person>& variant) override;
-  std::variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, Person>
-  getVariantHybrid(const std::variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, Person>& variant) override;
+  std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person>
+  getVariantHybrid(const std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person>& variant) override;
   std::variant<std::tuple<double, double>, std::tuple<double, double, double>>
   getVariantTuple(const std::variant<std::tuple<double, double>, std::tuple<double, double, double>>& variant) override;
 
@@ -116,14 +116,10 @@ public:
   std::shared_ptr<HybridBaseSpec> createBase() override;
   std::shared_ptr<HybridChildSpec> createChild() override;
   std::shared_ptr<HybridBaseSpec> createBaseActualChild() override;
-  std::shared_ptr<margelo::nitro::image::HybridChildSpec>
-  bounceChild(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) override;
-  std::shared_ptr<margelo::nitro::image::HybridBaseSpec>
-  bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) override;
-  std::shared_ptr<margelo::nitro::image::HybridBaseSpec>
-  bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) override;
-  std::shared_ptr<margelo::nitro::image::HybridChildSpec>
-  castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) override;
+  std::shared_ptr<HybridChildSpec> bounceChild(const std::shared_ptr<HybridChildSpec>& child) override;
+  std::shared_ptr<HybridBaseSpec> bounceBase(const std::shared_ptr<HybridBaseSpec>& base) override;
+  std::shared_ptr<HybridBaseSpec> bounceChildBase(const std::shared_ptr<HybridChildSpec>& child) override;
+  std::shared_ptr<HybridChildSpec> castBase(const std::shared_ptr<HybridBaseSpec>& base) override;
 
   // Raw JSI functions
   jsi::Value rawJsiFunc(jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* args, size_t count);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -106,7 +106,7 @@ namespace margelo::nitro::image {
       virtual std::variant<std::string, double> passVariant(const std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>& either) = 0;
       virtual std::variant<bool, OldEnum> getVariantEnum(const std::variant<bool, OldEnum>& variant) = 0;
       virtual std::variant<Car, Person> getVariantObjects(const std::variant<Car, Person>& variant) = 0;
-      virtual std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>> getVariantHybrid(const std::variant<Person, std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>>& variant) = 0;
+      virtual std::variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, Person> getVariantHybrid(const std::variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, Person>& variant) = 0;
       virtual std::variant<std::tuple<double, double>, std::tuple<double, double, double>> getVariantTuple(const std::variant<std::tuple<double, double>, std::tuple<double, double, double>>& variant) = 0;
       virtual std::tuple<double, double, double> flip(const std::tuple<double, double, double>& tuple) = 0;
       virtual std::tuple<double, std::string, bool> passTuple(const std::tuple<double, std::string, bool>& tuple) = 0;

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -1,17 +1,25 @@
 import { type HybridObject, type AnyMap } from 'react-native-nitro-modules'
 
+// Tuples become `std::tuple<...>` in C++.
+// In contrast to arrays, they are length-checked, and can have different types inside them.
 export type Float2 = [number, number]
 export type Float3 = [number, number, number]
 export type TestTuple = [number, string, boolean]
 
+// A discriminating string union becomes an `enum` in C++.
+// This one is string-backed.
 export type Powertrain = 'electric' | 'gas' | 'hybrid'
 
+// A classic TypeScript enum also becomes an `enum` in C++.
+// This one is number-backed.
 export enum OldEnum {
   FIRST,
   SECOND,
   THIRD,
 }
 
+// A plain interface that does not inherit from `HybridObject` becomes a `struct` in C++.
+// They can only have properties (get + set). No methods or native state.
 export interface Car {
   year: number
   make: string
@@ -21,11 +29,15 @@ export interface Car {
   driver?: Person
 }
 
+// A `type T = { ... }` declaration is the same as a `interface T { ... }` - it's a `struct` in C++.
 export type Person = {
   name: string
   age: number
 }
 
+// This is an `interface` we're going to use as a base in both of our `HybridObject`s later.
+// In this case, the `HybridObject`s will just flatten out and copy over all properties here.
+// There is no separate type for `SharedTestObjectProps` on the native side.
 interface SharedTestObjectProps {
   // Test Primitives
   numberValue: number
@@ -101,6 +113,9 @@ interface SharedTestObjectProps {
   castBase(base: Base): Child
 }
 
+// This is a C++-based `HybridObject`.
+// Since it inherited from the `SharedTestObjectProps` interface,
+// it will be flattened out and every property/method will be added here.
 export interface TestObjectCpp
   extends HybridObject<{ ios: 'c++' }>,
     SharedTestObjectProps {
@@ -133,6 +148,9 @@ export interface TestObjectCpp
   optionalHybrid?: TestObjectCpp
 }
 
+// This is a Swift/Kotlin-based `HybridObject`.
+// Since it inherited from the `SharedTestObjectProps` interface,
+// it will be flattened out and every property/method will be added here.
 export interface TestObjectSwiftKotlin
   extends HybridObject<{ ios: 'swift'; android: 'kotlin' }>,
     SharedTestObjectProps {
@@ -142,11 +160,15 @@ export interface TestObjectSwiftKotlin
   optionalHybrid?: TestObjectSwiftKotlin
 }
 
+// This is a simple `HybridObject` with just one value.
 export interface Base
   extends HybridObject<{ ios: 'swift'; android: 'kotlin' }> {
   readonly baseValue: number
 }
 
+// This is a `HybridObject` that actually inherits from a different `HybridObject`.
+// This will set up an inheritance chain on the native side.
+// The native `Child` Swift/Kotlin class will inherit from the `Base` Swift/Kotlin class.
 export interface Child extends Base {
   readonly childValue: number
 }

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -21,7 +21,7 @@ export interface Car {
   driver?: Person
 }
 
-export interface Person {
+export type Person = {
   name: string
   age: number
 }


### PR DESCRIPTION
In addition to `interface T { ... }`, nitrogen can now also detect `type T = { ... }` types, which are the same thing on the native side (= `struct`s).

- Closes #222