### PR TITLE
feat: Add visionOS support

### DIFF
--- a/packages/react-native-nitro-modules/NitroModules.podspec
+++ b/packages/react-native-nitro-modules/NitroModules.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported }
+  s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
   s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
 
   # VisionCamera Core C++ bindings

--- a/packages/react-native-nitro-modules/package.json
+++ b/packages/react-native-nitro-modules/package.json
@@ -27,6 +27,7 @@
     "nitro",
     "ios",
     "android",
+    "visionOS",
     "cpp",
     "framework",
     "react",


### PR DESCRIPTION
## Summary
Adds support for visionOS

## Description
I have successfully run my nitro library (react-native-video v7) on visionOS by only changing podspec of `react-native-nitro-modules`! 

- Added `visionos` to platforms
- Added `visionOS` keyword to package.json