### PR TITLE
chore: Create action that builds Android app on a GitHub release

### DIFF
--- a/.github/workflows/build-android-release.yml
+++ b/.github/workflows/build-android-release.yml
@@ -34,11 +34,6 @@ jobs:
         working-directory: example/android
         run: ./gradlew assembleRelease --no-daemon --build-cache
 
-      # Gradle cache doesn't like daemons
-      - name: Stop Gradle Daemon
-        working-directory: example/android
-        run: ./gradlew --stop
-
       - name: Upload APK to Release
         uses: actions/upload-release-asset@v1
         env:
@@ -48,3 +43,8 @@ jobs:
           asset_path: example/android/app/build/outputs/apk/debug/app-release.apk
           asset_name: app-release.apk
           asset_content_type: application/vnd.android.package-archive
+
+      # Gradle cache doesn't like daemons
+      - name: Stop Gradle Daemon
+        working-directory: example/android
+        run: ./gradlew --stop

--- a/.github/workflows/build-android-release.yml
+++ b/.github/workflows/build-android-release.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: example/android/app/build/outputs/apk/debug/app-release.apk
-          asset_name: app-release.apk
+          asset_name: "NitroExample-v${{ github.event.release.tag_name }}.apk"
           asset_content_type: application/vnd.android.package-archive
 
       # Gradle cache doesn't like daemons

--- a/.github/workflows/build-android-release.yml
+++ b/.github/workflows/build-android-release.yml
@@ -1,0 +1,50 @@
+name: Build Android (Release)
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build_release:
+    name: Build Android Example App (release, new architecture)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install npm dependencies (bun)
+        run: bun install
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          java-package: jdk
+
+      - name: Restore Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run Gradle Build for example/android/
+        working-directory: example/android
+        run: ./gradlew assembleRelease --no-daemon --build-cache
+
+      # Gradle cache doesn't like daemons
+      - name: Stop Gradle Daemon
+        working-directory: example/android
+        run: ./gradlew --stop
+
+      - name: Upload APK to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: example/android/app/build/outputs/apk/debug/app-release.apk
+          asset_name: app-release.apk
+          asset_content_type: application/vnd.android.package-archive


### PR DESCRIPTION
Creates a GitHub action/workflow that runs everytime a GitHub release is created.

When this happens, it will build the Nitro Example Android app in release mode and upload the .apk to the GitHub release artefacts.

That way, users can test it instantly.