### PR TITLE
fix: Import Nitro core in Kotlin struct and function

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
@@ -24,6 +24,7 @@ package ${packageName}
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
 /**

--- a/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
@@ -19,6 +19,7 @@ package ${packageName}
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.*
 
 /**
  * Represents the JavaScript object/struct "${structType.structName}".

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Car.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Car.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.image
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.*
 
 /**
  * Represents the JavaScript object/struct "Car".

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__optional_double_.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__optional_double_.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__string.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__string.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__vector_Powertrain_.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__vector_Powertrain_.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/ImageSize.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/ImageSize.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.image
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.*
 
 /**
  * Represents the JavaScript object/struct "ImageSize".

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Person.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Person.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.image
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.*
 
 /**
  * Represents the JavaScript object/struct "Person".


### PR DESCRIPTION
When using stuff from Nitro Core like `ArrayBuffer` in a Kotlin struct or function, the import was missing. This PR fixes that.

Also fixes nitro-codegen not locally rebuilding when running the `specs` command