### PR TITLE
fix: Exclude pre-packaged RN libs

### DIFF
--- a/packages/react-native-nitro-image/android/build.gradle
+++ b/packages/react-native-nitro-image/android/build.gradle
@@ -78,6 +78,7 @@ android {
             "**/libhermes.so",
             "**/libhermes-executor-debug.so",
             "**/libhermes_executor.so",
+            "**/libreactnative.so",
             "**/libreactnativejni.so",
             "**/libturbomodulejsijni.so",
             "**/libreact_nativemodule_core.so",

--- a/packages/react-native-nitro-modules/android/build.gradle
+++ b/packages/react-native-nitro-modules/android/build.gradle
@@ -80,6 +80,7 @@ android {
             "**/libhermes.so",
             "**/libhermes-executor-debug.so",
             "**/libhermes_executor.so",
+            "**/libreactnative.so",
             "**/libreactnativejni.so",
             "**/libturbomodulejsijni.so",
             "**/libreact_nativemodule_core.so",

--- a/packages/template/android/build.gradle
+++ b/packages/template/android/build.gradle
@@ -73,6 +73,7 @@ android {
             "**/libhermes.so",
             "**/libhermes-executor-debug.so",
             "**/libhermes_executor.so",
+            "**/libreactnative.so",
             "**/libreactnativejni.so",
             "**/libturbomodulejsijni.so",
             "**/libreact_nativemodule_core.so",


### PR DESCRIPTION
Excludes libraries that are pre-packaged by react-native.

Nitro (and nitro modules) depend on `libreactnative.so`, which is shipped by react-native - so it is a **local prefab**. 

Android thinks it needs to package all dependencies into a lib, but this is not true because RN is a peer dependency and is shared - locally. So we exclude it from Nitro's build.gradle.

- Fixes https://github.com/mrousavy/nitro/issues/269