### PR TITLE
fix: Fix JNI destructor being potentially called from a wrong Thread

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
@@ -97,6 +97,14 @@ ${spaces}          public virtual ${name.HybridTSpec} {
       _javaPart(jni::make_global(jThis)) {}
 
   public:
+    virtual ~${name.JHybridTSpec}() {
+      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
+      // connected to the JNI environment. To make sure fbjni can properly destroy
+      // the Java method, we connect to a JNI environment first.
+      jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
+    }
+
+  public:
     size_t getExternalMemorySize() noexcept override;
 
   public:

--- a/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
@@ -98,9 +98,7 @@ ${spaces}          public virtual ${name.HybridTSpec} {
 
   public:
     virtual ~${name.JHybridTSpec}() {
-      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
-      // connected to the JNI environment. To make sure fbjni can properly destroy
-      // the Java method, we connect to a JNI environment first.
+      // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridBaseSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridBaseSpec.hpp
@@ -32,6 +32,14 @@ namespace margelo::nitro::image {
       _javaPart(jni::make_global(jThis)) {}
 
   public:
+    virtual ~JHybridBaseSpec() {
+      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
+      // connected to the JNI environment. To make sure fbjni can properly destroy
+      // the Java method, we connect to a JNI environment first.
+      jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
+    }
+
+  public:
     size_t getExternalMemorySize() noexcept override;
 
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridBaseSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridBaseSpec.hpp
@@ -33,9 +33,7 @@ namespace margelo::nitro::image {
 
   public:
     virtual ~JHybridBaseSpec() {
-      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
-      // connected to the JNI environment. To make sure fbjni can properly destroy
-      // the Java method, we connect to a JNI environment first.
+      // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridChildSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridChildSpec.hpp
@@ -34,6 +34,14 @@ namespace margelo::nitro::image {
       _javaPart(jni::make_global(jThis)) {}
 
   public:
+    virtual ~JHybridChildSpec() {
+      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
+      // connected to the JNI environment. To make sure fbjni can properly destroy
+      // the Java method, we connect to a JNI environment first.
+      jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
+    }
+
+  public:
     size_t getExternalMemorySize() noexcept override;
 
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridChildSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridChildSpec.hpp
@@ -35,9 +35,7 @@ namespace margelo::nitro::image {
 
   public:
     virtual ~JHybridChildSpec() {
-      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
-      // connected to the JNI environment. To make sure fbjni can properly destroy
-      // the Java method, we connect to a JNI environment first.
+      // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageFactorySpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageFactorySpec.hpp
@@ -32,6 +32,14 @@ namespace margelo::nitro::image {
       _javaPart(jni::make_global(jThis)) {}
 
   public:
+    virtual ~JHybridImageFactorySpec() {
+      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
+      // connected to the JNI environment. To make sure fbjni can properly destroy
+      // the Java method, we connect to a JNI environment first.
+      jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
+    }
+
+  public:
     size_t getExternalMemorySize() noexcept override;
 
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageFactorySpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageFactorySpec.hpp
@@ -33,9 +33,7 @@ namespace margelo::nitro::image {
 
   public:
     virtual ~JHybridImageFactorySpec() {
-      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
-      // connected to the JNI environment. To make sure fbjni can properly destroy
-      // the Java method, we connect to a JNI environment first.
+      // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.hpp
@@ -32,6 +32,14 @@ namespace margelo::nitro::image {
       _javaPart(jni::make_global(jThis)) {}
 
   public:
+    virtual ~JHybridImageSpec() {
+      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
+      // connected to the JNI environment. To make sure fbjni can properly destroy
+      // the Java method, we connect to a JNI environment first.
+      jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
+    }
+
+  public:
     size_t getExternalMemorySize() noexcept override;
 
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.hpp
@@ -33,9 +33,7 @@ namespace margelo::nitro::image {
 
   public:
     virtual ~JHybridImageSpec() {
-      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
-      // connected to the JNI environment. To make sure fbjni can properly destroy
-      // the Java method, we connect to a JNI environment first.
+      // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -33,9 +33,7 @@ namespace margelo::nitro::image {
 
   public:
     virtual ~JHybridTestObjectSwiftKotlinSpec() {
-      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
-      // connected to the JNI environment. To make sure fbjni can properly destroy
-      // the Java method, we connect to a JNI environment first.
+      // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -32,6 +32,14 @@ namespace margelo::nitro::image {
       _javaPart(jni::make_global(jThis)) {}
 
   public:
+    virtual ~JHybridTestObjectSwiftKotlinSpec() {
+      // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
+      // connected to the JNI environment. To make sure fbjni can properly destroy
+      // the Java method, we connect to a JNI environment first.
+      jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
+    }
+
+  public:
     size_t getExternalMemorySize() noexcept override;
 
   public:

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/ByteBufferArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/ByteBufferArrayBuffer.hpp
@@ -25,9 +25,7 @@ public:
   }
 
   ~ByteBufferArrayBuffer() {
-    // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
-    // connected to the JNI environment. To make sure fbjni can properly destroy
-    // the Java method, we connect to a JNI environment first.
+    // Hermes GC can destroy JS objects on a non-JNI Thread.
     jni::ThreadScope::WithClassLoader([&] { _byteBuffer.reset(); });
   }
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/ByteBufferArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/ByteBufferArrayBuffer.hpp
@@ -24,6 +24,13 @@ public:
     _byteBuffer->order(jni::JByteOrder::nativeOrder());
   }
 
+  ~ByteBufferArrayBuffer() {
+    // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
+    // connected to the JNI environment. To make sure fbjni can properly destroy
+    // the Java method, we connect to a JNI environment first.
+    jni::ThreadScope::WithClassLoader([&] { _byteBuffer.reset(); });
+  }
+
 public:
   [[nodiscard]] uint8_t* data() override {
     return _byteBuffer->getDirectBytes();

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
@@ -31,17 +31,6 @@ public:
   }
 
 public:
-  ~JPromise() {
-    // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
-    // connected to the JNI environment. To make sure fbjni can properly destroy
-    // the Java method, we connect to a JNI environment first.
-    jni::ThreadScope::WithClassLoader([&] {
-      _result.reset();
-      _error.reset();
-    });
-  }
-
-public:
   void resolve(jni::alias_ref<jni::JObject> result) {
     _result = jni::make_global(result);
     for (const auto& onResolved : _onResolvedListeners) {

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
@@ -31,6 +31,17 @@ public:
   }
 
 public:
+  ~JPromise() {
+    // Hermes GC can destroy JS objects on an arbitrary Thread which might not be
+    // connected to the JNI environment. To make sure fbjni can properly destroy
+    // the Java method, we connect to a JNI environment first.
+    jni::ThreadScope::WithClassLoader([&] {
+      _result.reset();
+      _error.reset();
+    });
+  }
+
+public:
   void resolve(jni::alias_ref<jni::JObject> result) {
     _result = jni::make_global(result);
     for (const auto& onResolved : _onResolvedListeners) {


### PR DESCRIPTION
Fixes an issue where the destructor of a C++ JNI object could potentially be called from a Thread that isn't attached to the JNI environment (like a JS garbage collector thread)

- Fixes https://github.com/callstackincubator/react-native-fast-ws/issues/15

cc @grabbou