### PR TITLE
feat: Add RN 0.76 support

### DIFF
--- a/packages/nitrogen/src/autolinking/android/createCMakeExtension.ts
+++ b/packages/nitrogen/src/autolinking/android/createCMakeExtension.ts
@@ -65,9 +65,21 @@ target_link_libraries(
         ${name}
         fbjni::fbjni                              # <-- Facebook C++ JNI helpers
         ReactAndroid::jsi                         # <-- RN: JSI
-        ReactAndroid::react_nativemodule_core     # <-- RN: TurboModules Core
         react-native-nitro-modules::NitroModules  # <-- NitroModules Core :)
 )
+
+# Link react-native (different prefab between RN 0.75 and RN 0.76)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+    target_link_libraries(
+        ${name}
+        ReactAndroid::reactnative                 # <-- RN: Native Modules umbrella prefab
+    )
+else()
+    target_link_libraries(
+        ${name}
+        ReactAndroid::react_nativemodule_core     # <-- RN: TurboModules Core
+    )
+endif()
   `.trim()
   return {
     content: code,

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImage+autolinking.cmake
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImage+autolinking.cmake
@@ -51,6 +51,18 @@ target_link_libraries(
         NitroImage
         fbjni::fbjni                              # <-- Facebook C++ JNI helpers
         ReactAndroid::jsi                         # <-- RN: JSI
-        ReactAndroid::react_nativemodule_core     # <-- RN: TurboModules Core
         react-native-nitro-modules::NitroModules  # <-- NitroModules Core :)
 )
+
+# Link react-native (different prefab between RN 0.75 and RN 0.76)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+    target_link_libraries(
+        NitroImage
+        ReactAndroid::reactnative                 # <-- RN: Native Modules umbrella prefab
+    )
+else()
+    target_link_libraries(
+        NitroImage
+        ReactAndroid::react_nativemodule_core     # <-- RN: TurboModules Core
+    )
+endif()

--- a/packages/react-native-nitro-modules/android/CMakeLists.txt
+++ b/packages/react-native-nitro-modules/android/CMakeLists.txt
@@ -52,6 +52,18 @@ target_link_libraries(
         android                                   # <-- Android JNI core
         fbjni::fbjni                              # <-- Facebook C++ JNI helpers
         ReactAndroid::jsi                         # <-- RN: JSI
+)
+
+# Link react-native (different prefab between RN 0.75 and RN 0.76)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+    target_link_libraries(
+        NitroModules
+        ReactAndroid::reactnative                 # <-- RN: Native Modules umbrella prefab
+    )
+else()
+    target_link_libraries(
+        NitroModules
         ReactAndroid::react_nativemodule_core     # <-- RN: TurboModules Core
         ReactAndroid::turbomodulejsijni           # <-- RN: TurboModules utils (e.g. CallInvokerHolder)
-)
+    )
+endif()


### PR DESCRIPTION
react-native 0.76 merged most of their C++ shared libraries into one larger one; the `ReactAndroid::reactnative` umbrella prefab.

This unfortunately breaks all RN libs that contain C++ code, which Nitro does. So we have to add a special `if` to support this new change now and link the libs different on RN 0.75 than on RN 0.76.

- Fixes https://github.com/mrousavy/nitro/issues/262