### PR TITLE
fix: Fix jboolean parse in Structs

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -36,6 +36,7 @@ const TEST_CAR: Car = {
   power: 640,
   powertrain: 'gas',
   driver: undefined, // <-- value needs to be explicitly set, to equal it with native's std::optional<..>
+  isFast: true,
 }
 
 function createTest<T>(
@@ -760,6 +761,7 @@ export function getTests(
           model: 'Huracan Performante',
           power: 640,
           powertrain: 'gas',
+          isFast: true,
         })
       )
         .didNotThrow()
@@ -773,6 +775,7 @@ export function getTests(
           model: 'Huracan Performante',
           power: 640,
           powertrain: 'gas',
+          isFast: true,
         })
       )
         .didNotThrow()
@@ -787,6 +790,7 @@ export function getTests(
           power: 640,
           powertrain: 'gas',
           driver: { age: 24, name: 'marc' },
+          isFast: true,
         })
       )
         .didNotThrow()

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -537,6 +537,10 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
               // unbox an object (JDouble) to a primitive (double)
               return `${parameterName}->value()`
             } else {
+              if (this.type.kind === 'boolean') {
+                // jboolean =/= bool (it's a char in Java)
+                return `static_cast<bool>(${parameterName})`
+              }
               return parameterName
             }
           default:

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -139,7 +139,7 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
     }
 
     override fun getCar(): Car {
-        return Car(2018.0, "Lamborghini", "Huracán", 640.0, Powertrain.GAS, null)
+        return Car(2018.0, "Lamborghini", "Huracán", 640.0, Powertrain.GAS, null, true)
     }
 
     override fun isCarElectric(car: Car): Boolean {

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -286,7 +286,7 @@ HybridTestObjectCpp::getValueFromJsCallback(const std::function<std::future<std:
 }
 
 Car HybridTestObjectCpp::getCar() {
-  return Car(2018, "Lamborghini", "Huracan Performante", 640, Powertrain::GAS, std::nullopt);
+  return Car(2018, "Lamborghini", "Huracan Performante", 640, Powertrain::GAS, std::nullopt, true);
 }
 
 bool HybridTestObjectCpp::isCarElectric(const Car& car) {

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -13,7 +13,7 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
   var memorySize: Int {
     return 0
   }
-  
+
   var optionalArray: [String]? = []
 
   var someVariant: Variant_String_Double = .someDouble(55)
@@ -31,9 +31,9 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
   var stringOrNull: String? = nil
 
   var optionalString: String? = nil
-  
+
   var optionalHybrid: (any HybridTestObjectSwiftKotlinSpec)? = nil
-  
+
   var optionalEnum: Powertrain? = nil
 
   func simpleFunc() throws {
@@ -169,7 +169,7 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
   }
 
   func getCar() throws -> Car {
-    return Car(year: 2018, make: "Lamborghini", model: "Huracán", power: 640, powertrain: .gas, driver: nil)
+    return Car(year: 2018, make: "Lamborghini", model: "Huracán", power: 640, powertrain: .gas, driver: nil, isFast: true)
   }
 
   func isCarElectric(car: Car) throws -> Bool {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JCar.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JCar.hpp
@@ -47,13 +47,16 @@ namespace margelo::nitro::image {
       jni::local_ref<JPowertrain> powertrain = this->getFieldValue(fieldPowertrain);
       static const auto fieldDriver = clazz->getField<JPerson>("driver");
       jni::local_ref<JPerson> driver = this->getFieldValue(fieldDriver);
+      static const auto fieldIsFast = clazz->getField<jboolean>("isFast");
+      jboolean isFast = this->getFieldValue(fieldIsFast);
       return Car(
         year,
         make->toStdString(),
         model->toStdString(),
         power,
         powertrain->toCpp(),
-        driver != nullptr ? std::make_optional(driver->toCpp()) : std::nullopt
+        driver != nullptr ? std::make_optional(driver->toCpp()) : std::nullopt,
+        static_cast<bool>(isFast)
       );
     }
 
@@ -69,7 +72,8 @@ namespace margelo::nitro::image {
         jni::make_jstring(value.model),
         value.power,
         JPowertrain::fromCpp(value.powertrain),
-        value.driver.has_value() ? JPerson::fromCpp(value.driver.value()) : nullptr
+        value.driver.has_value() ? JPerson::fromCpp(value.driver.value()) : nullptr,
+        value.isFast
       );
     }
   };

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -98,7 +98,7 @@ namespace margelo::nitro::image {
   bool JHybridTestObjectSwiftKotlinSpec::getBoolValue() {
     static const auto method = _javaPart->getClass()->getMethod<jboolean()>("getBoolValue");
     auto __result = method(_javaPart);
-    return __result;
+    return static_cast<bool>(__result);
   }
   void JHybridTestObjectSwiftKotlinSpec::setBoolValue(bool boolValue) {
     static const auto method = _javaPart->getClass()->getMethod<void(jboolean /* boolValue */)>("setBoolValue");
@@ -398,7 +398,7 @@ namespace margelo::nitro::image {
   bool JHybridTestObjectSwiftKotlinSpec::isCarElectric(const Car& car) {
     static const auto method = _javaPart->getClass()->getMethod<jboolean(jni::alias_ref<JCar> /* car */)>("isCarElectric");
     auto __result = method(_javaPart, JCar::fromCpp(car));
-    return __result;
+    return static_cast<bool>(__result);
   }
   std::optional<Person> JHybridTestObjectSwiftKotlinSpec::getDriver(const Car& car) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPerson>(jni::alias_ref<JCar> /* car */)>("getDriver");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Car.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Car.kt
@@ -21,5 +21,6 @@ data class Car(
   val model: String,
   val power: Double,
   val powertrain: Powertrain,
-  val driver: Person?
+  val driver: Person?,
+  val isFast: Boolean
 )

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Car.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Car.swift
@@ -18,14 +18,14 @@ public extension Car {
   /**
    * Create a new instance of `Car`.
    */
-  init(year: Double, make: String, model: String, power: Double, powertrain: Powertrain, driver: Person?) {
+  init(year: Double, make: String, model: String, power: Double, powertrain: Powertrain, driver: Person?, isFast: Bool) {
     self.init(year, std.string(make), std.string(model), power, powertrain, { () -> bridge.std__optional_Person_ in
       if let __unwrappedValue = driver {
         return bridge.create_std__optional_Person_(__unwrappedValue)
       } else {
         return .init()
       }
-    }())
+    }(), isFast)
   }
 
   var year: Double {
@@ -103,6 +103,17 @@ public extension Car {
           return .init()
         }
       }()
+    }
+  }
+  
+  var isFast: Bool {
+    @inline(__always)
+    get {
+      return self.__isFast
+    }
+    @inline(__always)
+    set {
+      self.__isFast = newValue
     }
   }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/Car.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/Car.hpp
@@ -41,9 +41,10 @@ namespace margelo::nitro::image {
     double power     SWIFT_PRIVATE;
     Powertrain powertrain     SWIFT_PRIVATE;
     std::optional<Person> driver     SWIFT_PRIVATE;
+    bool isFast     SWIFT_PRIVATE;
 
   public:
-    explicit Car(double year, std::string make, std::string model, double power, Powertrain powertrain, std::optional<Person> driver): year(year), make(make), model(model), power(power), powertrain(powertrain), driver(driver) {}
+    explicit Car(double year, std::string make, std::string model, double power, Powertrain powertrain, std::optional<Person> driver, bool isFast): year(year), make(make), model(model), power(power), powertrain(powertrain), driver(driver), isFast(isFast) {}
   };
 
 } // namespace margelo::nitro::image
@@ -63,7 +64,8 @@ namespace margelo::nitro {
         JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, "model")),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "power")),
         JSIConverter<Powertrain>::fromJSI(runtime, obj.getProperty(runtime, "powertrain")),
-        JSIConverter<std::optional<Person>>::fromJSI(runtime, obj.getProperty(runtime, "driver"))
+        JSIConverter<std::optional<Person>>::fromJSI(runtime, obj.getProperty(runtime, "driver")),
+        JSIConverter<bool>::fromJSI(runtime, obj.getProperty(runtime, "isFast"))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const Car& arg) {
@@ -74,6 +76,7 @@ namespace margelo::nitro {
       obj.setProperty(runtime, "power", JSIConverter<double>::toJSI(runtime, arg.power));
       obj.setProperty(runtime, "powertrain", JSIConverter<Powertrain>::toJSI(runtime, arg.powertrain));
       obj.setProperty(runtime, "driver", JSIConverter<std::optional<Person>>::toJSI(runtime, arg.driver));
+      obj.setProperty(runtime, "isFast", JSIConverter<bool>::toJSI(runtime, arg.isFast));
       return obj;
     }
     static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
@@ -87,6 +90,7 @@ namespace margelo::nitro {
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, "power"))) return false;
       if (!JSIConverter<Powertrain>::canConvert(runtime, obj.getProperty(runtime, "powertrain"))) return false;
       if (!JSIConverter<std::optional<Person>>::canConvert(runtime, obj.getProperty(runtime, "driver"))) return false;
+      if (!JSIConverter<bool>::canConvert(runtime, obj.getProperty(runtime, "isFast"))) return false;
       return true;
     }
   };

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -27,6 +27,7 @@ export interface Car {
   power: number
   powertrain: Powertrain
   driver?: Person
+  isFast: boolean
 }
 
 // A `type T = { ... }` declaration is the same as a `interface T { ... }` - it's a `struct` in C++.


### PR DESCRIPTION
Booleans in JNI are actually chars. (jboolean).

So we need to cast them to bools instead.

Fixes https://github.com/mrousavy/nitro/issues/259#issuecomment-2441263658