### PR TITLE
feat: Explicitly catch `ClassNotFound` and `NoSuchMethod` errors

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinHybridObjectRegistration.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinHybridObjectRegistration.ts
@@ -59,7 +59,7 @@ HybridObjectRegistry::registerHybridObjectConstructor(
                                  "- Make sure the class is not stripped. If you are using ProGuard, add \`@Keep\` and \`@DoNotStrip\` annotations to ${jniClassName}.");
       } else if (message.find("NoSuchMethodError")) {
         throw std::runtime_error("Couldn't find ${jniClassName}'s default constructor!\\n"
-                                 "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\\n"
+                                 "- If you want to autolink ${jniClassName}, add a default constructor that takes zero arguments.\\n"
                                  "- If you need arguments to create instances of ${jniClassName}, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\\n"
                                  "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add \`@Keep\` and \`@DoNotStrip\` annotations to the default constructor.");
       } else {

--- a/packages/nitrogen/src/syntax/kotlin/KotlinHybridObjectRegistration.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinHybridObjectRegistration.ts
@@ -24,10 +24,6 @@ export function createJNIHybridObjectRegistration({
 }: Props): JNIHybridObjectRegistration {
   const { JHybridTSpec } = getHybridObjectName(hybridObjectName)
   const jniNamespace = NitroConfig.getAndroidPackage('c++/jni', jniClassName)
-  const javaNamespace = NitroConfig.getAndroidPackage(
-    'java/kotlin',
-    jniClassName
-  )
 
   return {
     requiredImports: [
@@ -37,42 +33,18 @@ export function createJNIHybridObjectRegistration({
         language: 'c++',
         space: 'system',
       },
+      {
+        name: 'NitroModules/DefaultConstructableObject.hpp',
+        language: 'c++',
+        space: 'system',
+      },
     ],
     cppCode: `
 HybridObjectRegistry::registerHybridObjectConstructor(
   "${hybridObjectName}",
   []() -> std::shared_ptr<HybridObject> {
-    static jni::alias_ref<jni::JClass> javaClass;
-    static jni::JConstructor<${JHybridTSpec}::javaobject()> defaultConstructor;
-    static bool isInitialized = false;
-    try {
-      if (!isInitialized) {
-        javaClass = jni::findClassStatic("${jniNamespace}");
-        defaultConstructor = javaClass->getConstructor<${JHybridTSpec}::javaobject()>();
-        isInitialized = true;
-      }
-    } catch (const jni::JniException& exc) {
-      std::string message = exc.what();
-      if (message.find("ClassNotFoundException")) {
-        throw std::runtime_error("Couldn't find class \`${javaNamespace}\`!\\n"
-                                 "- Make sure the class exists in the specified namespace.\\n"
-                                 "- Make sure the class is not stripped. If you are using ProGuard, add \`@Keep\` and \`@DoNotStrip\` annotations to ${jniClassName}.");
-      } else if (message.find("NoSuchMethodError")) {
-        throw std::runtime_error("Couldn't find ${jniClassName}'s default constructor!\\n"
-                                 "- If you want to autolink ${jniClassName}, add a default constructor that takes zero arguments.\\n"
-                                 "- If you need arguments to create instances of ${jniClassName}, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\\n"
-                                 "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add \`@Keep\` and \`@DoNotStrip\` annotations to the default constructor.");
-      } else {
-        throw;
-      }
-    }
-
-    auto instance = javaClass->newObject(defaultConstructor);
-#ifdef NITRO_DEBUG
-    if (instance == nullptr) [[unlikely]] {
-      throw std::runtime_error("Failed to create an instance of \\"${JHybridTSpec}\\" - the constructor returned null!");
-    }
-#endif
+    static DefaultConstructableObject<${JHybridTSpec}::javaobject> object("${jniNamespace}");
+    auto instance = object.create();
     auto globalRef = jni::make_global(instance);
     return JNISharedPtr::make_shared_from_jni<${JHybridTSpec}>(globalRef);
   }

--- a/packages/nitrogen/src/syntax/kotlin/KotlinHybridObjectRegistration.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinHybridObjectRegistration.ts
@@ -44,7 +44,7 @@ HybridObjectRegistry::registerHybridObjectConstructor(
   []() -> std::shared_ptr<HybridObject> {
     static jni::alias_ref<jni::JClass> javaClass;
     static jni::JConstructor<${JHybridTSpec}::javaobject()> defaultConstructor;
-    static bool isInitialized;
+    static bool isInitialized = false;
     try {
       if (!isInitialized) {
         javaClass = jni::findClassStatic("${jniNamespace}");
@@ -54,14 +54,14 @@ HybridObjectRegistry::registerHybridObjectConstructor(
     } catch (const jni::JniException& exc) {
       std::string message = exc.what();
       if (message.find("ClassNotFoundException")) {
-        throw std::runtime_error("Couldn't find class \\"${javaNamespace}\\"!\\n"
+        throw std::runtime_error("Couldn't find class \`${javaNamespace}\`!\\n"
                                  "- Make sure the class exists in the specified namespace.\\n"
-                                 "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to ${jniClassName}.");
+                                 "- Make sure the class is not stripped. If you are using ProGuard, add \`@Keep\` and \`@DoNotStrip\` annotations to ${jniClassName}.");
       } else if (message.find("NoSuchMethodError")) {
         throw std::runtime_error("Couldn't find ${jniClassName}'s default constructor!\\n"
                                  "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\\n"
                                  "- If you need arguments to create instances of ${jniClassName}, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\\n"
-                                 "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to the default constructor.");
+                                 "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add \`@Keep\` and \`@DoNotStrip\` annotations to the default constructor.");
       } else {
         throw;
       }

--- a/packages/nitrogen/src/syntax/kotlin/KotlinHybridObjectRegistration.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinHybridObjectRegistration.ts
@@ -44,19 +44,27 @@ HybridObjectRegistry::registerHybridObjectConstructor(
   []() -> std::shared_ptr<HybridObject> {
     static jni::alias_ref<jni::JClass> javaClass;
     static jni::JConstructor<${JHybridTSpec}::javaobject()> defaultConstructor;
+    static bool isInitialized;
     try {
-      if (javaClass == nullptr) {
+      if (!isInitialized) {
         javaClass = jni::findClassStatic("${jniNamespace}");
         defaultConstructor = javaClass->getConstructor<${JHybridTSpec}::javaobject()>();
+        isInitialized = true;
       }
     } catch (const jni::JniException& exc) {
       std::string message = exc.what();
       if (message.find("ClassNotFoundException")) {
-        throw std::runtime_error("Couldn't find class \\"${javaNamespace}\\"!\n"
-                                 "- Make sure the class exists in the specified namespace.\n"
+        throw std::runtime_error("Couldn't find class \\"${javaNamespace}\\"!\\n"
+                                 "- Make sure the class exists in the specified namespace.\\n"
                                  "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to ${jniClassName}.");
+      } else if (message.find("NoSuchMethodError")) {
+        throw std::runtime_error("Couldn't find ${jniClassName}'s default constructor!\\n"
+                                 "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\\n"
+                                 "- If you need arguments to create instances of ${jniClassName}, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\\n"
+                                 "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to the default constructor.");
+      } else {
+        throw;
       }
-      throw;
     }
 
     auto instance = javaClass->newObject(defaultConstructor);

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -49,8 +49,24 @@ int initialize(JavaVM* vm) {
     HybridObjectRegistry::registerHybridObjectConstructor(
       "ImageFactory",
       []() -> std::shared_ptr<HybridObject> {
-        static auto javaClass = jni::findClassStatic("com/margelo/nitro/image/ImageFactory");
-        static auto defaultConstructor = javaClass->getConstructor<JHybridImageFactorySpec::javaobject()>();
+        static jni::alias_ref<jni::JClass> javaClass;
+        static jni::JConstructor<JHybridImageFactorySpec::javaobject()> defaultConstructor;
+        try {
+          if (javaClass == nullptr) {
+            javaClass = jni::findClassStatic("com/margelo/nitro/image/ImageFactory");
+            defaultConstructor = javaClass->getConstructor<JHybridImageFactorySpec::javaobject()>();
+          }
+        } catch (const jni::JniException& exc) {
+          std::string message = exc.what();
+          if (message.find("ClassNotFoundException")) {
+            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.ImageFactory\"!
+    "
+                                     "- Make sure the class exists in the specified namespace.
+    "
+                                     "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to ImageFactory.");
+          }
+          throw;
+        }
     
         auto instance = javaClass->newObject(defaultConstructor);
     #ifdef NITRO_DEBUG
@@ -74,8 +90,24 @@ int initialize(JavaVM* vm) {
     HybridObjectRegistry::registerHybridObjectConstructor(
       "TestObjectSwiftKotlin",
       []() -> std::shared_ptr<HybridObject> {
-        static auto javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridTestObjectKotlin");
-        static auto defaultConstructor = javaClass->getConstructor<JHybridTestObjectSwiftKotlinSpec::javaobject()>();
+        static jni::alias_ref<jni::JClass> javaClass;
+        static jni::JConstructor<JHybridTestObjectSwiftKotlinSpec::javaobject()> defaultConstructor;
+        try {
+          if (javaClass == nullptr) {
+            javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridTestObjectKotlin");
+            defaultConstructor = javaClass->getConstructor<JHybridTestObjectSwiftKotlinSpec::javaobject()>();
+          }
+        } catch (const jni::JniException& exc) {
+          std::string message = exc.what();
+          if (message.find("ClassNotFoundException")) {
+            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridTestObjectKotlin\"!
+    "
+                                     "- Make sure the class exists in the specified namespace.
+    "
+                                     "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to HybridTestObjectKotlin.");
+          }
+          throw;
+        }
     
         auto instance = javaClass->newObject(defaultConstructor);
     #ifdef NITRO_DEBUG
@@ -90,8 +122,24 @@ int initialize(JavaVM* vm) {
     HybridObjectRegistry::registerHybridObjectConstructor(
       "Base",
       []() -> std::shared_ptr<HybridObject> {
-        static auto javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridBase");
-        static auto defaultConstructor = javaClass->getConstructor<JHybridBaseSpec::javaobject()>();
+        static jni::alias_ref<jni::JClass> javaClass;
+        static jni::JConstructor<JHybridBaseSpec::javaobject()> defaultConstructor;
+        try {
+          if (javaClass == nullptr) {
+            javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridBase");
+            defaultConstructor = javaClass->getConstructor<JHybridBaseSpec::javaobject()>();
+          }
+        } catch (const jni::JniException& exc) {
+          std::string message = exc.what();
+          if (message.find("ClassNotFoundException")) {
+            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridBase\"!
+    "
+                                     "- Make sure the class exists in the specified namespace.
+    "
+                                     "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to HybridBase.");
+          }
+          throw;
+        }
     
         auto instance = javaClass->newObject(defaultConstructor);
     #ifdef NITRO_DEBUG
@@ -106,8 +154,24 @@ int initialize(JavaVM* vm) {
     HybridObjectRegistry::registerHybridObjectConstructor(
       "Child",
       []() -> std::shared_ptr<HybridObject> {
-        static auto javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridChild");
-        static auto defaultConstructor = javaClass->getConstructor<JHybridChildSpec::javaobject()>();
+        static jni::alias_ref<jni::JClass> javaClass;
+        static jni::JConstructor<JHybridChildSpec::javaobject()> defaultConstructor;
+        try {
+          if (javaClass == nullptr) {
+            javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridChild");
+            defaultConstructor = javaClass->getConstructor<JHybridChildSpec::javaobject()>();
+          }
+        } catch (const jni::JniException& exc) {
+          std::string message = exc.what();
+          if (message.find("ClassNotFoundException")) {
+            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridChild\"!
+    "
+                                     "- Make sure the class exists in the specified namespace.
+    "
+                                     "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to HybridChild.");
+          }
+          throw;
+        }
     
         auto instance = javaClass->newObject(defaultConstructor);
     #ifdef NITRO_DEBUG

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -51,21 +51,27 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static jni::alias_ref<jni::JClass> javaClass;
         static jni::JConstructor<JHybridImageFactorySpec::javaobject()> defaultConstructor;
+        static bool isInitialized;
         try {
-          if (javaClass == nullptr) {
+          if (!isInitialized) {
             javaClass = jni::findClassStatic("com/margelo/nitro/image/ImageFactory");
             defaultConstructor = javaClass->getConstructor<JHybridImageFactorySpec::javaobject()>();
+            isInitialized = true;
           }
         } catch (const jni::JniException& exc) {
           std::string message = exc.what();
           if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.ImageFactory\"!
-    "
-                                     "- Make sure the class exists in the specified namespace.
-    "
+            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.ImageFactory\"!\n"
+                                     "- Make sure the class exists in the specified namespace.\n"
                                      "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to ImageFactory.");
+          } else if (message.find("NoSuchMethodError")) {
+            throw std::runtime_error("Couldn't find ImageFactory's default constructor!\n"
+                                     "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
+                                     "- If you need arguments to create instances of ImageFactory, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
+                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to the default constructor.");
+          } else {
+            throw;
           }
-          throw;
         }
     
         auto instance = javaClass->newObject(defaultConstructor);
@@ -92,21 +98,27 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static jni::alias_ref<jni::JClass> javaClass;
         static jni::JConstructor<JHybridTestObjectSwiftKotlinSpec::javaobject()> defaultConstructor;
+        static bool isInitialized;
         try {
-          if (javaClass == nullptr) {
+          if (!isInitialized) {
             javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridTestObjectKotlin");
             defaultConstructor = javaClass->getConstructor<JHybridTestObjectSwiftKotlinSpec::javaobject()>();
+            isInitialized = true;
           }
         } catch (const jni::JniException& exc) {
           std::string message = exc.what();
           if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridTestObjectKotlin\"!
-    "
-                                     "- Make sure the class exists in the specified namespace.
-    "
+            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridTestObjectKotlin\"!\n"
+                                     "- Make sure the class exists in the specified namespace.\n"
                                      "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to HybridTestObjectKotlin.");
+          } else if (message.find("NoSuchMethodError")) {
+            throw std::runtime_error("Couldn't find HybridTestObjectKotlin's default constructor!\n"
+                                     "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
+                                     "- If you need arguments to create instances of HybridTestObjectKotlin, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
+                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to the default constructor.");
+          } else {
+            throw;
           }
-          throw;
         }
     
         auto instance = javaClass->newObject(defaultConstructor);
@@ -124,21 +136,27 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static jni::alias_ref<jni::JClass> javaClass;
         static jni::JConstructor<JHybridBaseSpec::javaobject()> defaultConstructor;
+        static bool isInitialized;
         try {
-          if (javaClass == nullptr) {
+          if (!isInitialized) {
             javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridBase");
             defaultConstructor = javaClass->getConstructor<JHybridBaseSpec::javaobject()>();
+            isInitialized = true;
           }
         } catch (const jni::JniException& exc) {
           std::string message = exc.what();
           if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridBase\"!
-    "
-                                     "- Make sure the class exists in the specified namespace.
-    "
+            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridBase\"!\n"
+                                     "- Make sure the class exists in the specified namespace.\n"
                                      "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to HybridBase.");
+          } else if (message.find("NoSuchMethodError")) {
+            throw std::runtime_error("Couldn't find HybridBase's default constructor!\n"
+                                     "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
+                                     "- If you need arguments to create instances of HybridBase, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
+                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to the default constructor.");
+          } else {
+            throw;
           }
-          throw;
         }
     
         auto instance = javaClass->newObject(defaultConstructor);
@@ -156,21 +174,27 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static jni::alias_ref<jni::JClass> javaClass;
         static jni::JConstructor<JHybridChildSpec::javaobject()> defaultConstructor;
+        static bool isInitialized;
         try {
-          if (javaClass == nullptr) {
+          if (!isInitialized) {
             javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridChild");
             defaultConstructor = javaClass->getConstructor<JHybridChildSpec::javaobject()>();
+            isInitialized = true;
           }
         } catch (const jni::JniException& exc) {
           std::string message = exc.what();
           if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridChild\"!
-    "
-                                     "- Make sure the class exists in the specified namespace.
-    "
+            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridChild\"!\n"
+                                     "- Make sure the class exists in the specified namespace.\n"
                                      "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to HybridChild.");
+          } else if (message.find("NoSuchMethodError")) {
+            throw std::runtime_error("Couldn't find HybridChild's default constructor!\n"
+                                     "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
+                                     "- If you need arguments to create instances of HybridChild, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
+                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to the default constructor.");
+          } else {
+            throw;
           }
-          throw;
         }
     
         auto instance = javaClass->newObject(defaultConstructor);

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -66,7 +66,7 @@ int initialize(JavaVM* vm) {
                                      "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to ImageFactory.");
           } else if (message.find("NoSuchMethodError")) {
             throw std::runtime_error("Couldn't find ImageFactory's default constructor!\n"
-                                     "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
+                                     "- If you want to autolink ImageFactory, add a default constructor that takes zero arguments.\n"
                                      "- If you need arguments to create instances of ImageFactory, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
                                      "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
           } else {
@@ -113,7 +113,7 @@ int initialize(JavaVM* vm) {
                                      "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to HybridTestObjectKotlin.");
           } else if (message.find("NoSuchMethodError")) {
             throw std::runtime_error("Couldn't find HybridTestObjectKotlin's default constructor!\n"
-                                     "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
+                                     "- If you want to autolink HybridTestObjectKotlin, add a default constructor that takes zero arguments.\n"
                                      "- If you need arguments to create instances of HybridTestObjectKotlin, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
                                      "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
           } else {
@@ -151,7 +151,7 @@ int initialize(JavaVM* vm) {
                                      "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to HybridBase.");
           } else if (message.find("NoSuchMethodError")) {
             throw std::runtime_error("Couldn't find HybridBase's default constructor!\n"
-                                     "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
+                                     "- If you want to autolink HybridBase, add a default constructor that takes zero arguments.\n"
                                      "- If you need arguments to create instances of HybridBase, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
                                      "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
           } else {
@@ -189,7 +189,7 @@ int initialize(JavaVM* vm) {
                                      "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to HybridChild.");
           } else if (message.find("NoSuchMethodError")) {
             throw std::runtime_error("Couldn't find HybridChild's default constructor!\n"
-                                     "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
+                                     "- If you want to autolink HybridChild, add a default constructor that takes zero arguments.\n"
                                      "- If you need arguments to create instances of HybridChild, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
                                      "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
           } else {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -51,7 +51,7 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static jni::alias_ref<jni::JClass> javaClass;
         static jni::JConstructor<JHybridImageFactorySpec::javaobject()> defaultConstructor;
-        static bool isInitialized;
+        static bool isInitialized = false;
         try {
           if (!isInitialized) {
             javaClass = jni::findClassStatic("com/margelo/nitro/image/ImageFactory");
@@ -61,14 +61,14 @@ int initialize(JavaVM* vm) {
         } catch (const jni::JniException& exc) {
           std::string message = exc.what();
           if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.ImageFactory\"!\n"
+            throw std::runtime_error("Couldn't find class `com.margelo.nitro.image.ImageFactory`!\n"
                                      "- Make sure the class exists in the specified namespace.\n"
-                                     "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to ImageFactory.");
+                                     "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to ImageFactory.");
           } else if (message.find("NoSuchMethodError")) {
             throw std::runtime_error("Couldn't find ImageFactory's default constructor!\n"
                                      "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
                                      "- If you need arguments to create instances of ImageFactory, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
-                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to the default constructor.");
+                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
           } else {
             throw;
           }
@@ -98,7 +98,7 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static jni::alias_ref<jni::JClass> javaClass;
         static jni::JConstructor<JHybridTestObjectSwiftKotlinSpec::javaobject()> defaultConstructor;
-        static bool isInitialized;
+        static bool isInitialized = false;
         try {
           if (!isInitialized) {
             javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridTestObjectKotlin");
@@ -108,14 +108,14 @@ int initialize(JavaVM* vm) {
         } catch (const jni::JniException& exc) {
           std::string message = exc.what();
           if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridTestObjectKotlin\"!\n"
+            throw std::runtime_error("Couldn't find class `com.margelo.nitro.image.HybridTestObjectKotlin`!\n"
                                      "- Make sure the class exists in the specified namespace.\n"
-                                     "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to HybridTestObjectKotlin.");
+                                     "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to HybridTestObjectKotlin.");
           } else if (message.find("NoSuchMethodError")) {
             throw std::runtime_error("Couldn't find HybridTestObjectKotlin's default constructor!\n"
                                      "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
                                      "- If you need arguments to create instances of HybridTestObjectKotlin, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
-                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to the default constructor.");
+                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
           } else {
             throw;
           }
@@ -136,7 +136,7 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static jni::alias_ref<jni::JClass> javaClass;
         static jni::JConstructor<JHybridBaseSpec::javaobject()> defaultConstructor;
-        static bool isInitialized;
+        static bool isInitialized = false;
         try {
           if (!isInitialized) {
             javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridBase");
@@ -146,14 +146,14 @@ int initialize(JavaVM* vm) {
         } catch (const jni::JniException& exc) {
           std::string message = exc.what();
           if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridBase\"!\n"
+            throw std::runtime_error("Couldn't find class `com.margelo.nitro.image.HybridBase`!\n"
                                      "- Make sure the class exists in the specified namespace.\n"
-                                     "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to HybridBase.");
+                                     "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to HybridBase.");
           } else if (message.find("NoSuchMethodError")) {
             throw std::runtime_error("Couldn't find HybridBase's default constructor!\n"
                                      "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
                                      "- If you need arguments to create instances of HybridBase, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
-                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to the default constructor.");
+                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
           } else {
             throw;
           }
@@ -174,7 +174,7 @@ int initialize(JavaVM* vm) {
       []() -> std::shared_ptr<HybridObject> {
         static jni::alias_ref<jni::JClass> javaClass;
         static jni::JConstructor<JHybridChildSpec::javaobject()> defaultConstructor;
-        static bool isInitialized;
+        static bool isInitialized = false;
         try {
           if (!isInitialized) {
             javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridChild");
@@ -184,14 +184,14 @@ int initialize(JavaVM* vm) {
         } catch (const jni::JniException& exc) {
           std::string message = exc.what();
           if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class \"com.margelo.nitro.image.HybridChild\"!\n"
+            throw std::runtime_error("Couldn't find class `com.margelo.nitro.image.HybridChild`!\n"
                                      "- Make sure the class exists in the specified namespace.\n"
-                                     "- Make sure the class is not stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to HybridChild.");
+                                     "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to HybridChild.");
           } else if (message.find("NoSuchMethodError")) {
             throw std::runtime_error("Couldn't find HybridChild's default constructor!\n"
                                      "- If you don't have one, make sure to add a constructor that takes zero arguments (= default constructor).\n"
                                      "- If you need arguments to create instances of HybridChild, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
-                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add @Keep and @DoNotStrip annotations to the default constructor.");
+                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
           } else {
             throw;
           }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -21,6 +21,7 @@
 #include "JHybridBaseSpec.hpp"
 #include "JHybridChildSpec.hpp"
 #include <NitroModules/JNISharedPtr.hpp>
+#include <NitroModules/DefaultConstructableObject.hpp>
 #include "HybridTestObjectCpp.hpp"
 
 namespace margelo::nitro::image {
@@ -49,37 +50,8 @@ int initialize(JavaVM* vm) {
     HybridObjectRegistry::registerHybridObjectConstructor(
       "ImageFactory",
       []() -> std::shared_ptr<HybridObject> {
-        static jni::alias_ref<jni::JClass> javaClass;
-        static jni::JConstructor<JHybridImageFactorySpec::javaobject()> defaultConstructor;
-        static bool isInitialized = false;
-        try {
-          if (!isInitialized) {
-            javaClass = jni::findClassStatic("com/margelo/nitro/image/ImageFactory");
-            defaultConstructor = javaClass->getConstructor<JHybridImageFactorySpec::javaobject()>();
-            isInitialized = true;
-          }
-        } catch (const jni::JniException& exc) {
-          std::string message = exc.what();
-          if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class `com.margelo.nitro.image.ImageFactory`!\n"
-                                     "- Make sure the class exists in the specified namespace.\n"
-                                     "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to ImageFactory.");
-          } else if (message.find("NoSuchMethodError")) {
-            throw std::runtime_error("Couldn't find ImageFactory's default constructor!\n"
-                                     "- If you want to autolink ImageFactory, add a default constructor that takes zero arguments.\n"
-                                     "- If you need arguments to create instances of ImageFactory, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
-                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
-          } else {
-            throw;
-          }
-        }
-    
-        auto instance = javaClass->newObject(defaultConstructor);
-    #ifdef NITRO_DEBUG
-        if (instance == nullptr) [[unlikely]] {
-          throw std::runtime_error("Failed to create an instance of \"JHybridImageFactorySpec\" - the constructor returned null!");
-        }
-    #endif
+        static DefaultConstructableObject<JHybridImageFactorySpec::javaobject> object("com/margelo/nitro/image/ImageFactory");
+        auto instance = object.create();
         auto globalRef = jni::make_global(instance);
         return JNISharedPtr::make_shared_from_jni<JHybridImageFactorySpec>(globalRef);
       }
@@ -96,37 +68,8 @@ int initialize(JavaVM* vm) {
     HybridObjectRegistry::registerHybridObjectConstructor(
       "TestObjectSwiftKotlin",
       []() -> std::shared_ptr<HybridObject> {
-        static jni::alias_ref<jni::JClass> javaClass;
-        static jni::JConstructor<JHybridTestObjectSwiftKotlinSpec::javaobject()> defaultConstructor;
-        static bool isInitialized = false;
-        try {
-          if (!isInitialized) {
-            javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridTestObjectKotlin");
-            defaultConstructor = javaClass->getConstructor<JHybridTestObjectSwiftKotlinSpec::javaobject()>();
-            isInitialized = true;
-          }
-        } catch (const jni::JniException& exc) {
-          std::string message = exc.what();
-          if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class `com.margelo.nitro.image.HybridTestObjectKotlin`!\n"
-                                     "- Make sure the class exists in the specified namespace.\n"
-                                     "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to HybridTestObjectKotlin.");
-          } else if (message.find("NoSuchMethodError")) {
-            throw std::runtime_error("Couldn't find HybridTestObjectKotlin's default constructor!\n"
-                                     "- If you want to autolink HybridTestObjectKotlin, add a default constructor that takes zero arguments.\n"
-                                     "- If you need arguments to create instances of HybridTestObjectKotlin, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
-                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
-          } else {
-            throw;
-          }
-        }
-    
-        auto instance = javaClass->newObject(defaultConstructor);
-    #ifdef NITRO_DEBUG
-        if (instance == nullptr) [[unlikely]] {
-          throw std::runtime_error("Failed to create an instance of \"JHybridTestObjectSwiftKotlinSpec\" - the constructor returned null!");
-        }
-    #endif
+        static DefaultConstructableObject<JHybridTestObjectSwiftKotlinSpec::javaobject> object("com/margelo/nitro/image/HybridTestObjectKotlin");
+        auto instance = object.create();
         auto globalRef = jni::make_global(instance);
         return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(globalRef);
       }
@@ -134,37 +77,8 @@ int initialize(JavaVM* vm) {
     HybridObjectRegistry::registerHybridObjectConstructor(
       "Base",
       []() -> std::shared_ptr<HybridObject> {
-        static jni::alias_ref<jni::JClass> javaClass;
-        static jni::JConstructor<JHybridBaseSpec::javaobject()> defaultConstructor;
-        static bool isInitialized = false;
-        try {
-          if (!isInitialized) {
-            javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridBase");
-            defaultConstructor = javaClass->getConstructor<JHybridBaseSpec::javaobject()>();
-            isInitialized = true;
-          }
-        } catch (const jni::JniException& exc) {
-          std::string message = exc.what();
-          if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class `com.margelo.nitro.image.HybridBase`!\n"
-                                     "- Make sure the class exists in the specified namespace.\n"
-                                     "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to HybridBase.");
-          } else if (message.find("NoSuchMethodError")) {
-            throw std::runtime_error("Couldn't find HybridBase's default constructor!\n"
-                                     "- If you want to autolink HybridBase, add a default constructor that takes zero arguments.\n"
-                                     "- If you need arguments to create instances of HybridBase, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
-                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
-          } else {
-            throw;
-          }
-        }
-    
-        auto instance = javaClass->newObject(defaultConstructor);
-    #ifdef NITRO_DEBUG
-        if (instance == nullptr) [[unlikely]] {
-          throw std::runtime_error("Failed to create an instance of \"JHybridBaseSpec\" - the constructor returned null!");
-        }
-    #endif
+        static DefaultConstructableObject<JHybridBaseSpec::javaobject> object("com/margelo/nitro/image/HybridBase");
+        auto instance = object.create();
         auto globalRef = jni::make_global(instance);
         return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(globalRef);
       }
@@ -172,37 +86,8 @@ int initialize(JavaVM* vm) {
     HybridObjectRegistry::registerHybridObjectConstructor(
       "Child",
       []() -> std::shared_ptr<HybridObject> {
-        static jni::alias_ref<jni::JClass> javaClass;
-        static jni::JConstructor<JHybridChildSpec::javaobject()> defaultConstructor;
-        static bool isInitialized = false;
-        try {
-          if (!isInitialized) {
-            javaClass = jni::findClassStatic("com/margelo/nitro/image/HybridChild");
-            defaultConstructor = javaClass->getConstructor<JHybridChildSpec::javaobject()>();
-            isInitialized = true;
-          }
-        } catch (const jni::JniException& exc) {
-          std::string message = exc.what();
-          if (message.find("ClassNotFoundException")) {
-            throw std::runtime_error("Couldn't find class `com.margelo.nitro.image.HybridChild`!\n"
-                                     "- Make sure the class exists in the specified namespace.\n"
-                                     "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to HybridChild.");
-          } else if (message.find("NoSuchMethodError")) {
-            throw std::runtime_error("Couldn't find HybridChild's default constructor!\n"
-                                     "- If you want to autolink HybridChild, add a default constructor that takes zero arguments.\n"
-                                     "- If you need arguments to create instances of HybridChild, create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
-                                     "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to the default constructor.");
-          } else {
-            throw;
-          }
-        }
-    
-        auto instance = javaClass->newObject(defaultConstructor);
-    #ifdef NITRO_DEBUG
-        if (instance == nullptr) [[unlikely]] {
-          throw std::runtime_error("Failed to create an instance of \"JHybridChildSpec\" - the constructor returned null!");
-        }
-    #endif
+        static DefaultConstructableObject<JHybridChildSpec::javaobject> object("com/margelo/nitro/image/HybridChild");
+        auto instance = object.create();
         auto globalRef = jni::make_global(instance);
         return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(globalRef);
       }

--- a/packages/react-native-nitro-modules/android/src/main/cpp/registry/DefaultConstructableObject.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/registry/DefaultConstructableObject.hpp
@@ -1,0 +1,79 @@
+//
+//  DefaultConstructableObject.hpp
+//  react-native-nitro
+//
+//  Created by Marc Rousavy on 11.11.24.
+//
+
+#pragma once
+
+#include "NitroDefines.hpp"
+#include <fbjni/fbjni.h>
+
+namespace margelo::nitro {
+
+using namespace facebook;
+
+template <typename T>
+class DefaultConstructableObject {
+public:
+  explicit DefaultConstructableObject(const char* javaClassDescriptor) {
+    try {
+      // Find JNI class and default constructor
+      _javaClass = jni::findClassStatic(javaClassDescriptor);
+      _defaultConstructor = _javaClass->getConstructor<T()>();
+    } catch (const jni::JniException& exc) {
+      std::string message = exc.what();
+      std::string descriptor = javaClassDescriptor;
+      std::string className = findClassName(descriptor);
+      if (message.find("ClassNotFoundException")) {
+        // Java class cannot be found
+        throw std::runtime_error(
+            "Couldn't find class `" + descriptor +
+            "`!\n"
+            "- Make sure the class exists in the specified namespace.\n"
+            "- Make sure the class is not stripped. If you are using ProGuard, add `@Keep` and `@DoNotStrip` annotations to `" +
+            className + "`.");
+      } else if (message.find("NoSuchMethodError")) {
+        // Default Constructor cannot be found
+        throw std::runtime_error(
+            "Couldn't find " + className +
+            "'s default constructor!\n"
+            "- If you want to autolink " +
+            className +
+            ", add a default constructor that takes zero arguments.\n"
+            "- If you need arguments to create instances of " +
+            className +
+            ", create a separate HybridObject that acts as a factory for this HybridObject to create instances of it with parameters.\n"
+            "- If you already have a default constructor, make sure it is not being stripped. If you are using ProGuard, add `@Keep` and "
+            "`@DoNotStrip` annotations to the default constructor.");
+      } else {
+        throw;
+      }
+    }
+  }
+
+public:
+  jni::local_ref<T> create() const {
+    // Calls the class's default constructor
+    auto instance = _javaClass->newObject(_defaultConstructor);
+#ifdef NITRO_DEBUG
+    if (instance == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to create an instance of \"JHybridTestObjectSwiftKotlinSpec\" - the constructor returned null!");
+    }
+#endif
+    return instance;
+  }
+
+private:
+  static std::string findClassName(const std::string& jniDescriptor) {
+    size_t lastSlash = jniDescriptor.rfind('/');
+    return jniDescriptor.substr(lastSlash + 1);
+  }
+
+private:
+  jni::alias_ref<jni::JClass> _javaClass;
+  jni::JConstructor<T()> _defaultConstructor;
+};
+
+} // namespace margelo::nitro


### PR DESCRIPTION
Explicitly catches `ClassNotFoundException` and `NoSuchMethodError` errors, which happen when the class or constructor cannot be found by JNI.

These errors can occur when the user puts the class in the wrong namespace, forgets to implement a default-constructor, or when it gets stripped by ProGuard in release builds. In those cases, Nitro will throw with a nicer error message for the user.