### PR TITLE
fix: Perform safer checks for `toContain(..)` in example, and add `NitroModules.hasNativeState(value)`

### DIFF
--- a/example/src/Testers.ts
+++ b/example/src/Testers.ts
@@ -68,7 +68,10 @@ export class State<T> {
   toContain(key: keyof T): State<T> {
     if (
       this.result != null &&
-      (this.result[key] != null ||
+      (Object.hasOwn(this.result, key) ||
+        this.result[key] != null ||
+        // @ts-expect-error maybe a TypeScript bug? It's an object, so it's safe
+        (typeof key === 'object' && key in this.result) ||
         Object.keys(this.result).includes(key as string))
     ) {
       this.onPassed()

--- a/example/src/utils.ts
+++ b/example/src/utils.ts
@@ -21,18 +21,24 @@ export function stringify(value: unknown): string {
       }
       try {
         if ('toString' in value) {
-          if (NitroModules.hasNativeState(value)) {
-            // We sometimes stringify Prototypes.
-            // We can only call `toString()` on them if they have a NativeState assigned.
+          if (Object.hasOwn(value, 'toString')) {
+            // It is some kind of Object that has a toString() method directly.
             const string = value.toString()
             if (string !== '[object Object]') return string
+          } else {
+            // It is some kind of Object that has a toString() method somewhere in the prototype chain..
+            // It is _likely_ that this method requires NativeState
+            if (NitroModules.hasNativeState(value)) {
+              // If we have NativeState, toString() will likely work.
+              const string = value.toString()
+              if (string !== '[object Object]') return string
+            }
           }
         }
-        return `{ ${value} ${Object.keys(value).join(', ')} }`
       } catch {
         // toString() threw - maybe because we accessed it on a prototype.
-        return `{ [Object] ${Object.keys(value).join(', ')} }`
       }
+      return `{ [Object] ${Object.keys(value).join(', ')} }`
     default:
       return `${value}`
   }

--- a/example/src/utils.ts
+++ b/example/src/utils.ts
@@ -1,3 +1,5 @@
+import { NitroModules } from 'react-native-nitro-modules'
+
 export function stringify(value: unknown): string {
   if (value == null) {
     return 'null'
@@ -19,8 +21,12 @@ export function stringify(value: unknown): string {
       }
       try {
         if ('toString' in value) {
-          const string = value.toString()
-          if (string !== '[object Object]') return string
+          if (NitroModules.hasNativeState(value)) {
+            // We sometimes stringify Prototypes.
+            // We can only call `toString()` on them if they have a NativeState assigned.
+            const string = value.toString()
+            if (string !== '[object Object]') return string
+          }
         }
         return `{ ${value} ${Object.keys(value).join(', ')} }`
       } catch {

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
@@ -21,6 +21,8 @@ void HybridNitroModulesProxy::loadHybridMethods() {
 
     prototype.registerHybridMethod("box", &HybridNitroModulesProxy::box);
 
+    prototype.registerRawHybridMethod("hasNativeState", 1, &HybridNitroModulesProxy::hasNativeState);
+
     prototype.registerHybridGetter("buildType", &HybridNitroModulesProxy::getBuildType);
   });
 }
@@ -41,6 +43,13 @@ std::vector<std::string> HybridNitroModulesProxy::getAllHybridObjectNames() {
 // Helpers
 std::shared_ptr<BoxedHybridObject> HybridNitroModulesProxy::box(const std::shared_ptr<HybridObject>& hybridObject) {
   return std::make_shared<BoxedHybridObject>(hybridObject);
+}
+
+jsi::Value HybridNitroModulesProxy::hasNativeState(jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* args, size_t size) {
+  if (size != 1 || !args[0].isObject()) {
+    return false;
+  }
+  return args[0].getObject(runtime).hasNativeState(runtime);
 }
 
 // Build Info

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.hpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.hpp
@@ -37,6 +37,7 @@ public:
 
   // Helpers
   std::shared_ptr<BoxedHybridObject> box(const std::shared_ptr<HybridObject>& hybridObject);
+  jsi::Value hasNativeState(jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* args, size_t size);
 
   // Build Info
   std::string getBuildType();

--- a/packages/react-native-nitro-modules/src/NitroModulesProxy.ts
+++ b/packages/react-native-nitro-modules/src/NitroModulesProxy.ts
@@ -58,4 +58,9 @@ export interface NitroModulesProxy extends HybridObject {
    * ```
    */
   box<T extends HybridObject>(obj: T): BoxedHybridObject<T>
+
+  /**
+   * Returns whether the given {@linkcode object} has NativeState or not.
+   */
+  hasNativeState(object: unknown): boolean
 }


### PR DESCRIPTION
Adds a new API to `NitroModules`: `NitroModules.hasNativeState(value)`.

With this API, we guard the `toString()` call of a HybridObject in release builds because we relied on an error being thrown, which turns into an assert (crash) in release. 
To avoid relying on an error being thrown, we instead now somewhat safely check if we can stringify an object by checking if it has `toString()` or inherits from it - and then we check if it has NativeState. It is a fair assumption that `toString()` from prototype only works if we have NativeState, at least in the Nitro world.

- Fixes https://github.com/mrousavy/nitro/issues/314