### PR TITLE
chore: Add deprecation notice to `JSIConverter<std::future>`

### DIFF
--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Future.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Future.hpp
@@ -23,17 +23,21 @@ namespace margelo::nitro {
 using namespace facebook;
 
 // std::future<T> <> Promise<T>
+[[deprecated("Use JSIConverter<std::shared_ptr<Promise<T>>> instead.")]]
 template <typename TResult>
 struct JSIConverter<std::future<TResult>> final {
+  [[deprecated("Use JSIConverter<std::shared_ptr<Promise<T>>> instead.")]]
   static inline std::future<TResult> fromJSI(jsi::Runtime&, const jsi::Value&) {
     throw std::runtime_error("Promise cannot be converted to a native type - it needs to be awaited first!");
   }
 
+  [[deprecated("Use JSIConverter<std::shared_ptr<Promise<T>>> instead.")]]
   static inline jsi::Value toJSI(jsi::Runtime& runtime, std::future<TResult>&& arg) {
     auto promise = Promise<TResult>::awaitFuture(std::move(arg));
     return JSIConverter<std::shared_ptr<Promise<TResult>>>::toJSI(runtime, promise);
   }
 
+  [[deprecated("Use JSIConverter<std::shared_ptr<Promise<T>>> instead.")]]
   static inline bool canConvert(jsi::Runtime&, const jsi::Value&) {
     throw std::runtime_error("jsi::Value of type Promise cannot be converted to std::future yet!");
   }

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Future.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Future.hpp
@@ -23,7 +23,6 @@ namespace margelo::nitro {
 using namespace facebook;
 
 // std::future<T> <> Promise<T>
-[[deprecated("Use JSIConverter<std::shared_ptr<Promise<T>>> instead.")]]
 template <typename TResult>
 struct JSIConverter<std::future<TResult>> final {
   [[deprecated("Use JSIConverter<std::shared_ptr<Promise<T>>> instead.")]]

--- a/packages/react-native-nitro-modules/cpp/threading/ThreadPool.cpp
+++ b/packages/react-native-nitro-modules/cpp/threading/ThreadPool.cpp
@@ -12,7 +12,7 @@
 namespace margelo::nitro {
 
 ThreadPool::ThreadPool(const char* name, size_t initialThreadsCount, size_t maxThreadsCount)
-    : _isAlive(true), _name(name), _threadCountLimit(maxThreadsCount) {
+    : _isAlive(true), _threadCountLimit(maxThreadsCount), _name(name) {
   Logger::log(LogLevel::Info, TAG, "Creating ThreadPool \"%s\" with %i initial threads (max: %i)...", name, initialThreadsCount,
               maxThreadsCount);
 


### PR DESCRIPTION
Use `JSIConverter<std::shared_ptr<Promise>>` instead.