### PR TITLE
fix: Make `Promise` catch any `Throwable` instead of `Error` subclass

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -657,6 +657,9 @@ export function getTests(
         .didNotThrow()
         .equals(55n)
     ),
+    createTest('promiseThrows() throws', async () =>
+      (await it(() => testObject.promiseThrows())).didThrow()
+    ),
 
     // Callbacks
     createTest('callCallback(...)', async () =>

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -128,6 +128,12 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
         return Promise.async { delay(seconds.toLong() * 1000) }
     }
 
+    override fun promiseThrows(): Promise<Unit> {
+        return Promise.async {
+            throw Error("Promise throws :)")
+        }
+    }
+
     override fun callCallback(callback: () -> Unit) {
         callback()
     }

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -269,9 +269,7 @@ std::future<double> HybridTestObjectCpp::getValueFromJSCallbackAndWait(const std
 }
 
 std::future<void> HybridTestObjectCpp::promiseThrows() {
-  return std::async(std::launch::async, [=]() {
-    throw std::runtime_error("Promise throws :)");
-  });
+  return std::async(std::launch::async, [=]() { throw std::runtime_error("Promise throws :)"); });
 }
 
 void HybridTestObjectCpp::callAll(const std::function<void()>& first, const std::function<void()>& second,

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -268,6 +268,12 @@ std::future<double> HybridTestObjectCpp::getValueFromJSCallbackAndWait(const std
   });
 }
 
+std::future<void> HybridTestObjectCpp::promiseThrows() {
+  return std::async(std::launch::async, [=]() {
+    throw std::runtime_error("Promise throws :)");
+  });
+}
+
 void HybridTestObjectCpp::callAll(const std::function<void()>& first, const std::function<void()>& second,
                                   const std::function<void()>& third) {
   first();

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -108,6 +108,7 @@ public:
   void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) override;
   std::future<void> getValueFromJsCallback(const std::function<std::future<std::string>()>& callback,
                                            const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) override;
+  std::future<void> promiseThrows() override;
   Car getCar() override;
   bool isCarElectric(const Car& car) override;
   std::optional<Person> getDriver(const Car& car) override;

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -164,7 +164,7 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
 
   func promiseThrows() throws -> Promise<Void> {
     return Promise.async {
-      throw RuntimeError(withMessage: "Promise throws :)")
+      throw RuntimeError.error(withMessage: "Promise throws :)")
     }
   }
 

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -162,6 +162,12 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     }
   }
 
+  func promiseThrows() throws -> Promise<Void> {
+    return Promise.async {
+      throw RuntimeError(withMessage: "Promise throws :)")
+    }
+  }
+
   func callAll(first: @escaping (() -> Void), second: @escaping (() -> Void), third: @escaping (() -> Void)) throws {
     first()
     second()

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -377,6 +377,21 @@ namespace margelo::nitro::image {
       return __promise->get_future();
     }();
   }
+  std::future<void> JHybridTestObjectSwiftKotlinSpec::promiseThrows() {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("promiseThrows");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = std::make_shared<std::promise<void>>();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        __promise->set_value();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
+        std::runtime_error __error(__message->toStdString());
+        __promise->set_exception(std::make_exception_ptr(__error));
+      });
+      return __promise->get_future();
+    }();
+  }
   void JHybridTestObjectSwiftKotlinSpec::callCallback(const std::function<void()>& callback) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* callback */)>("callCallback");
     method(_javaPart, JFunc_void::fromCpp(callback));

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -92,6 +92,7 @@ namespace margelo::nitro::image {
     int64_t calculateFibonacciSync(double value) override;
     std::future<int64_t> calculateFibonacciAsync(double value) override;
     std::future<void> wait(double seconds) override;
+    std::future<void> promiseThrows() override;
     void callCallback(const std::function<void()>& callback) override;
     void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) override;
     void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) override;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -194,6 +194,10 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun promiseThrows(): Promise<Unit>
+  
+  @DoNotStrip
+  @Keep
   abstract fun callCallback(callback: () -> Unit): Unit
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -242,6 +242,10 @@ namespace margelo::nitro::image {
       auto __result = _swiftPart.wait(std::forward<decltype(seconds)>(seconds));
       return __result.getFuture();
     }
+    inline std::future<void> promiseThrows() override {
+      auto __result = _swiftPart.promiseThrows();
+      return __result.getFuture();
+    }
     inline void callCallback(const std::function<void()>& callback) override {
       _swiftPart.callCallback(callback);
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -62,6 +62,7 @@ public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
   func calculateFibonacciSync(value: Double) throws -> Int64
   func calculateFibonacciAsync(value: Double) throws -> Promise<Int64>
   func wait(seconds: Double) throws -> Promise<Void>
+  func promiseThrows() throws -> Promise<Void>
   func callCallback(callback: @escaping (() -> Void)) throws -> Void
   func callAll(first: @escaping (() -> Void), second: @escaping (() -> Void), third: @escaping (() -> Void)) throws -> Void
   func callWithOptional(value: Double?, callback: @escaping ((_ maybe: Double?) -> Void)) throws -> Void

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -599,6 +599,23 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   }
   
   @inline(__always)
+  public func promiseThrows() -> bridge.PromiseHolder_void_ {
+    do {
+      let __result = try self.__implementation.promiseThrows()
+      return { () -> bridge.PromiseHolder_void_ in
+        let __promiseHolder = bridge.create_PromiseHolder_void_()
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(std.string(String(describing: __error))) })
+        return __promiseHolder
+      }()
+    } catch {
+      let __message = "\(error.localizedDescription)"
+      fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(__message))")
+    }
+  }
+  
+  @inline(__always)
   public func callCallback(callback: bridge.Func_void) -> Void {
     do {
       try self.__implementation.callCallback(callback: { () -> (() -> Void) in

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -67,6 +67,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("calculateFibonacciSync", &HybridTestObjectCppSpec::calculateFibonacciSync);
       prototype.registerHybridMethod("calculateFibonacciAsync", &HybridTestObjectCppSpec::calculateFibonacciAsync);
       prototype.registerHybridMethod("wait", &HybridTestObjectCppSpec::wait);
+      prototype.registerHybridMethod("promiseThrows", &HybridTestObjectCppSpec::promiseThrows);
       prototype.registerHybridMethod("callCallback", &HybridTestObjectCppSpec::callCallback);
       prototype.registerHybridMethod("callAll", &HybridTestObjectCppSpec::callAll);
       prototype.registerHybridMethod("callWithOptional", &HybridTestObjectCppSpec::callWithOptional);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -133,6 +133,7 @@ namespace margelo::nitro::image {
       virtual int64_t calculateFibonacciSync(double value) = 0;
       virtual std::future<int64_t> calculateFibonacciAsync(double value) = 0;
       virtual std::future<void> wait(double seconds) = 0;
+      virtual std::future<void> promiseThrows() = 0;
       virtual void callCallback(const std::function<void()>& callback) = 0;
       virtual void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) = 0;
       virtual void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -56,6 +56,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("calculateFibonacciSync", &HybridTestObjectSwiftKotlinSpec::calculateFibonacciSync);
       prototype.registerHybridMethod("calculateFibonacciAsync", &HybridTestObjectSwiftKotlinSpec::calculateFibonacciAsync);
       prototype.registerHybridMethod("wait", &HybridTestObjectSwiftKotlinSpec::wait);
+      prototype.registerHybridMethod("promiseThrows", &HybridTestObjectSwiftKotlinSpec::promiseThrows);
       prototype.registerHybridMethod("callCallback", &HybridTestObjectSwiftKotlinSpec::callCallback);
       prototype.registerHybridMethod("callAll", &HybridTestObjectSwiftKotlinSpec::callAll);
       prototype.registerHybridMethod("callWithOptional", &HybridTestObjectSwiftKotlinSpec::callWithOptional);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -118,6 +118,7 @@ namespace margelo::nitro::image {
       virtual int64_t calculateFibonacciSync(double value) = 0;
       virtual std::future<int64_t> calculateFibonacciAsync(double value) = 0;
       virtual std::future<void> wait(double seconds) = 0;
+      virtual std::future<void> promiseThrows() = 0;
       virtual void callCallback(const std::function<void()>& callback) = 0;
       virtual void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) = 0;
       virtual void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) = 0;

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -86,6 +86,7 @@ interface SharedTestObjectProps {
   calculateFibonacciSync(value: number): bigint
   calculateFibonacciAsync(value: number): Promise<bigint>
   wait(seconds: number): Promise<void>
+  promiseThrows(): Promise<void>
 
   // Callbacks
   callCallback(callback: () => void): void

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
@@ -44,7 +44,7 @@ class Promise<T> {
    * Rejects the Promise with the given error.
    * Any `onRejected` listeners will be invoked.
    */
-  fun reject(error: Error) {
+  fun reject(error: Throwable) {
     nativeReject(error.toString())
   }
 
@@ -71,7 +71,7 @@ class Promise<T> {
         try {
           val result = run()
           promise.resolve(result)
-        } catch (e: Error) {
+        } catch (e: Throwable) {
           promise.reject(e)
         }
       }
@@ -91,7 +91,7 @@ class Promise<T> {
         try {
           val result = run()
           promise.resolve(result)
-        } catch (e: Error) {
+        } catch (e: Throwable) {
           promise.reject(e)
         }
       }
@@ -108,7 +108,7 @@ class Promise<T> {
     /**
      * Creates a new Promise that is already rejected with the given error.
      */
-    fun <T> rejected(error: Error): Promise<T> {
+    fun <T> rejected(error: Throwable): Promise<T> {
       return Promise<T>().apply { reject(error) }
     }
   }


### PR DESCRIPTION
Previously, `Promise` caught only `Error` on Kotlin. If you throw something else (e.g. `Exception`), this would've not been caught. So now instead we catch the highest level throwable, which is `Throwable` itself.

This catches every exception or runtime error and also carries enough string information with it to be represented as a JS error.