### PR TITLE
fix: Fix `Promise::awaitFuture` actually locking threads

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -664,10 +664,10 @@ export function getTests(
       (
         await it(async () => {
           const start = performance.now()
-          // 2s + 2s = ~4s in serial, ~2s in parallel
-          await Promise.all([testObject.wait(2), testObject.wait(2)])
+          // 0.5s + 0.5s = ~1s in serial, ~0.5s in parallel
+          await Promise.all([testObject.wait(0.5), testObject.wait(0.5)])
           const end = performance.now()
-          const didRunInParallel = end - start < 4000
+          const didRunInParallel = end - start < 1000
           return didRunInParallel
         })
       )

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -63,9 +63,7 @@ public:
    */
   static std::shared_ptr<Promise> awaitFuture(std::future<TResult>&& future) {
     auto sharedFuture = std::make_shared<std::future<TResult>>(std::move(future));
-    return async([sharedFuture = std::move(sharedFuture)]() {
-      return sharedFuture->get();
-    });
+    return async([sharedFuture = std::move(sharedFuture)]() { return sharedFuture->get(); });
   }
 
   /**

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -62,10 +62,9 @@ public:
    * Once the future resolves or rejects, the Promise resolves or rejects.
    */
   static std::shared_ptr<Promise> awaitFuture(std::future<TResult>&& future) {
-    std::shared_future<TResult> sharedFuture(std::move(future));
+    auto sharedFuture = std::make_shared<std::future<TResult>>(std::move(future));
     return async([sharedFuture = std::move(sharedFuture)]() {
-      sharedFuture.wait();
-      return sharedFuture.get();
+      return sharedFuture->get();
     });
   }
 
@@ -230,11 +229,8 @@ public:
   }
 
   static std::shared_ptr<Promise> awaitFuture(std::future<void>&& future) {
-    std::shared_future<void> sharedFuture(std::move(future));
-    return async([sharedFuture = std::move(sharedFuture)]() {
-      sharedFuture.wait();
-      sharedFuture.get();
-    });
+    auto sharedFuture = std::make_shared<std::future<void>>(std::move(future));
+    return async([sharedFuture = std::move(sharedFuture)]() { sharedFuture->get(); });
   }
 
   static std::shared_ptr<Promise> resolved() {


### PR DESCRIPTION
Fixes an issue where the new `Promise<T>` implementation introduced in https://github.com/mrousavy/nitro/commit/8832bc5225353e9ac0905c9a51cc57bf3dc1f076 actually caused a thread-lock since `std::future` was still used. This caused the `future` to be awaited on the JS thread instead of the background thread, making promises resolve synchronously instead of asynchronously.

The issue was caused by `std::future`/`std::shared_future`'s RAII mechanism where the destructor waits for the task to complete. Now, it is moved to a `shared_ptr` and only awaited for completion in the run function.