### PR TITLE
chore: remove `ontop` typo in docs

### DIFF
--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -307,7 +307,7 @@ Codegen also supports [Flow](https://flow.org), while Nitrogen doesn't.
 ## Legacy Native Modules
 
 Prior to [Turbo Modules](#turbo-modules), React Native provided a default approach for building native modules which was just called ["Native Modules"](https://reactnative.dev/docs/native-modules-intro).
-Instead of using JSI, Native Modules were built ontop of a communication layer that sent events and commands using JSON messages, both asynchronous and batched.
+Instead of using JSI, Native Modules were built on top of a communication layer that sent events and commands using JSON messages, both asynchronous and batched.
 
 Because Turbo Modules are just an evolution of Native Modules, their API is almost identical:
 

--- a/docs/docs/entry-point.md
+++ b/docs/docs/entry-point.md
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 
 # Entry Point
 
-Nitro is built ontop of JSI - while the primary target is React Native, Nitro even works on any other target that provides JSI.
+Nitro is built on top of JSI - while the primary target is React Native, Nitro even works on any other target that provides JSI.
 
 ## React Native's Entry Point
 

--- a/docs/docs/view-components.md
+++ b/docs/docs/view-components.md
@@ -292,6 +292,6 @@ While this works and is pretty extensible, there are a few trade-offs with this 
 
 1. This is pretty verbose. When Nitro gets first-class support for view components, this will be much simpler.
 2. This is updating props synchronously on the JS Thread. You can implement your own batching and thread-dispatching on the native side though.
-3. This does not go through React's prop updater. This means stuff like Reanimated will likely not work, as it was built ontop of `setNativeProps`.
+3. This does not go through React's prop updater. This means stuff like Reanimated will likely not work, as it was built on top of `setNativeProps`.
 
 With that said; just know what you are doing. Then you're good.

--- a/docs/docs/what-is-nitro.md
+++ b/docs/docs/what-is-nitro.md
@@ -72,7 +72,7 @@ Note: These benchmarks only compare native method throughput in extreme cases, a
 
 ### Lightweight layer
 
-While Nitro is built ontop of JSI, the layer is very lightweight and efficient.
+While Nitro is built on top of JSI, the layer is very lightweight and efficient.
 Many things like type-checking is compile-time only, and built with C++ templates or `constexpr` which introduces zero runtime overhead.
 
 ### Direct Swift &lt;&gt; C++ interop
@@ -82,7 +82,7 @@ Nitro is built using the new [Swift &lt;&gt; C++ interop](https://www.swift.org/
 
 ### Uses `jsi::NativeState`
 
-Hybrid Objects in Nitro are built ontop of `jsi::NativeState`, which is more efficient than `jsi::HostObject`. Such objects have proper native prototypes, and their native memory size is known, which allows the garbage collector to properly clean up unused objects.
+Hybrid Objects in Nitro are built on top of `jsi::NativeState`, which is more efficient than `jsi::HostObject`. Such objects have proper native prototypes, and their native memory size is known, which allows the garbage collector to properly clean up unused objects.
 
 ## Type Safety
 
@@ -147,7 +147,7 @@ This is somewhat similar to how other frameworks (like Turbo-Modules) implement 
 
 ## Modern Languages
 
-Nitro is a modern framework, built ontop of modern languages like Swift and Kotlin.
+Nitro is a modern framework, built on top of modern languages like Swift and Kotlin.
 It has first-class support for modern language features.
 
 ### Swift

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -14,7 +14,7 @@ const FeatureList: FeatureItem[] = [
     imageSource: require('@site/static/img/lightning-bolt.png').default,
     description: (
       <>
-        Nitro Modules are built ontop of a highly optimized JSI foundation that
+        Nitro Modules are built on top of a highly optimized JSI foundation that
         handles caching and property lookup really well. Nitro's communication
         layer is incredibly efficient and lightweight in memory!
       </>

--- a/packages/nitrogen/README.md
+++ b/packages/nitrogen/README.md
@@ -8,7 +8,7 @@
 
 <br />
 
-**Nitrogen** is a code-generator that takes TypeScript interfaces and generates C++, Swift and Kotlin code and native bindings built ontop of the [**react-native-nitro-modules**](../react-native-nitro-modules/) core APIs.
+**Nitrogen** is a code-generator that takes TypeScript interfaces and generates C++, Swift and Kotlin code and native bindings built on top of the [**react-native-nitro-modules**](../react-native-nitro-modules/) core APIs.
 
 ## Installation
 


### PR DESCRIPTION
This PR removes small `ontop` typo found in multiple places