### PR TITLE
fix: Fix `Promise<ArrayBuffer>` return type generated wrong in Swift

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -839,6 +839,11 @@ export function getTests(
         .didNotThrow()
         .equals(true)
     ),
+    createTest('createArrayBuffer()', async () =>
+      (await it(() => testObject.createArrayBufferAsync()))
+        .didNotThrow()
+        .didReturn('object')
+    ),
 
     // Base HybridObject inherited methods
     createTest('.toString()', () =>

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -579,7 +579,10 @@ case ${i}:
         const bridge = this.getBridgeOrThrow()
         const makePromise = `bridge.${bridge.funcName}`
         const promise = getTypeAs(this.type, PromiseType)
-        const resolvingType = new SwiftCxxBridgedType(promise.resultingType)
+        const resolvingType = new SwiftCxxBridgedType(
+          promise.resultingType,
+          true
+        )
         switch (language) {
           case 'c++':
             return `${swiftParameterName}.getFuture()`

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -158,6 +158,10 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
         return ArrayBuffer.allocate(1024 * 1024 * 10) // 10 MB
     }
 
+    override fun createArrayBufferAsync(): Promise<ArrayBuffer> {
+        return Promise.async { createArrayBuffer() }
+    }
+
     override fun getBufferLastItem(buffer: ArrayBuffer): Double {
         val byteBuffer = buffer.getBuffer(false)
         val lastItem = byteBuffer[buffer.size - 1]

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -335,6 +335,10 @@ void HybridTestObjectCpp::setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buf
   }
 }
 
+std::future<std::shared_ptr<ArrayBuffer>> HybridTestObjectCpp::createArrayBufferAsync() {
+  return std::async(std::launch::async, [this]() -> std::shared_ptr<ArrayBuffer> { return this->createArrayBuffer(); });
+}
+
 std::shared_ptr<HybridTestObjectCppSpec> HybridTestObjectCpp::newTestObject() {
   return std::make_shared<HybridTestObjectCpp>();
 }

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -114,6 +114,7 @@ public:
   std::shared_ptr<ArrayBuffer> createArrayBuffer() override;
   double getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) override;
   void setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) override;
+  std::future<std::shared_ptr<ArrayBuffer>> createArrayBufferAsync() override;
   std::shared_ptr<HybridTestObjectCppSpec> newTestObject() override;
 
   std::shared_ptr<HybridBaseSpec> createBase() override;

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -184,8 +184,8 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     return .allocate(size: 1024 * 1024 * 10) // 10 MB
   }
 
-  func createArrayBuffer() throws -> Promise<ArrayBufferHolder> {
-    return Promise.async { createArrayBuffer() }
+  func createArrayBufferAsync() throws -> Promise<ArrayBufferHolder> {
+    return Promise.async { try self.createArrayBuffer() }
   }
 
   func getBufferLastItem(buffer: ArrayBufferHolder) throws -> Double {

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -184,6 +184,10 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     return .allocate(size: 1024 * 1024 * 10) // 10 MB
   }
 
+  func createArrayBuffer() throws -> Promise<ArrayBufferHolder> {
+    return Promise.async { createArrayBuffer() }
+  }
+
   func getBufferLastItem(buffer: ArrayBufferHolder) throws -> Double {
     let lastBytePointer = buffer.data.advanced(by: buffer.size - 1)
     let lastByte = lastBytePointer.load(as: UInt8.self)

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -418,6 +418,22 @@ namespace margelo::nitro::image {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */, double /* value */)>("setAllValuesTo");
     method(_javaPart, JArrayBuffer::wrap(buffer), value);
   }
+  std::future<std::shared_ptr<ArrayBuffer>> JHybridTestObjectSwiftKotlinSpec::createArrayBufferAsync() {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("createArrayBufferAsync");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = std::make_shared<std::promise<std::shared_ptr<ArrayBuffer>>>();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
+        __promise->set_value(__result->cthis()->getArrayBuffer());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
+        std::runtime_error __error(__message->toStdString());
+        __promise->set_exception(std::make_exception_ptr(__error));
+      });
+      return __promise->get_future();
+    }();
+  }
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> JHybridTestObjectSwiftKotlinSpec::createChild() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>()>("createChild");
     auto __result = method(_javaPart);

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -101,6 +101,7 @@ namespace margelo::nitro::image {
     std::shared_ptr<ArrayBuffer> createArrayBuffer() override;
     double getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) override;
     void setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) override;
+    std::future<std::shared_ptr<ArrayBuffer>> createArrayBufferAsync() override;
     std::shared_ptr<margelo::nitro::image::HybridChildSpec> createChild() override;
     std::shared_ptr<margelo::nitro::image::HybridBaseSpec> createBase() override;
     std::shared_ptr<margelo::nitro::image::HybridBaseSpec> createBaseActualChild() override;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -251,6 +251,10 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun createArrayBufferAsync(): Promise<ArrayBuffer>
+  
+  @DoNotStrip
+  @Keep
   abstract fun createChild(): HybridChildSpec
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -8,6 +8,10 @@
 #pragma once
 
 // Forward declarations of C++ defined types
+// Forward declaration of `ArrayBufferHolder` to properly resolve imports.
+namespace NitroModules { class ArrayBufferHolder; }
+// Forward declaration of `ArrayBuffer` to properly resolve imports.
+namespace NitroModules { class ArrayBuffer; }
 // Forward declaration of `HybridBaseSpec` to properly resolve imports.
 namespace margelo::nitro::image { class HybridBaseSpec; }
 // Forward declaration of `HybridChildSpec` to properly resolve imports.
@@ -43,6 +47,8 @@ namespace NitroImage { class HybridTestObjectSwiftKotlinSpecCxx; }
 #include "HybridTestObjectSwiftKotlinSpec.hpp"
 #include "Person.hpp"
 #include "Powertrain.hpp"
+#include <NitroModules/ArrayBuffer.hpp>
+#include <NitroModules/ArrayBufferHolder.hpp>
 #include <NitroModules/PromiseHolder.hpp>
 #include <functional>
 #include <future>
@@ -346,6 +352,15 @@ namespace margelo::nitro::image::bridge::swift {
   using std__optional_Person_ = std::optional<Person>;
   inline std::optional<Person> create_std__optional_Person_(const Person& value) {
     return std::optional<Person>(value);
+  }
+  
+  // pragma MARK: PromiseHolder<std::shared_ptr<ArrayBuffer>>
+  /**
+   * Specialized version of `PromiseHolder<std::shared_ptr<ArrayBuffer>>`.
+   */
+  using PromiseHolder_std__shared_ptr_ArrayBuffer__ = PromiseHolder<std::shared_ptr<ArrayBuffer>>;
+  inline PromiseHolder<std::shared_ptr<ArrayBuffer>> create_PromiseHolder_std__shared_ptr_ArrayBuffer__() {
+    return PromiseHolder<std::shared_ptr<ArrayBuffer>>();
   }
   
   // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridChildSpec>

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -274,6 +274,10 @@ namespace margelo::nitro::image {
     inline void setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) override {
       _swiftPart.setAllValuesTo(ArrayBufferHolder(buffer), std::forward<decltype(value)>(value));
     }
+    inline std::future<std::shared_ptr<ArrayBuffer>> createArrayBufferAsync() override {
+      auto __result = _swiftPart.createArrayBufferAsync();
+      return __result.getFuture();
+    }
     inline std::shared_ptr<margelo::nitro::image::HybridChildSpec> createChild() override {
       auto __result = _swiftPart.createChild();
       return __result;

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -71,6 +71,7 @@ public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
   func createArrayBuffer() throws -> ArrayBufferHolder
   func getBufferLastItem(buffer: ArrayBufferHolder) throws -> Double
   func setAllValuesTo(buffer: ArrayBufferHolder, value: Double) throws -> Void
+  func createArrayBufferAsync() throws -> Promise<ArrayBufferHolder>
   func createChild() throws -> (any HybridChildSpec)
   func createBase() throws -> (any HybridBaseSpec)
   func createBaseActualChild() throws -> (any HybridBaseSpec)

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -741,7 +741,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
       return { () -> bridge.PromiseHolder_std__shared_ptr_ArrayBuffer__ in
         let __promiseHolder = bridge.create_PromiseHolder_std__shared_ptr_ArrayBuffer__()
         __result
-          .then({ __result in __promiseHolder.resolve(__result.getArrayBuffer()) })
+          .then({ __result in __promiseHolder.resolve(__result) })
           .catch({ __error in __promiseHolder.reject(std.string(String(describing: __error))) })
         return __promiseHolder
       }()

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -735,6 +735,23 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   }
   
   @inline(__always)
+  public func createArrayBufferAsync() -> bridge.PromiseHolder_std__shared_ptr_ArrayBuffer__ {
+    do {
+      let __result = try self.__implementation.createArrayBufferAsync()
+      return { () -> bridge.PromiseHolder_std__shared_ptr_ArrayBuffer__ in
+        let __promiseHolder = bridge.create_PromiseHolder_std__shared_ptr_ArrayBuffer__()
+        __result
+          .then({ __result in __promiseHolder.resolve(__result.getArrayBuffer()) })
+          .catch({ __error in __promiseHolder.reject(std.string(String(describing: __error))) })
+        return __promiseHolder
+      }()
+    } catch {
+      let __message = "\(error.localizedDescription)"
+      fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(__message))")
+    }
+  }
+  
+  @inline(__always)
   public func createChild() -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ {
     do {
       let __result = try self.__implementation.createChild()

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -741,7 +741,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
       return { () -> bridge.PromiseHolder_std__shared_ptr_ArrayBuffer__ in
         let __promiseHolder = bridge.create_PromiseHolder_std__shared_ptr_ArrayBuffer__()
         __result
-          .then({ __result in __promiseHolder.resolve(__result) })
+          .then({ __result in __promiseHolder.resolve(__result.getArrayBuffer()) })
           .catch({ __error in __promiseHolder.reject(std.string(String(describing: __error))) })
         return __promiseHolder
       }()

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -76,6 +76,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("createArrayBuffer", &HybridTestObjectCppSpec::createArrayBuffer);
       prototype.registerHybridMethod("getBufferLastItem", &HybridTestObjectCppSpec::getBufferLastItem);
       prototype.registerHybridMethod("setAllValuesTo", &HybridTestObjectCppSpec::setAllValuesTo);
+      prototype.registerHybridMethod("createArrayBufferAsync", &HybridTestObjectCppSpec::createArrayBufferAsync);
       prototype.registerHybridMethod("createChild", &HybridTestObjectCppSpec::createChild);
       prototype.registerHybridMethod("createBase", &HybridTestObjectCppSpec::createBase);
       prototype.registerHybridMethod("createBaseActualChild", &HybridTestObjectCppSpec::createBaseActualChild);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -142,6 +142,7 @@ namespace margelo::nitro::image {
       virtual std::shared_ptr<ArrayBuffer> createArrayBuffer() = 0;
       virtual double getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) = 0;
       virtual void setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) = 0;
+      virtual std::future<std::shared_ptr<ArrayBuffer>> createArrayBufferAsync() = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridChildSpec> createChild() = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridBaseSpec> createBase() = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridBaseSpec> createBaseActualChild() = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -65,6 +65,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("createArrayBuffer", &HybridTestObjectSwiftKotlinSpec::createArrayBuffer);
       prototype.registerHybridMethod("getBufferLastItem", &HybridTestObjectSwiftKotlinSpec::getBufferLastItem);
       prototype.registerHybridMethod("setAllValuesTo", &HybridTestObjectSwiftKotlinSpec::setAllValuesTo);
+      prototype.registerHybridMethod("createArrayBufferAsync", &HybridTestObjectSwiftKotlinSpec::createArrayBufferAsync);
       prototype.registerHybridMethod("createChild", &HybridTestObjectSwiftKotlinSpec::createChild);
       prototype.registerHybridMethod("createBase", &HybridTestObjectSwiftKotlinSpec::createBase);
       prototype.registerHybridMethod("createBaseActualChild", &HybridTestObjectSwiftKotlinSpec::createBaseActualChild);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -127,6 +127,7 @@ namespace margelo::nitro::image {
       virtual std::shared_ptr<ArrayBuffer> createArrayBuffer() = 0;
       virtual double getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) = 0;
       virtual void setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) = 0;
+      virtual std::future<std::shared_ptr<ArrayBuffer>> createArrayBufferAsync() = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridChildSpec> createChild() = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridBaseSpec> createBase() = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridBaseSpec> createBaseActualChild() = 0;

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -104,6 +104,7 @@ interface SharedTestObjectProps {
   createArrayBuffer(): ArrayBuffer
   getBufferLastItem(buffer: ArrayBuffer): number
   setAllValuesTo(buffer: ArrayBuffer, value: number): void
+  createArrayBufferAsync(): Promise<ArrayBuffer>
 
   // Inheritance
   createChild(): Child


### PR DESCRIPTION
Adds a test that has this function signature:

```ts
func(): Promise<ArrayBuffer>
```

Apparently this broke before on iOS.

- Fixes https://github.com/mrousavy/nitro/issues/329