### PR TITLE
feat: Add `stacktrace` to errors in Nitro

### DIFF
--- a/example/ios/NitroExample.xcodeproj/project.pbxproj
+++ b/example/ios/NitroExample.xcodeproj/project.pbxproj
@@ -624,7 +624,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -698,7 +701,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_INTEROP_MODE = objcxx;

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1891,7 +1891,7 @@ SPEC CHECKSUMS:
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 46f1ffbf0297f4298862068dd4c274d4ac17a1fd
   NitroImage: 5f785fe73750fe0f44d1914d5360ecf4f722666c
-  NitroModules: f37dedb0894bb3474aa27a8e034c26b18dc741d0
+  NitroModules: e8d8de9e1dbc73a605126e3f3d2eb1ddbda1f726
   RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
   RCTDeprecation: fde92935b3caa6cb65cbff9fbb7d3a9867ffb259
   RCTRequired: 75c6cee42d21c1530a6f204ba32ff57335d19007

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -83,6 +83,11 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
           name: 'NitroModules/JPromise.hpp',
           space: 'system',
         })
+        imports.push({
+          language: 'c++',
+          name: 'NitroModules/ExceptionWithStacktrace.hpp',
+          space: 'system',
+        })
         break
       case 'map':
         imports.push({
@@ -709,9 +714,11 @@ __promise->resolve();
   ${parameterName}->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
     ${indent(resolveBody, '    ')}
   });
-  ${parameterName}->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-    std::runtime_error __error(__message->toStdString());
-    __promise->reject(__error);
+  ${parameterName}->cthis()->addOnRejectedListener([=](jni::alias_ref<jni::JThrowable> __error) {
+    jni::local_ref<jni::JString> __message = __error->getMessage();
+    jni::local_ref<jni::JString> __stacktrace = __error->getStackTrace();
+    ExceptionWithStacktrace __exception(__message->toStdString(), __stacktrace->toStdString());
+    __promise->reject(__exception);
   });
   return __promise;
 }()

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -45,6 +45,7 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include <NitroModules/JAnyMap.hpp>
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/JPromise.hpp>
+#include <NitroModules/ExceptionWithStacktrace.hpp>
 #include "Car.hpp"
 #include "JCar.hpp"
 #include <NitroModules/ArrayBuffer.hpp>
@@ -368,9 +369,11 @@ namespace margelo::nitro::image {
         auto __result = jni::static_ref_cast<jni::JLong>(__boxedResult);
         __promise->resolve(__result->value());
       });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-        std::runtime_error __error(__message->toStdString());
-        __promise->reject(__error);
+      __result->cthis()->addOnRejectedListener([=](jni::alias_ref<jni::JThrowable> __error) {
+        jni::local_ref<jni::JString> __message = __error->getMessage();
+        jni::local_ref<jni::JString> __stacktrace = __error->getStackTrace();
+        ExceptionWithStacktrace __exception(__message->toStdString(), __stacktrace->toStdString());
+        __promise->reject(__exception);
       });
       return __promise;
     }();
@@ -383,9 +386,11 @@ namespace margelo::nitro::image {
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
         __promise->resolve();
       });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-        std::runtime_error __error(__message->toStdString());
-        __promise->reject(__error);
+      __result->cthis()->addOnRejectedListener([=](jni::alias_ref<jni::JThrowable> __error) {
+        jni::local_ref<jni::JString> __message = __error->getMessage();
+        jni::local_ref<jni::JString> __stacktrace = __error->getStackTrace();
+        ExceptionWithStacktrace __exception(__message->toStdString(), __stacktrace->toStdString());
+        __promise->reject(__exception);
       });
       return __promise;
     }();
@@ -398,9 +403,11 @@ namespace margelo::nitro::image {
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
         __promise->resolve();
       });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-        std::runtime_error __error(__message->toStdString());
-        __promise->reject(__error);
+      __result->cthis()->addOnRejectedListener([=](jni::alias_ref<jni::JThrowable> __error) {
+        jni::local_ref<jni::JString> __message = __error->getMessage();
+        jni::local_ref<jni::JString> __stacktrace = __error->getStackTrace();
+        ExceptionWithStacktrace __exception(__message->toStdString(), __stacktrace->toStdString());
+        __promise->reject(__exception);
       });
       return __promise;
     }();
@@ -455,9 +462,11 @@ namespace margelo::nitro::image {
         auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
         __promise->resolve(__result->cthis()->getArrayBuffer());
       });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-        std::runtime_error __error(__message->toStdString());
-        __promise->reject(__error);
+      __result->cthis()->addOnRejectedListener([=](jni::alias_ref<jni::JThrowable> __error) {
+        jni::local_ref<jni::JString> __message = __error->getMessage();
+        jni::local_ref<jni::JString> __stacktrace = __error->getStackTrace();
+        ExceptionWithStacktrace __exception(__message->toStdString(), __stacktrace->toStdString());
+        __promise->reject(__exception);
       });
       return __promise;
     }();

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
@@ -21,7 +21,7 @@ class JPromise final : public jni::HybridClass<JPromise> {
 public:
   static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/Promise;";
   using OnResolvedFunc = std::function<void(jni::alias_ref<jni::JObject>)>;
-  using OnRejectedFunc = std::function<void(jni::alias_ref<jni::JString>)>;
+  using OnRejectedFunc = std::function<void(jni::alias_ref<jni::JThrowable>)>;
 
 public:
   /**
@@ -38,7 +38,7 @@ public:
       onResolved(_result);
     }
   }
-  void reject(jni::alias_ref<jni::JString> error) {
+  void reject(jni::alias_ref<jni::JThrowable> error) {
     _error = jni::make_global(error);
     for (const auto& onRejected : _onRejectedListeners) {
       onRejected(_error);
@@ -72,7 +72,7 @@ private:
   friend HybridBase;
   using HybridBase::HybridBase;
   jni::global_ref<jni::JObject> _result;
-  jni::global_ref<jni::JString> _error;
+  jni::global_ref<jni::JThrowable> _error;
   std::vector<OnResolvedFunc> _onResolvedListeners;
   std::vector<OnRejectedFunc> _onRejectedListeners;
 

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
@@ -45,12 +45,12 @@ class Promise<T> {
    * Any `onRejected` listeners will be invoked.
    */
   fun reject(error: Throwable) {
-    nativeReject(error.toString())
+    nativeReject(error)
   }
 
   // C++ functions
   private external fun nativeResolve(result: Any)
-  private external fun nativeReject(error: String)
+  private external fun nativeReject(error: Throwable)
   private external fun initHybrid(): HybridData
 
   companion object {

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
@@ -14,6 +14,7 @@ struct JSIConverter;
 
 #include <exception>
 #include <jsi/jsi.h>
+#include "GetExceptionStacktrace.hpp"
 
 namespace margelo::nitro {
 
@@ -29,7 +30,8 @@ struct JSIConverter<std::exception> final {
     return std::runtime_error(name + ": " + message);
   }
   static inline jsi::Value toJSI(jsi::Runtime& runtime, const std::exception& exception) {
-    jsi::JSError error(runtime, exception.what());
+    std::string stacktrace = getExceptionStacktrace(exception);
+    jsi::JSError error(runtime, exception.what(), stacktrace);
     return jsi::Value(runtime, error.value());
   }
   static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {

--- a/packages/react-native-nitro-modules/cpp/utils/ExceptionWithStacktrace.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/ExceptionWithStacktrace.hpp
@@ -1,0 +1,44 @@
+//
+//  ExceptionWithStacktrace.hpp
+//  react-native-nitro
+//
+//  Created by Marc Rousavy on 19.11.24.
+//
+
+#pragma once
+
+#include <exception>
+#include <string>
+
+namespace margelo::nitro {
+
+/**
+ * Represents an exception that also contains a stacktrace.
+ */
+class ExceptionWithStacktrace: public std::exception {
+public:
+  explicit ExceptionWithStacktrace(std::string message, std::string stacktrace):
+    std::exception(), _message(std::move(message)), _stacktrace(std::move(stacktrace)) {}
+
+public:
+  [[nodiscard]]
+  const char* what() const noexcept override {
+    return _message.c_str();
+  }
+
+[[nodiscard]]
+inline const std::string& getMessage() const noexcept {
+    return _message;
+}
+
+[[nodiscard]]
+inline const std::string& getStacktrace() const noexcept {
+    return _stacktrace;
+}
+
+private:
+  std::string _message;
+  std::string _stacktrace;
+};
+
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/utils/GetExceptionStacktrace.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/GetExceptionStacktrace.hpp
@@ -1,0 +1,61 @@
+//
+//  GetExceptionStacktrace.hpp
+//  react-native-nitro
+//
+//  Created by Marc Rousavy on 19.11.24.
+//
+
+#pragma once
+
+#include <exception>
+#include <string>
+#include <execinfo.h>
+#include <sstream>
+#include <cxxabi.h>
+#include <cstdlib>
+#include "ExceptionWithStacktrace.hpp"
+
+namespace margelo::nitro {
+
+/**
+ * Get the stacktrace of an `std::exception`.
+ */
+std::string getExceptionStacktrace(const std::exception& exception) {
+  if (dynamic_cast<const ExceptionWithStacktrace*>(&exception)) {
+    // It has a stacktrace! Maybe a Java exception.
+    auto exceptionWithStacktrace = dynamic_cast<const ExceptionWithStacktrace*>(&exception);
+    return exceptionWithStacktrace->getStacktrace();
+  }
+
+  // It doesn't have a stacktrace. Use backtrace() to figure out a stacktrace..
+  const int maxFrames = 100;
+  void* callstack[maxFrames];
+  int frames = backtrace(callstack, maxFrames);
+  char** symbols = backtrace_symbols(callstack, frames);
+
+  std::ostringstream oss;
+  for (int i = 0; i < frames; ++i) {
+      char* demangled = nullptr;
+      char* begin = nullptr;
+      char* end = nullptr;
+
+      // Try to demangle the function name
+      for (char* p = symbols[i]; *p; ++p) {
+          if (*p == '(') begin = p;
+          else if (*p == '+') end = p;
+      }
+
+      if (begin && end && begin < end) {
+          *end = '\0';
+          int status;
+          demangled = abi::__cxa_demangle(begin + 1, nullptr, nullptr, &status);
+      }
+
+      oss << (demangled ? demangled : symbols[i]) << "\n";
+      free(demangled);
+  }
+  free(symbols);
+  return oss.str();
+}
+
+} // namespace margelo::nitro


### PR DESCRIPTION
Adds `stacktrace` to all errors - in Java this comes from `JThrowable`.