### PR TITLE
Fix built package autolinking

### DIFF
--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -11,6 +11,7 @@
     "src",
     "react-native.config.js",
     "lib",
+    "nitrogen",
     "android/build.gradle",
     "android/gradle.properties",
     "android/CMakeLists.txt",


### PR DESCRIPTION
Currently the package.json doesn't include the nitrogen folder which is needed to execute the autolinking