### PR TITLE
fix: Fix optional bools in JNI structs

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -533,16 +533,19 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
       case 'bigint':
         switch (language) {
           case 'c++':
+            let code: string
             if (isBoxed) {
               // unbox an object (JDouble) to a primitive (double)
-              return `${parameterName}->value()`
+              code = `${parameterName}->value()`
             } else {
-              if (this.type.kind === 'boolean') {
-                // jboolean =/= bool (it's a char in Java)
-                return `static_cast<bool>(${parameterName})`
-              }
-              return parameterName
+              // it's just the primitive type directly
+              code = parameterName
             }
+            if (this.type.kind === 'boolean') {
+              // jboolean =/= bool (it's a char in Java)
+              code = `static_cast<bool>(${code})`
+            }
+            return code
           default:
             return parameterName
         }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JCar.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JCar.hpp
@@ -56,7 +56,7 @@ namespace margelo::nitro::image {
         power,
         powertrain->toCpp(),
         driver != nullptr ? std::make_optional(driver->toCpp()) : std::nullopt,
-        isFast != nullptr ? std::make_optional(isFast->value()) : std::nullopt
+        isFast != nullptr ? std::make_optional(static_cast<bool>(isFast->value())) : std::nullopt
       );
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JCar.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JCar.hpp
@@ -47,8 +47,8 @@ namespace margelo::nitro::image {
       jni::local_ref<JPowertrain> powertrain = this->getFieldValue(fieldPowertrain);
       static const auto fieldDriver = clazz->getField<JPerson>("driver");
       jni::local_ref<JPerson> driver = this->getFieldValue(fieldDriver);
-      static const auto fieldIsFast = clazz->getField<jboolean>("isFast");
-      jboolean isFast = this->getFieldValue(fieldIsFast);
+      static const auto fieldIsFast = clazz->getField<jni::JBoolean>("isFast");
+      jni::local_ref<jni::JBoolean> isFast = this->getFieldValue(fieldIsFast);
       return Car(
         year,
         make->toStdString(),
@@ -56,7 +56,7 @@ namespace margelo::nitro::image {
         power,
         powertrain->toCpp(),
         driver != nullptr ? std::make_optional(driver->toCpp()) : std::nullopt,
-        static_cast<bool>(isFast)
+        isFast != nullptr ? std::make_optional(isFast->value()) : std::nullopt
       );
     }
 
@@ -73,7 +73,7 @@ namespace margelo::nitro::image {
         value.power,
         JPowertrain::fromCpp(value.powertrain),
         value.driver.has_value() ? JPerson::fromCpp(value.driver.value()) : nullptr,
-        value.isFast
+        value.isFast.has_value() ? jni::JBoolean::valueOf(value.isFast.value()) : nullptr
       );
     }
   };

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Car.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Car.kt
@@ -22,5 +22,5 @@ data class Car(
   val power: Double,
   val powertrain: Powertrain,
   val driver: Person?,
-  val isFast: Boolean
+  val isFast: Boolean?
 )

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Car.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Car.swift
@@ -18,14 +18,20 @@ public extension Car {
   /**
    * Create a new instance of `Car`.
    */
-  init(year: Double, make: String, model: String, power: Double, powertrain: Powertrain, driver: Person?, isFast: Bool) {
+  init(year: Double, make: String, model: String, power: Double, powertrain: Powertrain, driver: Person?, isFast: Bool?) {
     self.init(year, std.string(make), std.string(model), power, powertrain, { () -> bridge.std__optional_Person_ in
       if let __unwrappedValue = driver {
         return bridge.create_std__optional_Person_(__unwrappedValue)
       } else {
         return .init()
       }
-    }(), isFast)
+    }(), { () -> bridge.std__optional_bool_ in
+      if let __unwrappedValue = isFast {
+        return bridge.create_std__optional_bool_(__unwrappedValue)
+      } else {
+        return .init()
+      }
+    }())
   }
 
   var year: Double {
@@ -106,14 +112,20 @@ public extension Car {
     }
   }
   
-  var isFast: Bool {
+  var isFast: Bool? {
     @inline(__always)
     get {
-      return self.__isFast
+      return self.__isFast.value
     }
     @inline(__always)
     set {
-      self.__isFast = newValue
+      self.__isFast = { () -> bridge.std__optional_bool_ in
+        if let __unwrappedValue = newValue {
+          return bridge.create_std__optional_bool_(__unwrappedValue)
+        } else {
+          return .init()
+        }
+      }()
     }
   }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/Car.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/Car.hpp
@@ -41,10 +41,10 @@ namespace margelo::nitro::image {
     double power     SWIFT_PRIVATE;
     Powertrain powertrain     SWIFT_PRIVATE;
     std::optional<Person> driver     SWIFT_PRIVATE;
-    bool isFast     SWIFT_PRIVATE;
+    std::optional<bool> isFast     SWIFT_PRIVATE;
 
   public:
-    explicit Car(double year, std::string make, std::string model, double power, Powertrain powertrain, std::optional<Person> driver, bool isFast): year(year), make(make), model(model), power(power), powertrain(powertrain), driver(driver), isFast(isFast) {}
+    explicit Car(double year, std::string make, std::string model, double power, Powertrain powertrain, std::optional<Person> driver, std::optional<bool> isFast): year(year), make(make), model(model), power(power), powertrain(powertrain), driver(driver), isFast(isFast) {}
   };
 
 } // namespace margelo::nitro::image
@@ -65,7 +65,7 @@ namespace margelo::nitro {
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "power")),
         JSIConverter<Powertrain>::fromJSI(runtime, obj.getProperty(runtime, "powertrain")),
         JSIConverter<std::optional<Person>>::fromJSI(runtime, obj.getProperty(runtime, "driver")),
-        JSIConverter<bool>::fromJSI(runtime, obj.getProperty(runtime, "isFast"))
+        JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, "isFast"))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const Car& arg) {
@@ -76,7 +76,7 @@ namespace margelo::nitro {
       obj.setProperty(runtime, "power", JSIConverter<double>::toJSI(runtime, arg.power));
       obj.setProperty(runtime, "powertrain", JSIConverter<Powertrain>::toJSI(runtime, arg.powertrain));
       obj.setProperty(runtime, "driver", JSIConverter<std::optional<Person>>::toJSI(runtime, arg.driver));
-      obj.setProperty(runtime, "isFast", JSIConverter<bool>::toJSI(runtime, arg.isFast));
+      obj.setProperty(runtime, "isFast", JSIConverter<std::optional<bool>>::toJSI(runtime, arg.isFast));
       return obj;
     }
     static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
@@ -90,7 +90,7 @@ namespace margelo::nitro {
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, "power"))) return false;
       if (!JSIConverter<Powertrain>::canConvert(runtime, obj.getProperty(runtime, "powertrain"))) return false;
       if (!JSIConverter<std::optional<Person>>::canConvert(runtime, obj.getProperty(runtime, "driver"))) return false;
-      if (!JSIConverter<bool>::canConvert(runtime, obj.getProperty(runtime, "isFast"))) return false;
+      if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, "isFast"))) return false;
       return true;
     }
   };

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -27,7 +27,7 @@ export interface Car {
   power: number
   powertrain: Powertrain
   driver?: Person
-  isFast: boolean
+  isFast?: boolean
 }
 
 // A `type T = { ... }` declaration is the same as a `interface T { ... }` - it's a `struct` in C++.


### PR DESCRIPTION
Fixes an error where structs that contain optional bools where not properly converted from Java to C++.

```ts
interface SomeStruct {
  someBool?: boolean
}
```

The reason this failed is because a Java boolean is not the same as a C++ boolean in JNI. It is an `unsigned char`, whereas a C++ boolean is a `bool`.
This cannot be implicitly converted, so we have to wrap booleans with `static_cast<bool>(value)` in order for it to work. This is what this PR now does.

And it adds the code to the example so it doesn't break in the future anymore.

- Fixes https://github.com/mrousavy/nitro/issues/259