### PR TITLE
repro: Add test where Promise.all checks if they can run in parallel

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -660,6 +660,26 @@ export function getTests(
     createTest('promiseThrows() throws', async () =>
       (await it(() => testObject.promiseThrows())).didThrow()
     ),
+    createTest('twoPromises', async () =>
+      (
+        await it(async () => {
+          let fooResolved: boolean | undefined
+          let barResolvedBeforeFoo: boolean | undefined
+          const foo = async () => {
+            await testObject.wait(2)
+            fooResolved = true
+          }
+          const bar = async () => {
+            await testObject.createArrayBufferAsync()
+            barResolvedBeforeFoo = !fooResolved
+          }
+          await Promise.all([foo(), bar()])
+          return barResolvedBeforeFoo
+        })
+      )
+        .didNotThrow()
+        .equals(true)
+    ),
 
     // Callbacks
     createTest('callCallback(...)', async () =>

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -660,21 +660,15 @@ export function getTests(
     createTest('promiseThrows() throws', async () =>
       (await it(() => testObject.promiseThrows())).didThrow()
     ),
-    createTest('twoPromises', async () =>
+    createTest('twoPromises can run in parallel', async () =>
       (
         await it(async () => {
-          let fooResolved: boolean | undefined
-          let barResolvedBeforeFoo: boolean | undefined
-          const foo = async () => {
-            await testObject.wait(2)
-            fooResolved = true
-          }
-          const bar = async () => {
-            await testObject.createArrayBufferAsync()
-            barResolvedBeforeFoo = !fooResolved
-          }
-          await Promise.all([foo(), bar()])
-          return barResolvedBeforeFoo
+          const start = performance.now()
+          // 2s + 2s = ~4s in serial, ~2s in parallel
+          await Promise.all([testObject.wait(2), testObject.wait(2)])
+          const end = performance.now()
+          const didRunInParallel = (end - start) < 4000
+          return didRunInParallel
         })
       )
         .didNotThrow()


### PR DESCRIPTION
On Android, when there are two promises, second promise will wait for the first one to resolve. 

In this example, the resolution should be:
- Promise.all(foo(), bar()) called, both functions are running
- foo() is pending
- bar() is pending
- bar gets resolved
- 2 seconds later
- foo() gets resolved
- Promise.all gets resolved