### PR TITLE
Use "nitrogen" as bin

### DIFF
--- a/.github/ISSUE_TEMPLATE/NITROGEN_ERROR.yml
+++ b/.github/ISSUE_TEMPLATE/NITROGEN_ERROR.yml
@@ -15,7 +15,7 @@ body:
       description: Share the full logs that appear in the console when running nitrogen with the `--logLevel="debug"` flag.
       render: tsx
       placeholder: >
-        $ npx nitro-codegen --logLevel="debug"
+        $ npx nitrogen --logLevel="debug"
 
         🔧  Loading nitro.json config...
 

--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -119,22 +119,22 @@ Now run nitrogen:
 <Tabs groupId="package-manager">
   <TabItem value="npm" label="npm" default>
     ```sh
-    npm run nitro-codegen
+    npx nitrogen
     ```
   </TabItem>
   <TabItem value="yarn" label="yarn">
     ```sh
-    yarn nitro-codegen
+    yarn nitrogen
     ```
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
     ```sh
-    pnpm nitro-codegen
+    pnpm exec nitrogen
     ```
   </TabItem>
   <TabItem value="bun" label="bun">
     ```sh
-    bun nitro-codegen
+    bunx nitrogen
     ```
   </TabItem>
 </Tabs>

--- a/packages/nitrogen/package.json
+++ b/packages/nitrogen/package.json
@@ -11,7 +11,9 @@
     "src",
     "README.md"
   ],
-  "bin": "./lib/index.js",
+  "bin": {
+    "nitrogen": "./lib/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mrousavy/nitro.git"

--- a/packages/react-native-nitro-image/package.json
+++ b/packages/react-native-nitro-image/package.json
@@ -50,8 +50,8 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint-ci": "eslint \"**/*.{js,ts,tsx}\" -f @jamesacarr/github-actions",
     "build-nitrogen-first": "cd ../react-native-nitro-modules && bun tsc && cd ../nitrogen && bun tsc",
-    "specs": "bun build-nitrogen-first && bun run nitro-codegen --logLevel=\"debug\"",
-    "specs-ci": "bun run nitro-codegen --logLevel=\"debug\"",
+    "specs": "bun build-nitrogen-first && nitrogen --logLevel=\"debug\"",
+    "specs-ci": "nitrogen --logLevel=\"debug\"",
     "clean": "rm -rf android/build node_modules/**/android/build lib"
   },
   "devDependencies": {

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -32,7 +32,7 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint-ci": "eslint \"**/*.{js,ts,tsx}\" -f @jamesacarr/github-actions",
     "typescript": "tsc",
-    "specs": "typescript && nitro-codegen --logLevel=\"debug\""
+    "specs": "typescript && nitrogen --logLevel=\"debug\""
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
Merging this will declare the "bin" of "nitro-codegen" as "nitrogen", allowing any package taking on the "nitro-codegen" to execute the local "nitrogen" binary. I've updated docs and usage to the best of my abilities 🤞