### PR TITLE
fix: Call `ordinal()` method instead of trying to access field which doesn't exist

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinEnum.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinEnum.ts
@@ -58,8 +58,8 @@ namespace ${cxxNamespace} {
     [[maybe_unused]]
     ${enumType.enumName} toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("ordinal");
-      int ordinal = this->getFieldValue(fieldOrdinal);
+      static const auto ordinalMethod = clazz->getMethod<int()>("ordinal");
+      int ordinal = ordinalMethod(self());
       return static_cast<${enumType.enumName}>(ordinal);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JImageFormat.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JImageFormat.hpp
@@ -28,8 +28,8 @@ namespace margelo::nitro::image {
     [[maybe_unused]]
     ImageFormat toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("ordinal");
-      int ordinal = this->getFieldValue(fieldOrdinal);
+      static const auto ordinalMethod = clazz->getMethod<int()>("ordinal");
+      int ordinal = ordinalMethod(self());
       return static_cast<ImageFormat>(ordinal);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPixelFormat.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPixelFormat.hpp
@@ -28,8 +28,8 @@ namespace margelo::nitro::image {
     [[maybe_unused]]
     PixelFormat toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("ordinal");
-      int ordinal = this->getFieldValue(fieldOrdinal);
+      static const auto ordinalMethod = clazz->getMethod<int()>("ordinal");
+      int ordinal = ordinalMethod(self());
       return static_cast<PixelFormat>(ordinal);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPowertrain.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPowertrain.hpp
@@ -28,8 +28,8 @@ namespace margelo::nitro::image {
     [[maybe_unused]]
     Powertrain toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("ordinal");
-      int ordinal = this->getFieldValue(fieldOrdinal);
+      static const auto ordinalMethod = clazz->getMethod<int()>("ordinal");
+      int ordinal = ordinalMethod(self());
       return static_cast<Powertrain>(ordinal);
     }
 


### PR DESCRIPTION
Previously, we tried to access `.ordinal` as a field on an enum.

Apparently this doesn't exist, and `ordinal()` is a method on an enum. So this PR now changes this to call that method.

One thing I am wondering is; how did this work before? Afaik we have those test cases... 🤔 

1. We get an enum from a property here: https://github.com/mrousavy/nitro/blob/d76d0c02621d4183544d2a8af5b8b334318b4551/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts#L52
2. We get an array of enums here: https://github.com/mrousavy/nitro/blob/d76d0c02621d4183544d2a8af5b8b334318b4551/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts#L64
3. We get an enum from a method here: https://github.com/mrousavy/nitro/blob/d76d0c02621d4183544d2a8af5b8b334318b4551/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts#L80

cc @Szymon20000 - didn't those tests work? In the example app they're green...?