### PR TITLE
feat: Support awaiting JS `Promise` in Kotlin and Swift

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1891,7 +1891,7 @@ SPEC CHECKSUMS:
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 46f1ffbf0297f4298862068dd4c274d4ac17a1fd
   NitroImage: 5f785fe73750fe0f44d1914d5360ecf4f722666c
-  NitroModules: f37dedb0894bb3474aa27a8e034c26b18dc741d0
+  NitroModules: 0531eae34895d20c8968709d1d36ff7d889d737d
   RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
   RCTDeprecation: fde92935b3caa6cb65cbff9fbb7d3a9867ffb259
   RCTRequired: 75c6cee42d21c1530a6f204ba32ff57335d19007

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -703,7 +703,7 @@ export function getTests(
         .didNotThrow()
         .equals(true)
     ),
-    createTest('JS Promise can be awaited on native side', async () =>
+    createTest('JS Promise<number> can be awaited on native side', async () =>
       (
         await it(() => {
           return timeoutedPromise(async (complete) => {
@@ -711,7 +711,7 @@ export function getTests(
             const promise = new Promise<number>((r) => {
               resolve = r
             })
-            const nativePromise = testObject.awaitPromise(promise)
+            const nativePromise = testObject.awaitAndGetPromise(promise)
             resolve(5)
             const result = await nativePromise
             complete(result)
@@ -720,6 +720,42 @@ export function getTests(
       )
         .didNotThrow()
         .equals(5)
+    ),
+    createTest('JS Promise<Car> can be awaited on native side', async () =>
+      (
+        await it(() => {
+          return timeoutedPromise(async (complete) => {
+            let resolve = (_: Car) => {}
+            const promise = new Promise<Car>((r) => {
+              resolve = r
+            })
+            const nativePromise = testObject.awaitAndGetComplexPromise(promise)
+            resolve(TEST_CAR)
+            const result = await nativePromise
+            complete(result)
+          })
+        })
+      )
+        .didNotThrow()
+        .equals(TEST_CAR)
+    ),
+    createTest('JS Promise<void> can be awaited on native side', async () =>
+      (
+        await it(() => {
+          return timeoutedPromise(async (complete) => {
+            let resolve = () => {}
+            const promise = new Promise<void>((r) => {
+              resolve = r
+            })
+            const nativePromise = testObject.awaitPromise(promise)
+            resolve()
+            const result = await nativePromise
+            complete(result)
+          })
+        })
+      )
+        .didNotThrow()
+        .equals(undefined)
     ),
 
     // Callbacks

--- a/packages/nitrogen/src/autolinking/ios/createSwiftCxxBridge.ts
+++ b/packages/nitrogen/src/autolinking/ios/createSwiftCxxBridge.ts
@@ -31,6 +31,7 @@ export function createSwiftCxxBridge(): SourceFile[] {
       })
     })
     .filter((b) => b != null)
+    .flatMap((b) => [b, ...b?.dependencies])
     .filter(filterDuplicateHelperBridges)
   const headerHelperFunctions = bridges
     .map((b) => `// pragma MARK: ${b.cxxType}\n${b.cxxHeader.code}`)

--- a/packages/nitrogen/src/autolinking/ios/createSwiftUmbrellaHeader.ts
+++ b/packages/nitrogen/src/autolinking/ios/createSwiftUmbrellaHeader.ts
@@ -56,6 +56,7 @@ ${includes.sort().join('\n')}
 #include <NitroModules/ArrayBufferHolder.hpp>
 #include <NitroModules/AnyMapHolder.hpp>
 #include <NitroModules/HybridContext.hpp>
+#include <NitroModules/RuntimeError.hpp>
 
 // Forward declarations of Swift defined types
 ${swiftForwardDeclares.sort().join('\n')}

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -529,7 +529,8 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
     __promise->cthis()->resolve(${indent(bridge.parseFromCppToKotlin('__result', 'c++', true), '    ')});
   });
   ${parameterName}->addOnRejectedListener([=](const std::exception& __error) {
-    __promise->cthis()->reject(jni::make_jstring(__error.what()));
+    auto __jniError = jni::JCppException::create(__error);
+    __promise->cthis()->reject(__jniError);
   });
   return __promise;
 }()
@@ -732,9 +733,9 @@ __promise->resolve();
   ${parameterName}->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
     ${indent(resolveBody, '    ')}
   });
-  ${parameterName}->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-    std::runtime_error __error(__message->toStdString());
-    __promise->reject(std::move(__error));
+  ${parameterName}->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+    jni::JniException __jniError(__throwable);
+    __promise->reject(std::move(__jniError));
   });
   return __promise;
 }()

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -339,16 +339,16 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
               ])
               const rejecterFuncBridge = new SwiftCxxBridgedType(rejecterFunc)
               return `
-  { () -> ${promise.getCode('swift')} in
-    let __promise = ${promise.getCode('swift')}()
-    let __rejecter = { (__error: std.exception) in
-      __promise.reject(withError: RuntimeError.from(cppError: __error))
-    }
-    let __resolverCpp = SwiftClosure { __promise.resolve() }
-    let __rejecterCpp = ${indent(rejecterFuncBridge.parseFromSwiftToCpp('__rejecter', 'swift'), '  ')}
-    // TODO: Listeners
-    return __promise
-  }()`.trim()
+{ () -> ${promise.getCode('swift')} in
+  let __promise = ${promise.getCode('swift')}()
+  let __rejecter = { (__error: std.exception) in
+    __promise.reject(withError: RuntimeError.from(cppError: __error))
+  }
+  let __resolverCpp = SwiftClosure { __promise.resolve() }
+  let __rejecterCpp = ${indent(rejecterFuncBridge.parseFromSwiftToCpp('__rejecter', 'swift'), '  ')}
+  // TODO: Listeners
+  return __promise
+}()`.trim()
             } else {
               // It's resolving to a type - resolve(T)
               const resolverFunc = new FunctionType(new VoidType(), [
@@ -360,18 +360,19 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
               const resolverFuncBridge = new SwiftCxxBridgedType(resolverFunc)
               const rejecterFuncBridge = new SwiftCxxBridgedType(rejecterFunc)
               return `
-  { () -> ${promise.getCode('swift')} in
-    let __promise = ${promise.getCode('swift')}()
-    let __resolver = { (__result: ${resolvingTypeBridge.getTypeCode('swift')}) in
-      __promise.resolve(withResult: ${indent(resolvingTypeBridge.parseFromCppToSwift('__result', 'swift'), '    ')})
-    }
-    let __rejecter = { (__error: std.exception) in
-      __promise.reject(withError: RuntimeError.from(cppError: __error))
-    }
-    let __resolverCpp = ${indent(resolverFuncBridge.parseFromSwiftToCpp('__resolver', 'swift'), '  ')}
-    let __rejecterCpp = ${indent(rejecterFuncBridge.parseFromSwiftToCpp('__rejecter', 'swift'), '  ')}
-    return __promise
-  }()`.trim()
+{ () -> ${promise.getCode('swift')} in
+  let __promise = ${promise.getCode('swift')}()
+  let __resolver = { (__result: ${resolvingTypeBridge.getTypeCode('swift')}) in
+    __promise.resolve(withResult: ${indent(resolvingTypeBridge.parseFromCppToSwift('__result', 'swift'), '    ')})
+  }
+  let __rejecter = { (__error: std.exception) in
+    __promise.reject(withError: RuntimeError.from(cppError: __error))
+  }
+  let __resolverCpp = ${indent(resolverFuncBridge.parseFromSwiftToCpp('__resolver', 'swift'), '  ')}
+  let __rejecterCpp = ${indent(rejecterFuncBridge.parseFromSwiftToCpp('__rejecter', 'swift'), '  ')}
+  // TODO: Listeners
+  return __promise
+}()`.trim()
             }
           }
           default:

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -359,6 +359,10 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
               const rejecterFunc = new FunctionType(new VoidType(), [
                 new NamedWrappingType('error', new ErrorType()),
               ])
+              const addResolverName = promise.resultingType
+                .canBePassedByReference
+                ? 'addOnResolvedListener'
+                : 'addOnResolvedListenerCopy'
               const resolverFuncBridge = new SwiftCxxBridgedType(resolverFunc)
               const rejecterFuncBridge = new SwiftCxxBridgedType(rejecterFunc)
               return `
@@ -372,7 +376,7 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
   }
   let __resolverCpp = ${indent(resolverFuncBridge.parseFromSwiftToCpp('__resolver', 'swift'), '  ')}
   let __rejecterCpp = ${indent(rejecterFuncBridge.parseFromSwiftToCpp('__rejecter', 'swift'), '  ')}
-  ${cppParameterName}.pointee.addOnResolvedListener(__resolverCpp)
+  ${cppParameterName}.pointee.${addResolverName}(__resolverCpp)
   ${cppParameterName}.pointee.addOnRejectedListener(__rejecterCpp)
   return __promise
 }()`.trim()

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -755,7 +755,7 @@ case ${i}:
               .map((p) => `__${p.escapedName}`)
               .join(', ')
             const cFuncParamsSignature = [
-              '__closureHolder: UnsafeMutableRawPointer?',
+              '__closureHolder: UnsafeMutableRawPointer',
               ...func.parameters.map((p) => {
                 const bridged = new SwiftCxxBridgedType(p)
                 return `__${p.escapedName}: ${bridged.getTypeCode('swift')}`
@@ -776,11 +776,11 @@ case ${i}:
 
   let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: ${swiftParameterName})).toOpaque()
   func __callClosure(${cFuncParamsSignature}) -> Void {
-    let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder!).takeUnretainedValue()
+    let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
     closure.invoke(${indent(cFuncParamsForward, '    ')})
   }
-  func __destroyClosure(_ __closureHolder: UnsafeMutableRawPointer?) -> Void {
-    Unmanaged<ClosureHolder>.fromOpaque(__closureHolder!).release()
+  func __destroyClosure(_ __closureHolder: UnsafeMutableRawPointer) -> Void {
+    Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
   }
 
   return ${createFunc}(__closureHolder, __callClosure, __destroyClosure)

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -600,7 +600,7 @@ case ${i}:
   let __promise = ${makePromise}()
   ${swiftParameterName}
     .then({ __result in __promise.pointee.resolve(${arg}) })
-    .catch({ __error in __promise.pointee.reject(std.string(String(describing: __error))) })
+    .catch({ __error in __promise.pointee.reject(__error.toCpp()) })
   return __promise
 }()`.trim()
           default:

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -341,7 +341,7 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
               return `
 { () -> ${promise.getCode('swift')} in
   let __promise = ${promise.getCode('swift')}()
-  let __resolver = SwiftClosure { __promise.resolve() }
+  let __resolver = SwiftClosure { __promise.resolve(withResult: ()) }
   let __rejecter = { (__error: std.exception) in
     __promise.reject(withError: RuntimeError.from(cppError: __error))
   }

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -6,7 +6,7 @@ import { FunctionType } from '../types/FunctionType.js'
 import { getTypeAs } from '../types/getTypeAs.js'
 import { OptionalType } from '../types/OptionalType.js'
 import { RecordType } from '../types/RecordType.js'
-import type { Type } from '../types/Type.js'
+import type { NamedType, Type } from '../types/Type.js'
 import { TupleType } from '../types/TupleType.js'
 import { escapeComments, indent } from '../../utils.js'
 import { PromiseType } from '../types/PromiseType.js'
@@ -476,9 +476,11 @@ function createCxxPromiseSwiftHelper(type: PromiseType): SwiftCxxHelper {
   const bridgedType = new SwiftCxxBridgedType(type)
   const actualType = `std::shared_ptr<Promise<${resultingType}>>`
 
-  const resolveFunction = new FunctionType(new VoidType(), [
-    new NamedWrappingType('result', type.resultingType),
-  ])
+  const resolverArgs: NamedType[] = []
+  if (type.resultingType.kind !== 'void') {
+    resolverArgs.push(new NamedWrappingType('result', type.resultingType))
+  }
+  const resolveFunction = new FunctionType(new VoidType(), resolverArgs)
   const rejectFunction = new FunctionType(new VoidType(), [
     new NamedWrappingType('error', new ErrorType()),
   ])

--- a/packages/nitrogen/src/syntax/types/ErrorType.ts
+++ b/packages/nitrogen/src/syntax/types/ErrorType.ts
@@ -1,0 +1,42 @@
+import type { Language } from '../../getPlatformSpecs.js'
+import { type SourceFile, type SourceImport } from '../SourceFile.js'
+import type { Type, TypeKind } from './Type.js'
+
+export class ErrorType implements Type {
+  constructor() {}
+
+  get canBePassedByReference(): boolean {
+    // It's a exception<..>, pass by reference.
+    return true
+  }
+  get kind(): TypeKind {
+    return 'error'
+  }
+
+  getCode(language: Language): string {
+    switch (language) {
+      case 'c++':
+        return `std::exception`
+      case 'swift':
+        return `std.exception`
+      case 'kotlin':
+        return `Throwable`
+      default:
+        throw new Error(
+          `Language ${language} is not yet supported for ThrowableType!`
+        )
+    }
+  }
+  getExtraFiles(): SourceFile[] {
+    return []
+  }
+  getRequiredImports(): SourceImport[] {
+    return [
+      {
+        language: 'c++',
+        name: 'exception',
+        space: 'system',
+      },
+    ]
+  }
+}

--- a/packages/nitrogen/src/syntax/types/Type.ts
+++ b/packages/nitrogen/src/syntax/types/Type.ts
@@ -7,6 +7,7 @@ export type TypeKind =
   | 'bigint'
   | 'boolean'
   | 'enum'
+  | 'error'
   | 'function'
   | 'hybrid-object'
   | 'hybrid-object-base'

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -135,6 +135,10 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
         }
     }
 
+    override fun awaitPromise(promise: Promise<Double>): Promise<Double> {
+        return promise
+    }
+
     override fun callCallback(callback: () -> Unit) {
         callback()
     }

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -136,6 +136,13 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
     }
 
     override fun awaitPromise(promise: Promise<Double>): Promise<Double> {
+        val newPromise = Promise<Double>()
+        promise.addOnResolvedListener { result ->
+            newPromise.resolve(result)
+        }
+        promise.addOnRejectedListener { error ->
+            newPromise.reject(Error(error))
+        }
         return promise
     }
 

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -142,7 +142,7 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
         }
     }
 
-    override fun awaitAndGetComplexPromise(promise: Promise<Car>): Promise<Double> {
+    override fun awaitAndGetComplexPromise(promise: Promise<Car>): Promise<Car> {
         return Promise.async {
             val result = promise.await()
             return@async result

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -136,14 +136,10 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
     }
 
     override fun awaitPromise(promise: Promise<Double>): Promise<Double> {
-        val newPromise = Promise<Double>()
-        promise.addOnResolvedListener { result ->
-            newPromise.resolve(result)
+        return Promise.async {
+            val result = promise.await()
+            return@async result
         }
-        promise.addOnRejectedListener { error ->
-            newPromise.reject(Error(error))
-        }
-        return promise
     }
 
     override fun callCallback(callback: () -> Unit) {

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -135,10 +135,23 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
         }
     }
 
-    override fun awaitPromise(promise: Promise<Double>): Promise<Double> {
+    override fun awaitAndGetPromise(promise: Promise<Double>): Promise<Double> {
         return Promise.async {
             val result = promise.await()
             return@async result
+        }
+    }
+
+    override fun awaitAndGetComplexPromise(promise: Promise<Car>): Promise<Double> {
+        return Promise.async {
+            val result = promise.await()
+            return@async result
+        }
+    }
+
+    override fun awaitPromise(promise: Promise<Unit>): Promise<Unit> {
+        return Promise.async {
+            promise.await()
         }
     }
 

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -13,6 +13,7 @@
 
 #include "HybridBase.hpp"
 #include "HybridChild.hpp"
+#include <type_traits>
 
 namespace margelo::nitro::image {
 
@@ -276,9 +277,23 @@ std::shared_ptr<Promise<double>> HybridTestObjectCpp::getValueFromJSCallbackAndW
   });
 }
 
-std::shared_ptr<Promise<double>> HybridTestObjectCpp::awaitPromise(const std::shared_ptr<Promise<double>>& promise) {
+std::shared_ptr<Promise<double>> HybridTestObjectCpp::awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) {
   auto newPromise = Promise<double>::create();
   promise->addOnResolvedListener([=](double result) { newPromise->resolve(result); });
+  promise->addOnRejectedListener([=](const std::exception& error) { newPromise->reject(error); });
+  return newPromise;
+}
+
+std::shared_ptr<Promise<Car>> HybridTestObjectCpp::awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) {
+  auto newPromise = Promise<Car>::create();
+  promise->addOnResolvedListener([=](const Car& result) { newPromise->resolve(result); });
+  promise->addOnRejectedListener([=](const std::exception& error) { newPromise->reject(error); });
+  return newPromise;
+}
+
+std::shared_ptr<Promise<void>> HybridTestObjectCpp::awaitPromise(const std::shared_ptr<Promise<void>>& promise) {
+  auto newPromise = Promise<void>::create();
+  promise->addOnResolvedListener([=]() { newPromise->resolve(); });
   promise->addOnRejectedListener([=](const std::exception& error) { newPromise->reject(error); });
   return newPromise;
 }

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -13,7 +13,6 @@
 
 #include "HybridBase.hpp"
 #include "HybridChild.hpp"
-#include <type_traits>
 
 namespace margelo::nitro::image {
 

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -278,8 +278,8 @@ std::shared_ptr<Promise<double>> HybridTestObjectCpp::getValueFromJSCallbackAndW
 
 std::shared_ptr<Promise<double>> HybridTestObjectCpp::awaitPromise(const std::shared_ptr<Promise<double>>& promise) {
   auto newPromise = Promise<double>::create();
-  promise->addOnResolvedListener([=](auto result) { newPromise->resolve(result); });
-  promise->addOnRejectedListener([=](auto error) { newPromise->reject(error); });
+  promise->addOnResolvedListener([=](double result) { newPromise->resolve(result); });
+  promise->addOnRejectedListener([=](const std::exception& error) { newPromise->reject(error); });
   return newPromise;
 }
 

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -112,7 +112,9 @@ public:
   std::shared_ptr<Promise<void>>
   getValueFromJsCallback(const std::function<std::future<std::string>()>& callback,
                          const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) override;
-  std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) override;
+  std::shared_ptr<Promise<double>> awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) override;
+  std::shared_ptr<Promise<Car>> awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) override;
+  std::shared_ptr<Promise<void>> awaitPromise(const std::shared_ptr<Promise<void>>& promise) override;
   std::shared_ptr<Promise<void>> promiseThrows() override;
   Car getCar() override;
   bool isCarElectric(const Car& car) override;

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -169,6 +169,13 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
       throw RuntimeError.error(withMessage: "Promise throws :)")
     }
   }
+  
+  func awaitPromise(promise: Promise<Double>) throws -> Promise<Double> {
+    return .async {
+      let result = try await promise.await()
+      return result
+    }
+  }
 
   func callAll(first: @escaping (() -> Void), second: @escaping (() -> Void), third: @escaping (() -> Void)) throws {
     first()

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -170,10 +170,21 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     }
   }
   
-  func awaitPromise(promise: Promise<Double>) throws -> Promise<Double> {
+  func awaitAndGetPromise(promise: Promise<Double>) throws -> Promise<Double> {
     return .async {
       let result = try await promise.await()
       return result
+    }
+  }
+  func awaitAndGetComplexPromise(promise: Promise<Car>) throws -> Promise<Car> {
+    return .async {
+      let result = try await promise.await()
+      return result
+    }
+  }
+  func awaitPromise(promise: Promise<Void>) throws -> Promise<Void> {
+    return .async {
+      try await promise.await()
     }
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -405,6 +405,31 @@ namespace margelo::nitro::image {
       return __promise;
     }();
   }
+  std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::awaitPromise(const std::shared_ptr<Promise<double>>& promise) {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitPromise");
+    auto __result = method(_javaPart, [&]() {
+      jni::local_ref<JPromise::javaobject> __promise = JPromise::create();
+      promise->addOnResolvedListener([=](const double& __result) {
+        __promise->cthis()->resolve(jni::JDouble::valueOf(__result));
+      });
+      promise->addOnRejectedListener([=](const std::exception& __error) {
+        __promise->cthis()->reject(jni::make_jstring(__error.what()));
+      });
+      return __promise;
+    }());
+    return [&]() {
+      auto __promise = Promise<double>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+        __promise->resolve(__result->value());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
+        std::runtime_error __error(__message->toStdString());
+        __promise->reject(std::move(__error));
+      });
+      return __promise;
+    }();
+  }
   void JHybridTestObjectSwiftKotlinSpec::callCallback(const std::function<void()>& callback) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* callback */)>("callCallback");
     method(_javaPart, JFunc_void::fromCpp(callback));

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -368,9 +368,9 @@ namespace margelo::nitro::image {
         auto __result = jni::static_ref_cast<jni::JLong>(__boxedResult);
         __promise->resolve(__result->value());
       });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-        std::runtime_error __error(__message->toStdString());
-        __promise->reject(std::move(__error));
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::move(__jniError));
       });
       return __promise;
     }();
@@ -383,9 +383,9 @@ namespace margelo::nitro::image {
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
         __promise->resolve();
       });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-        std::runtime_error __error(__message->toStdString());
-        __promise->reject(std::move(__error));
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::move(__jniError));
       });
       return __promise;
     }();
@@ -398,9 +398,9 @@ namespace margelo::nitro::image {
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
         __promise->resolve();
       });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-        std::runtime_error __error(__message->toStdString());
-        __promise->reject(std::move(__error));
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::move(__jniError));
       });
       return __promise;
     }();
@@ -413,7 +413,8 @@ namespace margelo::nitro::image {
         __promise->cthis()->resolve(jni::JDouble::valueOf(__result));
       });
       promise->addOnRejectedListener([=](const std::exception& __error) {
-        __promise->cthis()->reject(jni::make_jstring(__error.what()));
+        auto __jniError = jni::JCppException::create(__error);
+        __promise->cthis()->reject(__jniError);
       });
       return __promise;
     }());
@@ -423,9 +424,9 @@ namespace margelo::nitro::image {
         auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
         __promise->resolve(__result->value());
       });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-        std::runtime_error __error(__message->toStdString());
-        __promise->reject(std::move(__error));
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::move(__jniError));
       });
       return __promise;
     }();
@@ -480,9 +481,9 @@ namespace margelo::nitro::image {
         auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
         __promise->resolve(__result->cthis()->getArrayBuffer());
       });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JString>& __message) {
-        std::runtime_error __error(__message->toStdString());
-        __promise->reject(std::move(__error));
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::move(__jniError));
       });
       return __promise;
     }();

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -405,8 +405,8 @@ namespace margelo::nitro::image {
       return __promise;
     }();
   }
-  std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::awaitPromise(const std::shared_ptr<Promise<double>>& promise) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitPromise");
+  std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetPromise");
     auto __result = method(_javaPart, [&]() {
       jni::local_ref<JPromise::javaobject> __promise = JPromise::create();
       promise->addOnResolvedListener([=](const double& __result) {
@@ -423,6 +423,57 @@ namespace margelo::nitro::image {
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
         auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
         __promise->resolve(__result->value());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::move(__jniError));
+      });
+      return __promise;
+    }();
+  }
+  std::shared_ptr<Promise<Car>> JHybridTestObjectSwiftKotlinSpec::awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetComplexPromise");
+    auto __result = method(_javaPart, [&]() {
+      jni::local_ref<JPromise::javaobject> __promise = JPromise::create();
+      promise->addOnResolvedListener([=](const Car& __result) {
+        __promise->cthis()->resolve(JCar::fromCpp(__result));
+      });
+      promise->addOnRejectedListener([=](const std::exception& __error) {
+        auto __jniError = jni::JCppException::create(__error);
+        __promise->cthis()->reject(__jniError);
+      });
+      return __promise;
+    }());
+    return [&]() {
+      auto __promise = Promise<Car>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<JCar>(__boxedResult);
+        __promise->resolve(__result->toCpp());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::move(__jniError));
+      });
+      return __promise;
+    }();
+  }
+  std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::awaitPromise(const std::shared_ptr<Promise<void>>& promise) {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitPromise");
+    auto __result = method(_javaPart, [&]() {
+      jni::local_ref<JPromise::javaobject> __promise = JPromise::create();
+      promise->addOnResolvedListener([=](const void& __result) {
+        __promise->cthis()->resolve(__result);
+      });
+      promise->addOnRejectedListener([=](const std::exception& __error) {
+        auto __jniError = jni::JCppException::create(__error);
+        __promise->cthis()->reject(__jniError);
+      });
+      return __promise;
+    }());
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        __promise->resolve();
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -95,7 +95,9 @@ namespace margelo::nitro::image {
     std::shared_ptr<Promise<int64_t>> calculateFibonacciAsync(double value) override;
     std::shared_ptr<Promise<void>> wait(double seconds) override;
     std::shared_ptr<Promise<void>> promiseThrows() override;
-    std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) override;
+    std::shared_ptr<Promise<double>> awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) override;
+    std::shared_ptr<Promise<Car>> awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) override;
+    std::shared_ptr<Promise<void>> awaitPromise(const std::shared_ptr<Promise<void>>& promise) override;
     void callCallback(const std::function<void()>& callback) override;
     void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) override;
     void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) override;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -95,6 +95,7 @@ namespace margelo::nitro::image {
     std::shared_ptr<Promise<int64_t>> calculateFibonacciAsync(double value) override;
     std::shared_ptr<Promise<void>> wait(double seconds) override;
     std::shared_ptr<Promise<void>> promiseThrows() override;
+    std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) override;
     void callCallback(const std::function<void()>& callback) override;
     void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) override;
     void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) override;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -204,7 +204,15 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun awaitPromise(promise: Promise<Double>): Promise<Double>
+  abstract fun awaitAndGetPromise(promise: Promise<Double>): Promise<Double>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun awaitAndGetComplexPromise(promise: Promise<Car>): Promise<Car>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun awaitPromise(promise: Promise<Unit>): Promise<Unit>
   
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -204,6 +204,10 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun awaitPromise(promise: Promise<Double>): Promise<Double>
+  
+  @DoNotStrip
+  @Keep
   abstract fun callCallback(callback: () -> Unit): Unit
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -53,6 +53,7 @@ namespace NitroImage { class HybridTestObjectSwiftKotlinSpecCxx; }
 #include <NitroModules/ArrayBuffer.hpp>
 #include <NitroModules/ArrayBufferHolder.hpp>
 #include <NitroModules/Promise.hpp>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -282,6 +283,62 @@ namespace margelo::nitro::image::bridge::swift {
     return Promise<int64_t>::create();
   }
   
+  // pragma MARK: std::function<void(int64_t /* result */)>
+  /**
+   * Specialized version of `std::function<void(int64_t)>`.
+   */
+  using Func_void_int64_t = std::function<void(int64_t /* result */)>;
+  /**
+   * Wrapper class for a `std::function<void(int64_t / * result * /)>`, this can be used from Swift.
+   */
+  class Func_void_int64_t_Wrapper final {
+  public:
+    explicit Func_void_int64_t_Wrapper(const std::function<void(int64_t /* result */)>& func): _function(func) {}
+    explicit Func_void_int64_t_Wrapper(std::function<void(int64_t /* result */)>&& func): _function(std::move(func)) {}
+    inline void call(int64_t result) const {
+      _function(result);
+    }
+  private:
+    std::function<void(int64_t /* result */)> _function;
+  };
+  inline Func_void_int64_t create_Func_void_int64_t(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, int64_t), void(* _Nonnull destroy)(void* _Nonnull)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_void_int64_t([sharedClosureHolder, call](int64_t result) -> void {
+      call(sharedClosureHolder.get(), result);
+    });
+  }
+  inline std::shared_ptr<Func_void_int64_t_Wrapper> share_Func_void_int64_t(const Func_void_int64_t& value) {
+    return std::make_shared<Func_void_int64_t_Wrapper>(value);
+  }
+  
+  // pragma MARK: std::function<void(const std::exception& /* error */)>
+  /**
+   * Specialized version of `std::function<void(const std::exception&)>`.
+   */
+  using Func_void_std__exception = std::function<void(const std::exception& /* error */)>;
+  /**
+   * Wrapper class for a `std::function<void(const std::exception& / * error * /)>`, this can be used from Swift.
+   */
+  class Func_void_std__exception_Wrapper final {
+  public:
+    explicit Func_void_std__exception_Wrapper(const std::function<void(const std::exception& /* error */)>& func): _function(func) {}
+    explicit Func_void_std__exception_Wrapper(std::function<void(const std::exception& /* error */)>&& func): _function(std::move(func)) {}
+    inline void call(std::exception error) const {
+      _function(error);
+    }
+  private:
+    std::function<void(const std::exception& /* error */)> _function;
+  };
+  inline Func_void_std__exception create_Func_void_std__exception(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::exception), void(* _Nonnull destroy)(void* _Nonnull)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_void_std__exception([sharedClosureHolder, call](const std::exception& error) -> void {
+      call(sharedClosureHolder.get(), error);
+    });
+  }
+  inline std::shared_ptr<Func_void_std__exception_Wrapper> share_Func_void_std__exception(const Func_void_std__exception& value) {
+    return std::make_shared<Func_void_std__exception_Wrapper>(value);
+  }
+  
   // pragma MARK: std::shared_ptr<Promise<void>>
   /**
    * Specialized version of `std::shared_ptr<Promise<void>>`.
@@ -289,15 +346,6 @@ namespace margelo::nitro::image::bridge::swift {
   using std__shared_ptr_Promise_void__ = std::shared_ptr<Promise<void>>;
   inline std::shared_ptr<Promise<void>> create_std__shared_ptr_Promise_void__() {
     return Promise<void>::create();
-  }
-  
-  // pragma MARK: std::shared_ptr<Promise<double>>
-  /**
-   * Specialized version of `std::shared_ptr<Promise<double>>`.
-   */
-  using std__shared_ptr_Promise_double__ = std::shared_ptr<Promise<double>>;
-  inline std::shared_ptr<Promise<double>> create_std__shared_ptr_Promise_double__() {
-    return Promise<double>::create();
   }
   
   // pragma MARK: std::function<void()>
@@ -326,6 +374,43 @@ namespace margelo::nitro::image::bridge::swift {
   }
   inline std::shared_ptr<Func_void_Wrapper> share_Func_void(const Func_void& value) {
     return std::make_shared<Func_void_Wrapper>(value);
+  }
+  
+  // pragma MARK: std::shared_ptr<Promise<double>>
+  /**
+   * Specialized version of `std::shared_ptr<Promise<double>>`.
+   */
+  using std__shared_ptr_Promise_double__ = std::shared_ptr<Promise<double>>;
+  inline std::shared_ptr<Promise<double>> create_std__shared_ptr_Promise_double__() {
+    return Promise<double>::create();
+  }
+  
+  // pragma MARK: std::function<void(double /* result */)>
+  /**
+   * Specialized version of `std::function<void(double)>`.
+   */
+  using Func_void_double = std::function<void(double /* result */)>;
+  /**
+   * Wrapper class for a `std::function<void(double / * result * /)>`, this can be used from Swift.
+   */
+  class Func_void_double_Wrapper final {
+  public:
+    explicit Func_void_double_Wrapper(const std::function<void(double /* result */)>& func): _function(func) {}
+    explicit Func_void_double_Wrapper(std::function<void(double /* result */)>&& func): _function(std::move(func)) {}
+    inline void call(double result) const {
+      _function(result);
+    }
+  private:
+    std::function<void(double /* result */)> _function;
+  };
+  inline Func_void_double create_Func_void_double(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, double), void(* _Nonnull destroy)(void* _Nonnull)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_void_double([sharedClosureHolder, call](double result) -> void {
+      call(sharedClosureHolder.get(), result);
+    });
+  }
+  inline std::shared_ptr<Func_void_double_Wrapper> share_Func_void_double(const Func_void_double& value) {
+    return std::make_shared<Func_void_double_Wrapper>(value);
   }
   
   // pragma MARK: std::optional<double>
@@ -381,6 +466,34 @@ namespace margelo::nitro::image::bridge::swift {
   using std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ = std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>;
   inline std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> create_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___() {
     return Promise<std::shared_ptr<ArrayBuffer>>::create();
+  }
+  
+  // pragma MARK: std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)>
+  /**
+   * Specialized version of `std::function<void(const std::shared_ptr<ArrayBuffer>&)>`.
+   */
+  using Func_void_std__shared_ptr_ArrayBuffer_ = std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)>;
+  /**
+   * Wrapper class for a `std::function<void(const std::shared_ptr<ArrayBuffer>& / * result * /)>`, this can be used from Swift.
+   */
+  class Func_void_std__shared_ptr_ArrayBuffer__Wrapper final {
+  public:
+    explicit Func_void_std__shared_ptr_ArrayBuffer__Wrapper(const std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)>& func): _function(func) {}
+    explicit Func_void_std__shared_ptr_ArrayBuffer__Wrapper(std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)>&& func): _function(std::move(func)) {}
+    inline void call(ArrayBufferHolder result) const {
+      _function(result.getArrayBuffer());
+    }
+  private:
+    std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)> _function;
+  };
+  inline Func_void_std__shared_ptr_ArrayBuffer_ create_Func_void_std__shared_ptr_ArrayBuffer_(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, ArrayBufferHolder), void(* _Nonnull destroy)(void* _Nonnull)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_void_std__shared_ptr_ArrayBuffer_([sharedClosureHolder, call](const std::shared_ptr<ArrayBuffer>& result) -> void {
+      call(sharedClosureHolder.get(), ArrayBufferHolder(result));
+    });
+  }
+  inline std::shared_ptr<Func_void_std__shared_ptr_ArrayBuffer__Wrapper> share_Func_void_std__shared_ptr_ArrayBuffer_(const Func_void_std__shared_ptr_ArrayBuffer_& value) {
+    return std::make_shared<Func_void_std__shared_ptr_ArrayBuffer__Wrapper>(value);
   }
   
   // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridChildSpec>

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -291,6 +291,15 @@ namespace margelo::nitro::image::bridge::swift {
     return Promise<void>::create();
   }
   
+  // pragma MARK: std::shared_ptr<Promise<double>>
+  /**
+   * Specialized version of `std::shared_ptr<Promise<double>>`.
+   */
+  using std__shared_ptr_Promise_double__ = std::shared_ptr<Promise<double>>;
+  inline std::shared_ptr<Promise<double>> create_std__shared_ptr_Promise_double__() {
+    return Promise<double>::create();
+  }
+  
   // pragma MARK: std::function<void()>
   /**
    * Specialized version of `std::function<void()>`.

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -12,6 +12,8 @@
 namespace NitroModules { class ArrayBufferHolder; }
 // Forward declaration of `ArrayBuffer` to properly resolve imports.
 namespace NitroModules { class ArrayBuffer; }
+// Forward declaration of `Car` to properly resolve imports.
+namespace margelo::nitro::image { struct Car; }
 // Forward declaration of `HybridBaseSpec` to properly resolve imports.
 namespace margelo::nitro::image { class HybridBaseSpec; }
 // Forward declaration of `HybridChildSpec` to properly resolve imports.
@@ -42,6 +44,7 @@ namespace NitroImage { class HybridImageSpecCxx; }
 namespace NitroImage { class HybridTestObjectSwiftKotlinSpecCxx; }
 
 // Include C++ defined types
+#include "Car.hpp"
 #include "HybridBaseSpec.hpp"
 #include "HybridChildSpec.hpp"
 #include "HybridImageFactorySpec.hpp"
@@ -413,6 +416,52 @@ namespace margelo::nitro::image::bridge::swift {
     return std::make_shared<Func_void_double_Wrapper>(value);
   }
   
+  // pragma MARK: std::optional<Person>
+  /**
+   * Specialized version of `std::optional<Person>`.
+   */
+  using std__optional_Person_ = std::optional<Person>;
+  inline std::optional<Person> create_std__optional_Person_(const Person& value) {
+    return std::optional<Person>(value);
+  }
+  
+  // pragma MARK: std::shared_ptr<Promise<Car>>
+  /**
+   * Specialized version of `std::shared_ptr<Promise<Car>>`.
+   */
+  using std__shared_ptr_Promise_Car__ = std::shared_ptr<Promise<Car>>;
+  inline std::shared_ptr<Promise<Car>> create_std__shared_ptr_Promise_Car__() {
+    return Promise<Car>::create();
+  }
+  
+  // pragma MARK: std::function<void(const Car& /* result */)>
+  /**
+   * Specialized version of `std::function<void(const Car&)>`.
+   */
+  using Func_void_Car = std::function<void(const Car& /* result */)>;
+  /**
+   * Wrapper class for a `std::function<void(const Car& / * result * /)>`, this can be used from Swift.
+   */
+  class Func_void_Car_Wrapper final {
+  public:
+    explicit Func_void_Car_Wrapper(const std::function<void(const Car& /* result */)>& func): _function(func) {}
+    explicit Func_void_Car_Wrapper(std::function<void(const Car& /* result */)>&& func): _function(std::move(func)) {}
+    inline void call(Car result) const {
+      _function(result);
+    }
+  private:
+    std::function<void(const Car& /* result */)> _function;
+  };
+  inline Func_void_Car create_Func_void_Car(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, Car), void(* _Nonnull destroy)(void* _Nonnull)) {
+    std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
+    return Func_void_Car([sharedClosureHolder, call](const Car& result) -> void {
+      call(sharedClosureHolder.get(), result);
+    });
+  }
+  inline std::shared_ptr<Func_void_Car_Wrapper> share_Func_void_Car(const Func_void_Car& value) {
+    return std::make_shared<Func_void_Car_Wrapper>(value);
+  }
+  
   // pragma MARK: std::optional<double>
   /**
    * Specialized version of `std::optional<double>`.
@@ -448,15 +497,6 @@ namespace margelo::nitro::image::bridge::swift {
   }
   inline std::shared_ptr<Func_void_std__optional_double__Wrapper> share_Func_void_std__optional_double_(const Func_void_std__optional_double_& value) {
     return std::make_shared<Func_void_std__optional_double__Wrapper>(value);
-  }
-  
-  // pragma MARK: std::optional<Person>
-  /**
-   * Specialized version of `std::optional<Person>`.
-   */
-  using std__optional_Person_ = std::optional<Person>;
-  inline std::optional<Person> create_std__optional_Person_(const Person& value) {
-    return std::optional<Person>(value);
   }
   
   // pragma MARK: std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Umbrella.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Umbrella.hpp
@@ -67,6 +67,7 @@ namespace margelo::nitro::image { enum class Powertrain; }
 #include <NitroModules/ArrayBufferHolder.hpp>
 #include <NitroModules/AnyMapHolder.hpp>
 #include <NitroModules/HybridContext.hpp>
+#include <NitroModules/RuntimeError.hpp>
 
 // Forward declarations of Swift defined types
 // Forward declaration of `HybridBaseSpecCxx` to properly resolve imports.

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -256,7 +256,7 @@ namespace margelo::nitro::image {
       return __result;
     }
     inline std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) override {
-      auto __result = _swiftPart.awaitPromise([]() -> std::shared_ptr<Promise<double>> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }());
+      auto __result = _swiftPart.awaitPromise(promise);
       return __result;
     }
     inline void callCallback(const std::function<void()>& callback) override {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -255,7 +255,15 @@ namespace margelo::nitro::image {
       auto __result = _swiftPart.promiseThrows();
       return __result;
     }
-    inline std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) override {
+    inline std::shared_ptr<Promise<double>> awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) override {
+      auto __result = _swiftPart.awaitAndGetPromise(promise);
+      return __result;
+    }
+    inline std::shared_ptr<Promise<Car>> awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) override {
+      auto __result = _swiftPart.awaitAndGetComplexPromise(promise);
+      return __result;
+    }
+    inline std::shared_ptr<Promise<void>> awaitPromise(const std::shared_ptr<Promise<void>>& promise) override {
       auto __result = _swiftPart.awaitPromise(promise);
       return __result;
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -255,6 +255,10 @@ namespace margelo::nitro::image {
       auto __result = _swiftPart.promiseThrows();
       return __result;
     }
+    inline std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) override {
+      auto __result = _swiftPart.awaitPromise([]() -> std::shared_ptr<Promise<double>> { throw std::runtime_error("Promise<..> cannot be converted to Swift yet!"); }());
+      return __result;
+    }
     inline void callCallback(const std::function<void()>& callback) override {
       _swiftPart.callCallback(callback);
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -64,7 +64,9 @@ public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
   func calculateFibonacciAsync(value: Double) throws -> Promise<Int64>
   func wait(seconds: Double) throws -> Promise<Void>
   func promiseThrows() throws -> Promise<Void>
-  func awaitPromise(promise: Promise<Double>) throws -> Promise<Double>
+  func awaitAndGetPromise(promise: Promise<Double>) throws -> Promise<Double>
+  func awaitAndGetComplexPromise(promise: Promise<Car>) throws -> Promise<Car>
+  func awaitPromise(promise: Promise<Void>) throws -> Promise<Void>
   func callCallback(callback: @escaping (() -> Void)) throws -> Void
   func callAll(first: @escaping (() -> Void), second: @escaping (() -> Void), third: @escaping (() -> Void)) throws -> Void
   func callWithOptional(value: Double?, callback: @escaping ((_ maybe: Double?) -> Void)) throws -> Void

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -64,6 +64,7 @@ public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
   func calculateFibonacciAsync(value: Double) throws -> Promise<Int64>
   func wait(seconds: Double) throws -> Promise<Void>
   func promiseThrows() throws -> Promise<Void>
+  func awaitPromise(promise: Promise<Double>) throws -> Promise<Double>
   func callCallback(callback: @escaping (() -> Void)) throws -> Void
   func callAll(first: @escaping (() -> Void), second: @escaping (() -> Void), third: @escaping (() -> Void)) throws -> Void
   func callWithOptional(value: Double?, callback: @escaping ((_ maybe: Double?) -> Void)) throws -> Void

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -687,7 +687,8 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         
           return bridge.create_Func_void_std__exception(__closureHolder, __callClosure, __destroyClosure)
         }()
-        // TODO: Listeners
+        promise.pointee.addOnResolvedListener(__resolverCpp)
+        promise.pointee.addOnRejectedListener(__rejecterCpp)
         return __promise
       }())
       return { () -> bridge.std__shared_ptr_Promise_double__ in

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -589,7 +589,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         let __promise = bridge.create_std__shared_ptr_Promise_int64_t__()
         __result
           .then({ __result in __promise.pointee.resolve(__result) })
-          .catch({ __error in __promise.pointee.reject(std.string(String(describing: __error))) })
+          .catch({ __error in __promise.pointee.reject(__error.toCpp()) })
         return __promise
       }()
     } catch {
@@ -606,7 +606,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         let __promise = bridge.create_std__shared_ptr_Promise_void__()
         __result
           .then({ __result in __promise.pointee.resolve() })
-          .catch({ __error in __promise.pointee.reject(std.string(String(describing: __error))) })
+          .catch({ __error in __promise.pointee.reject(__error.toCpp()) })
         return __promise
       }()
     } catch {
@@ -623,7 +623,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         let __promise = bridge.create_std__shared_ptr_Promise_void__()
         __result
           .then({ __result in __promise.pointee.resolve() })
-          .catch({ __error in __promise.pointee.reject(std.string(String(describing: __error))) })
+          .catch({ __error in __promise.pointee.reject(__error.toCpp()) })
         return __promise
       }()
     } catch {
@@ -640,7 +640,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         let __promise = bridge.create_std__shared_ptr_Promise_double__()
         __result
           .then({ __result in __promise.pointee.resolve(__result) })
-          .catch({ __error in __promise.pointee.reject(std.string(String(describing: __error))) })
+          .catch({ __error in __promise.pointee.reject(__error.toCpp()) })
         return __promise
       }()
     } catch {
@@ -793,7 +793,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         let __promise = bridge.create_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___()
         __result
           .then({ __result in __promise.pointee.resolve(__result.getArrayBuffer()) })
-          .catch({ __error in __promise.pointee.reject(std.string(String(describing: __error))) })
+          .catch({ __error in __promise.pointee.reject(__error.toCpp()) })
         return __promise
       }()
     } catch {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -687,7 +687,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         
           return bridge.create_Func_void_std__exception(__closureHolder, __callClosure, __destroyClosure)
         }()
-        promise.pointee.addOnResolvedListener(__resolverCpp)
+        promise.pointee.addOnResolvedListenerCopy(__resolverCpp)
         promise.pointee.addOnRejectedListener(__rejecterCpp)
         return __promise
       }())

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -636,14 +636,14 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   public func awaitPromise(promise: bridge.std__shared_ptr_Promise_double__) -> bridge.std__shared_ptr_Promise_double__ {
     do {
       let __result = try self.__implementation.awaitPromise(promise: { () -> Promise<Double> in
-          let __promise = Promise<Double>()
-          let __resolver = { (__result: Double) in
-            __promise.resolve(withResult: __result)
-          }
-          let __rejecter = { (__error: std.exception) in
-            __promise.reject(withError: RuntimeError.from(cppError: __error))
-          }
-          let __resolverCpp = { () -> bridge.Func_void_double in
+        let __promise = Promise<Double>()
+        let __resolver = { (__result: Double) in
+          __promise.resolve(withResult: __result)
+        }
+        let __rejecter = { (__error: std.exception) in
+          __promise.reject(withError: RuntimeError.from(cppError: __error))
+        }
+        let __resolverCpp = { () -> bridge.Func_void_double in
           class ClosureHolder {
             let closure: ((_ result: Double) -> Void)
             init(wrappingClosure closure: @escaping ((_ result: Double) -> Void)) {
@@ -665,7 +665,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         
           return bridge.create_Func_void_double(__closureHolder, __callClosure, __destroyClosure)
         }()
-          let __rejecterCpp = { () -> bridge.Func_void_std__exception in
+        let __rejecterCpp = { () -> bridge.Func_void_std__exception in
           class ClosureHolder {
             let closure: ((_ error: std.exception) -> Void)
             init(wrappingClosure closure: @escaping ((_ error: std.exception) -> Void)) {
@@ -687,8 +687,10 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         
           return bridge.create_Func_void_std__exception(__closureHolder, __callClosure, __destroyClosure)
         }()
-          return __promise
-        }())
+        promise.pointee.addOnResolvedListener(__resolverCpp)
+        //promise.pointee.addOnRejectedListener(__rejecterCpp)
+        return __promise
+      }())
       return { () -> bridge.std__shared_ptr_Promise_double__ in
         let __promise = bridge.create_std__shared_ptr_Promise_double__()
         __result

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -633,6 +633,23 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   }
   
   @inline(__always)
+  public func awaitPromise(promise: bridge.std__shared_ptr_Promise_double__) -> bridge.std__shared_ptr_Promise_double__ {
+    do {
+      let __result = try self.__implementation.awaitPromise(promise: promise)
+      return { () -> bridge.std__shared_ptr_Promise_double__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_double__()
+        __result
+          .then({ __result in __promise.pointee.resolve(__result) })
+          .catch({ __error in __promise.pointee.reject(std.string(String(describing: __error))) })
+        return __promise
+      }()
+    } catch {
+      let __message = "\(error.localizedDescription)"
+      fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(__message))")
+    }
+  }
+  
+  @inline(__always)
   public func callCallback(callback: bridge.Func_void) -> Void {
     do {
       try self.__implementation.callCallback(callback: { () -> (() -> Void) in

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -633,9 +633,9 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   }
   
   @inline(__always)
-  public func awaitPromise(promise: bridge.std__shared_ptr_Promise_double__) -> bridge.std__shared_ptr_Promise_double__ {
+  public func awaitAndGetPromise(promise: bridge.std__shared_ptr_Promise_double__) -> bridge.std__shared_ptr_Promise_double__ {
     do {
-      let __result = try self.__implementation.awaitPromise(promise: { () -> Promise<Double> in
+      let __result = try self.__implementation.awaitAndGetPromise(promise: { () -> Promise<Double> in
         let __promise = Promise<Double>()
         let __resolver = { (__result: Double) in
           __promise.resolve(withResult: __result)
@@ -695,6 +695,127 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         let __promise = bridge.create_std__shared_ptr_Promise_double__()
         __result
           .then({ __result in __promise.pointee.resolve(__result) })
+          .catch({ __error in __promise.pointee.reject(__error.toCpp()) })
+        return __promise
+      }()
+    } catch {
+      let __message = "\(error.localizedDescription)"
+      fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(__message))")
+    }
+  }
+  
+  @inline(__always)
+  public func awaitAndGetComplexPromise(promise: bridge.std__shared_ptr_Promise_Car__) -> bridge.std__shared_ptr_Promise_Car__ {
+    do {
+      let __result = try self.__implementation.awaitAndGetComplexPromise(promise: { () -> Promise<Car> in
+        let __promise = Promise<Car>()
+        let __resolver = { (__result: Car) in
+          __promise.resolve(withResult: __result)
+        }
+        let __rejecter = { (__error: std.exception) in
+          __promise.reject(withError: RuntimeError.from(cppError: __error))
+        }
+        let __resolverCpp = { () -> bridge.Func_void_Car in
+          class ClosureHolder {
+            let closure: ((_ result: Car) -> Void)
+            init(wrappingClosure closure: @escaping ((_ result: Car) -> Void)) {
+              self.closure = closure
+            }
+            func invoke(_ __result: Car) {
+              self.closure(__result)
+            }
+          }
+        
+          let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: __resolver)).toOpaque()
+          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __result: Car) -> Void {
+            let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
+            closure.invoke(__result)
+          }
+          func __destroyClosure(_ __closureHolder: UnsafeMutableRawPointer) -> Void {
+            Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
+          }
+        
+          return bridge.create_Func_void_Car(__closureHolder, __callClosure, __destroyClosure)
+        }()
+        let __rejecterCpp = { () -> bridge.Func_void_std__exception in
+          class ClosureHolder {
+            let closure: ((_ error: std.exception) -> Void)
+            init(wrappingClosure closure: @escaping ((_ error: std.exception) -> Void)) {
+              self.closure = closure
+            }
+            func invoke(_ __error: std.exception) {
+              self.closure(__error)
+            }
+          }
+        
+          let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: __rejecter)).toOpaque()
+          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __error: std.exception) -> Void {
+            let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
+            closure.invoke(__error)
+          }
+          func __destroyClosure(_ __closureHolder: UnsafeMutableRawPointer) -> Void {
+            Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
+          }
+        
+          return bridge.create_Func_void_std__exception(__closureHolder, __callClosure, __destroyClosure)
+        }()
+        promise.pointee.addOnResolvedListener(__resolverCpp)
+        promise.pointee.addOnRejectedListener(__rejecterCpp)
+        return __promise
+      }())
+      return { () -> bridge.std__shared_ptr_Promise_Car__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_Car__()
+        __result
+          .then({ __result in __promise.pointee.resolve(__result) })
+          .catch({ __error in __promise.pointee.reject(__error.toCpp()) })
+        return __promise
+      }()
+    } catch {
+      let __message = "\(error.localizedDescription)"
+      fatalError("Swift errors can currently not be propagated to C++! See https://github.com/swiftlang/swift/issues/75290 (Error: \(__message))")
+    }
+  }
+  
+  @inline(__always)
+  public func awaitPromise(promise: bridge.std__shared_ptr_Promise_void__) -> bridge.std__shared_ptr_Promise_void__ {
+    do {
+      let __result = try self.__implementation.awaitPromise(promise: { () -> Promise<Void> in
+        let __promise = Promise<Void>()
+        let __resolver = SwiftClosure { __promise.resolve(withResult: ()) }
+        let __rejecter = { (__error: std.exception) in
+          __promise.reject(withError: RuntimeError.from(cppError: __error))
+        }
+        let __resolverCpp = __resolver.getFunctionCopy()
+        let __rejecterCpp = { () -> bridge.Func_void_std__exception in
+          class ClosureHolder {
+            let closure: ((_ error: std.exception) -> Void)
+            init(wrappingClosure closure: @escaping ((_ error: std.exception) -> Void)) {
+              self.closure = closure
+            }
+            func invoke(_ __error: std.exception) {
+              self.closure(__error)
+            }
+          }
+        
+          let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: __rejecter)).toOpaque()
+          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __error: std.exception) -> Void {
+            let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
+            closure.invoke(__error)
+          }
+          func __destroyClosure(_ __closureHolder: UnsafeMutableRawPointer) -> Void {
+            Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
+          }
+        
+          return bridge.create_Func_void_std__exception(__closureHolder, __callClosure, __destroyClosure)
+        }()
+        promise.pointee.addOnResolvedListener(__resolverCpp)
+        promise.pointee.addOnRejectedListener(__rejecterCpp)
+        return __promise
+      }())
+      return { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        __result
+          .then({ __result in __promise.pointee.resolve() })
           .catch({ __error in __promise.pointee.reject(__error.toCpp()) })
         return __promise
       }()

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -687,8 +687,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         
           return bridge.create_Func_void_std__exception(__closureHolder, __callClosure, __destroyClosure)
         }()
-        promise.pointee.addOnResolvedListener(__resolverCpp)
-        //promise.pointee.addOnRejectedListener(__rejecterCpp)
+        // TODO: Listeners
         return __promise
       }())
       return { () -> bridge.std__shared_ptr_Promise_double__ in

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -635,7 +635,60 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
   @inline(__always)
   public func awaitPromise(promise: bridge.std__shared_ptr_Promise_double__) -> bridge.std__shared_ptr_Promise_double__ {
     do {
-      let __result = try self.__implementation.awaitPromise(promise: promise)
+      let __result = try self.__implementation.awaitPromise(promise: { () -> Promise<Double> in
+          let __promise = Promise<Double>()
+          let __resolver = { (__result: Double) in
+            __promise.resolve(withResult: __result)
+          }
+          let __rejecter = { (__error: std.exception) in
+            __promise.reject(withError: RuntimeError.from(cppError: __error))
+          }
+          let __resolverCpp = { () -> bridge.Func_void_double in
+          class ClosureHolder {
+            let closure: ((_ result: Double) -> Void)
+            init(wrappingClosure closure: @escaping ((_ result: Double) -> Void)) {
+              self.closure = closure
+            }
+            func invoke(_ __result: Double) {
+              self.closure(__result)
+            }
+          }
+        
+          let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: __resolver)).toOpaque()
+          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __result: Double) -> Void {
+            let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
+            closure.invoke(__result)
+          }
+          func __destroyClosure(_ __closureHolder: UnsafeMutableRawPointer) -> Void {
+            Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
+          }
+        
+          return bridge.create_Func_void_double(__closureHolder, __callClosure, __destroyClosure)
+        }()
+          let __rejecterCpp = { () -> bridge.Func_void_std__exception in
+          class ClosureHolder {
+            let closure: ((_ error: std.exception) -> Void)
+            init(wrappingClosure closure: @escaping ((_ error: std.exception) -> Void)) {
+              self.closure = closure
+            }
+            func invoke(_ __error: std.exception) {
+              self.closure(__error)
+            }
+          }
+        
+          let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: __rejecter)).toOpaque()
+          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __error: std.exception) -> Void {
+            let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
+            closure.invoke(__error)
+          }
+          func __destroyClosure(_ __closureHolder: UnsafeMutableRawPointer) -> Void {
+            Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
+          }
+        
+          return bridge.create_Func_void_std__exception(__closureHolder, __callClosure, __destroyClosure)
+        }()
+          return __promise
+        }())
       return { () -> bridge.std__shared_ptr_Promise_double__ in
         let __promise = bridge.create_std__shared_ptr_Promise_double__()
         __result

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -70,6 +70,8 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("calculateFibonacciAsync", &HybridTestObjectCppSpec::calculateFibonacciAsync);
       prototype.registerHybridMethod("wait", &HybridTestObjectCppSpec::wait);
       prototype.registerHybridMethod("promiseThrows", &HybridTestObjectCppSpec::promiseThrows);
+      prototype.registerHybridMethod("awaitAndGetPromise", &HybridTestObjectCppSpec::awaitAndGetPromise);
+      prototype.registerHybridMethod("awaitAndGetComplexPromise", &HybridTestObjectCppSpec::awaitAndGetComplexPromise);
       prototype.registerHybridMethod("awaitPromise", &HybridTestObjectCppSpec::awaitPromise);
       prototype.registerHybridMethod("callCallback", &HybridTestObjectCppSpec::callCallback);
       prototype.registerHybridMethod("callAll", &HybridTestObjectCppSpec::callAll);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -50,7 +50,6 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("passTuple", &HybridTestObjectCppSpec::passTuple);
       prototype.registerHybridMethod("getValueFromJSCallbackAndWait", &HybridTestObjectCppSpec::getValueFromJSCallbackAndWait);
       prototype.registerHybridMethod("getValueFromJsCallback", &HybridTestObjectCppSpec::getValueFromJsCallback);
-      prototype.registerHybridMethod("awaitPromise", &HybridTestObjectCppSpec::awaitPromise);
       prototype.registerHybridMethod("newTestObject", &HybridTestObjectCppSpec::newTestObject);
       prototype.registerHybridMethod("simpleFunc", &HybridTestObjectCppSpec::simpleFunc);
       prototype.registerHybridMethod("addNumbers", &HybridTestObjectCppSpec::addNumbers);
@@ -71,6 +70,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("calculateFibonacciAsync", &HybridTestObjectCppSpec::calculateFibonacciAsync);
       prototype.registerHybridMethod("wait", &HybridTestObjectCppSpec::wait);
       prototype.registerHybridMethod("promiseThrows", &HybridTestObjectCppSpec::promiseThrows);
+      prototype.registerHybridMethod("awaitPromise", &HybridTestObjectCppSpec::awaitPromise);
       prototype.registerHybridMethod("callCallback", &HybridTestObjectCppSpec::callCallback);
       prototype.registerHybridMethod("callAll", &HybridTestObjectCppSpec::callAll);
       prototype.registerHybridMethod("callWithOptional", &HybridTestObjectCppSpec::callWithOptional);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -116,7 +116,6 @@ namespace margelo::nitro::image {
       virtual std::tuple<double, std::string, bool> passTuple(const std::tuple<double, std::string, bool>& tuple) = 0;
       virtual std::shared_ptr<Promise<double>> getValueFromJSCallbackAndWait(const std::function<std::future<double>()>& getValue) = 0;
       virtual std::shared_ptr<Promise<void>> getValueFromJsCallback(const std::function<std::future<std::string>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) = 0;
-      virtual std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec> newTestObject() = 0;
       virtual void simpleFunc() = 0;
       virtual double addNumbers(double a, double b) = 0;
@@ -137,6 +136,7 @@ namespace margelo::nitro::image {
       virtual std::shared_ptr<Promise<int64_t>> calculateFibonacciAsync(double value) = 0;
       virtual std::shared_ptr<Promise<void>> wait(double seconds) = 0;
       virtual std::shared_ptr<Promise<void>> promiseThrows() = 0;
+      virtual std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) = 0;
       virtual void callCallback(const std::function<void()>& callback) = 0;
       virtual void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) = 0;
       virtual void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -136,7 +136,9 @@ namespace margelo::nitro::image {
       virtual std::shared_ptr<Promise<int64_t>> calculateFibonacciAsync(double value) = 0;
       virtual std::shared_ptr<Promise<void>> wait(double seconds) = 0;
       virtual std::shared_ptr<Promise<void>> promiseThrows() = 0;
-      virtual std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) = 0;
+      virtual std::shared_ptr<Promise<double>> awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) = 0;
+      virtual std::shared_ptr<Promise<Car>> awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) = 0;
+      virtual std::shared_ptr<Promise<void>> awaitPromise(const std::shared_ptr<Promise<void>>& promise) = 0;
       virtual void callCallback(const std::function<void()>& callback) = 0;
       virtual void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) = 0;
       virtual void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -59,6 +59,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("calculateFibonacciAsync", &HybridTestObjectSwiftKotlinSpec::calculateFibonacciAsync);
       prototype.registerHybridMethod("wait", &HybridTestObjectSwiftKotlinSpec::wait);
       prototype.registerHybridMethod("promiseThrows", &HybridTestObjectSwiftKotlinSpec::promiseThrows);
+      prototype.registerHybridMethod("awaitPromise", &HybridTestObjectSwiftKotlinSpec::awaitPromise);
       prototype.registerHybridMethod("callCallback", &HybridTestObjectSwiftKotlinSpec::callCallback);
       prototype.registerHybridMethod("callAll", &HybridTestObjectSwiftKotlinSpec::callAll);
       prototype.registerHybridMethod("callWithOptional", &HybridTestObjectSwiftKotlinSpec::callWithOptional);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -59,6 +59,8 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("calculateFibonacciAsync", &HybridTestObjectSwiftKotlinSpec::calculateFibonacciAsync);
       prototype.registerHybridMethod("wait", &HybridTestObjectSwiftKotlinSpec::wait);
       prototype.registerHybridMethod("promiseThrows", &HybridTestObjectSwiftKotlinSpec::promiseThrows);
+      prototype.registerHybridMethod("awaitAndGetPromise", &HybridTestObjectSwiftKotlinSpec::awaitAndGetPromise);
+      prototype.registerHybridMethod("awaitAndGetComplexPromise", &HybridTestObjectSwiftKotlinSpec::awaitAndGetComplexPromise);
       prototype.registerHybridMethod("awaitPromise", &HybridTestObjectSwiftKotlinSpec::awaitPromise);
       prototype.registerHybridMethod("callCallback", &HybridTestObjectSwiftKotlinSpec::callCallback);
       prototype.registerHybridMethod("callAll", &HybridTestObjectSwiftKotlinSpec::callAll);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -124,6 +124,7 @@ namespace margelo::nitro::image {
       virtual std::shared_ptr<Promise<int64_t>> calculateFibonacciAsync(double value) = 0;
       virtual std::shared_ptr<Promise<void>> wait(double seconds) = 0;
       virtual std::shared_ptr<Promise<void>> promiseThrows() = 0;
+      virtual std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) = 0;
       virtual void callCallback(const std::function<void()>& callback) = 0;
       virtual void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) = 0;
       virtual void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -124,7 +124,9 @@ namespace margelo::nitro::image {
       virtual std::shared_ptr<Promise<int64_t>> calculateFibonacciAsync(double value) = 0;
       virtual std::shared_ptr<Promise<void>> wait(double seconds) = 0;
       virtual std::shared_ptr<Promise<void>> promiseThrows() = 0;
-      virtual std::shared_ptr<Promise<double>> awaitPromise(const std::shared_ptr<Promise<double>>& promise) = 0;
+      virtual std::shared_ptr<Promise<double>> awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) = 0;
+      virtual std::shared_ptr<Promise<Car>> awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) = 0;
+      virtual std::shared_ptr<Promise<void>> awaitPromise(const std::shared_ptr<Promise<void>>& promise) = 0;
       virtual void callCallback(const std::function<void()>& callback) = 0;
       virtual void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) = 0;
       virtual void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) = 0;

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -88,7 +88,11 @@ interface SharedTestObjectProps {
   calculateFibonacciAsync(value: number): Promise<bigint>
   wait(seconds: number): Promise<void>
   promiseThrows(): Promise<void>
-  awaitPromise(promise: Promise<number>): Promise<number>
+
+  // Complex Promises
+  awaitAndGetPromise(promise: Promise<number>): Promise<number>
+  awaitAndGetComplexPromise(promise: Promise<Car>): Promise<Car>
+  awaitPromise(promise: Promise<void>): Promise<void>
 
   // Callbacks
   callCallback(callback: () => void): void

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -88,6 +88,7 @@ interface SharedTestObjectProps {
   calculateFibonacciAsync(value: number): Promise<bigint>
   wait(seconds: number): Promise<void>
   promiseThrows(): Promise<void>
+  awaitPromise(promise: Promise<number>): Promise<number>
 
   // Callbacks
   callCallback(callback: () => void): void
@@ -146,9 +147,6 @@ export interface TestObjectCpp
     callback: () => string,
     andThenCall: (valueFromJs: string) => void
   ): Promise<void>
-
-  // Complex Promise tests
-  awaitPromise(promise: Promise<number>): Promise<number>
 
   // Other HybridObjects
   readonly thisObject: TestObjectCpp

--- a/packages/react-native-nitro-modules/NitroModules.podspec
+++ b/packages/react-native-nitro-modules/NitroModules.podspec
@@ -43,6 +43,7 @@ Pod::Spec.new do |s|
     "ios/core/ArrayBufferHolder.hpp",
     "ios/core/AnyMapHolder.hpp",
     "ios/core/HybridContext.hpp",
+    "ios/utils/RuntimeError.hpp",
     "ios/utils/SwiftClosure.hpp",
   ]
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
@@ -23,12 +23,20 @@ public:
   using OnResolvedFunc = std::function<void(jni::alias_ref<jni::JObject>)>;
   using OnRejectedFunc = std::function<void(jni::alias_ref<jni::JString>)>;
 
-public:
+private:
   /**
    * Create a new, still unresolved `JPromise` from Java.
    */
   static jni::local_ref<JPromise::jhybriddata> initHybrid(jni::alias_ref<jhybridobject>) {
     return makeCxxInstance();
+  }
+
+public:
+  /**
+   * Create a new, still unresolved `JPromise` from C++.
+   */
+  static jni::local_ref<JPromise::javaobject> create() {
+    return newObjectCxxArgs();
   }
 
 public:

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
@@ -16,20 +16,19 @@ using namespace facebook;
 
 struct JOnResolvedCallback : public jni::JavaClass<JOnResolvedCallback> {
   static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/Promise$OnResolvedCallback;";
-    void onResolved(jni::alias_ref<jni::JObject> result) const {
-        static const auto method = javaClassLocal()->getMethod<void(jni::alias_ref<jni::JObject>)>("onResolved");
-        method(self(), result);
-    }
+  void onResolved(jni::alias_ref<jni::JObject> result) const {
+    static const auto method = javaClassLocal()->getMethod<void(jni::alias_ref<jni::JObject>)>("onResolved");
+    method(self(), result);
+  }
 };
 
 struct JOnRejectedCallback : public jni::JavaClass<JOnRejectedCallback> {
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/Promise$OnRejectedCallback;";
-    void onRejected(jni::alias_ref<jni::JString> error) const {
-        static const auto method = javaClassLocal()->getMethod<void(jni::alias_ref<jni::JString>)>("onRejected");
-        method(self(), error);
-    }
+  static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/Promise$OnRejectedCallback;";
+  void onRejected(jni::alias_ref<jni::JString> error) const {
+    static const auto method = javaClassLocal()->getMethod<void(jni::alias_ref<jni::JString>)>("onRejected");
+    method(self(), error);
+  }
 };
-
 
 /**
  * Represents a Promise implemented in Java.
@@ -70,30 +69,27 @@ public:
     }
   }
 
-    void addOnResolvedListenerJava(jni::alias_ref<JOnResolvedCallback> callback) {
-        if (_result != nullptr) {
-            // Promise is already resolved! Call the callback immediately
-            callback->onResolved(_result);
-        } else {
-            // Promise is not yet resolved, put the listener in our queue.
-            auto sharedCallback = jni::make_global(callback);
-            _onResolvedListeners.push_back([=](const jni::alias_ref<jni::JObject>& result) {
-                sharedCallback->onResolved(result);
-            });
-        }
+public:
+  void addOnResolvedListenerJava(jni::alias_ref<JOnResolvedCallback> callback) {
+    if (_result != nullptr) {
+      // Promise is already resolved! Call the callback immediately
+      callback->onResolved(_result);
+    } else {
+      // Promise is not yet resolved, put the listener in our queue.
+      auto sharedCallback = jni::make_global(callback);
+      _onResolvedListeners.push_back([=](const jni::alias_ref<jni::JObject>& result) { sharedCallback->onResolved(result); });
     }
-    void addOnRejectedListenerJava(jni::alias_ref<JOnRejectedCallback> callback) {
-        if (_error != nullptr) {
-            // Promise is already rejected! Call the callback immediately
-            callback->onRejected(_error);
-        } else {
-            // Promise is not yet rejected, put the listener in our queue.
-            auto sharedCallback = jni::make_global(callback);
-            _onRejectedListeners.push_back([=](const jni::alias_ref<jni::JString>& error) {
-                sharedCallback->onRejected(error);
-            });
-        }
+  }
+  void addOnRejectedListenerJava(jni::alias_ref<JOnRejectedCallback> callback) {
+    if (_error != nullptr) {
+      // Promise is already rejected! Call the callback immediately
+      callback->onRejected(_error);
+    } else {
+      // Promise is not yet rejected, put the listener in our queue.
+      auto sharedCallback = jni::make_global(callback);
+      _onRejectedListeners.push_back([=](const jni::alias_ref<jni::JString>& error) { sharedCallback->onRejected(error); });
     }
+  }
 
 public:
   void addOnResolvedListener(OnResolvedFunc&& onResolved) {
@@ -132,8 +128,8 @@ public:
         makeNativeMethod("initHybrid", JPromise::initHybrid),
         makeNativeMethod("nativeResolve", JPromise::resolve),
         makeNativeMethod("nativeReject", JPromise::reject),
-        makeNativeMethod("nativeAddOnResolvedListener", JPromise::addOnResolvedListenerJava),
-        makeNativeMethod("nativeAddOnRejectedListener", JPromise::addOnRejectedListenerJava),
+        makeNativeMethod("addOnResolvedListener", JPromise::addOnResolvedListenerJava),
+        makeNativeMethod("addOnRejectedListener", JPromise::addOnRejectedListenerJava),
     });
   }
 };

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
@@ -14,6 +14,23 @@ namespace margelo::nitro {
 
 using namespace facebook;
 
+struct JOnResolvedCallback : public jni::JavaClass<JOnResolvedCallback> {
+  static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/Promise$OnResolvedCallback;";
+    void onResolved(jni::alias_ref<jni::JObject> result) const {
+        static const auto method = javaClassLocal()->getMethod<void(jni::alias_ref<jni::JObject>)>("onResolved");
+        method(self(), result);
+    }
+};
+
+struct JOnRejectedCallback : public jni::JavaClass<JOnRejectedCallback> {
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/Promise$OnRejectedCallback;";
+    void onRejected(jni::alias_ref<jni::JString> error) const {
+        static const auto method = javaClassLocal()->getMethod<void(jni::alias_ref<jni::JString>)>("onRejected");
+        method(self(), error);
+    }
+};
+
+
 /**
  * Represents a Promise implemented in Java.
  */
@@ -53,6 +70,31 @@ public:
     }
   }
 
+    void addOnResolvedListenerJava(jni::alias_ref<JOnResolvedCallback> callback) {
+        if (_result != nullptr) {
+            // Promise is already resolved! Call the callback immediately
+            callback->onResolved(_result);
+        } else {
+            // Promise is not yet resolved, put the listener in our queue.
+            auto sharedCallback = jni::make_global(callback);
+            _onResolvedListeners.push_back([=](const jni::alias_ref<jni::JObject>& result) {
+                sharedCallback->onResolved(result);
+            });
+        }
+    }
+    void addOnRejectedListenerJava(jni::alias_ref<JOnRejectedCallback> callback) {
+        if (_error != nullptr) {
+            // Promise is already rejected! Call the callback immediately
+            callback->onRejected(_error);
+        } else {
+            // Promise is not yet rejected, put the listener in our queue.
+            auto sharedCallback = jni::make_global(callback);
+            _onRejectedListeners.push_back([=](const jni::alias_ref<jni::JString>& error) {
+                sharedCallback->onRejected(error);
+            });
+        }
+    }
+
 public:
   void addOnResolvedListener(OnResolvedFunc&& onResolved) {
     if (_result != nullptr) {
@@ -90,6 +132,8 @@ public:
         makeNativeMethod("initHybrid", JPromise::initHybrid),
         makeNativeMethod("nativeResolve", JPromise::resolve),
         makeNativeMethod("nativeReject", JPromise::reject),
+        makeNativeMethod("nativeAddOnResolvedListener", JPromise::addOnResolvedListenerJava),
+        makeNativeMethod("nativeAddOnRejectedListener", JPromise::addOnRejectedListenerJava),
     });
   }
 };

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
@@ -102,7 +102,7 @@ class Promise<T> {
   suspend fun await(): T {
     return suspendCoroutine { continuation ->
       addOnResolvedListener { result -> continuation.resume(result) }
-      addOnRejectedListener { error -> continuation.resumeWithException(Error(error)) }
+      addOnRejectedListener { error -> continuation.resumeWithException(error) }
     }
   }
 

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
@@ -38,7 +38,7 @@ class Promise<T> {
   fun interface OnRejectedCallback {
     @Keep
     @DoNotStrip
-    fun onRejected(error: String)
+    fun onRejected(error: Throwable)
   }
 
   @Keep
@@ -72,7 +72,7 @@ class Promise<T> {
    * Any `onRejected` listeners will be invoked.
    */
   fun reject(error: Throwable) {
-    nativeReject(error.toString())
+    nativeReject(error)
   }
 
   /**
@@ -108,7 +108,7 @@ class Promise<T> {
 
   // C++ functions
   private external fun nativeResolve(result: Any)
-  private external fun nativeReject(error: String)
+  private external fun nativeReject(error: Throwable)
   private external fun addOnResolvedListener(callback: OnResolvedCallback<T>)
   private external fun addOnRejectedListener(callback: OnRejectedCallback)
   private external fun initHybrid(): HybridData

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
@@ -23,13 +23,21 @@ import kotlin.concurrent.thread
 @Keep
 @DoNotStrip
 class Promise<T> {
+  @Keep
+  @DoNotStrip
   private val mHybridData: HybridData
 
   /**
    * Creates a new Promise with fully manual control over the `resolve(..)`/`reject(..)` functions
    */
-  init {
+  constructor() {
     mHybridData = initHybrid()
+  }
+
+  @Keep
+  @DoNotStrip
+  private constructor(hybridData: HybridData) {
+    mHybridData = hybridData
   }
 
   /**

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
@@ -25,6 +25,21 @@ import kotlin.concurrent.thread
 class Promise<T> {
   @Keep
   @DoNotStrip
+  fun interface OnResolvedCallback<T> {
+    @Keep
+    @DoNotStrip
+    fun onResolved(result: T)
+  }
+  @Keep
+  @DoNotStrip
+  fun interface OnRejectedCallback {
+    @Keep
+    @DoNotStrip
+    fun onRejected(error: String)
+  }
+
+  @Keep
+  @DoNotStrip
   private val mHybridData: HybridData
 
   /**
@@ -34,6 +49,7 @@ class Promise<T> {
     mHybridData = initHybrid()
   }
 
+  @Suppress("unused")
   @Keep
   @DoNotStrip
   private constructor(hybridData: HybridData) {
@@ -56,9 +72,19 @@ class Promise<T> {
     nativeReject(error.toString())
   }
 
+  fun addOnResolvedListener(listener: OnResolvedCallback<T>) {
+    nativeAddOnResolvedListener(listener)
+  }
+
+  fun addOnRejectedListener(listener: OnRejectedCallback) {
+    nativeAddOnRejectedListener(listener)
+  }
+
   // C++ functions
   private external fun nativeResolve(result: Any)
   private external fun nativeReject(error: String)
+  private external fun nativeAddOnResolvedListener(callback: OnResolvedCallback<T>)
+  private external fun nativeAddOnRejectedListener(callback: OnRejectedCallback)
   private external fun initHybrid(): HybridData
 
   companion object {

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -152,7 +152,7 @@ public:
       _onResolvedListeners.push_back(onResolved);
     }
   }
-  
+
   /**
    * Add a listener that will be called when the Promise gets rejected.
    * If the Promise is already rejected, the listener will be immediately called.

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -143,6 +143,15 @@ public:
       _onResolvedListeners.push_back(onResolved);
     }
   }
+  void addOnResolvedListenerCopy(const std::function<void(TResult)>& onResolved) {
+    if (std::holds_alternative<TResult>(_result)) {
+      // Promise is already resolved! Call the callback immediately
+      onResolved(std::get<TResult>(_result));
+    } else {
+      // Promise is not yet resolved, put the listener in our queue.
+      _onResolvedListeners.push_back(onResolved);
+    }
+  }
   
   /**
    * Add a listener that will be called when the Promise gets rejected.

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -143,6 +143,7 @@ public:
       _onResolvedListeners.push_back(onResolved);
     }
   }
+  
   /**
    * Add a listener that will be called when the Promise gets rejected.
    * If the Promise is already rejected, the listener will be immediately called.

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -134,6 +134,15 @@ public:
       _onResolvedListeners.push_back(std::move(onResolved));
     }
   }
+  void addOnResolvedListener(const OnResolvedFunc& onResolved) {
+    if (std::holds_alternative<TResult>(_result)) {
+      // Promise is already resolved! Call the callback immediately
+      onResolved(std::get<TResult>(_result));
+    } else {
+      // Promise is not yet resolved, put the listener in our queue.
+      _onResolvedListeners.push_back(onResolved);
+    }
+  }
   /**
    * Add a listener that will be called when the Promise gets rejected.
    * If the Promise is already rejected, the listener will be immediately called.
@@ -145,6 +154,15 @@ public:
     } else {
       // Promise is not yet rejected, put the listener in our queue.
       _onRejectedListeners.push_back(std::move(onRejected));
+    }
+  }
+  void addOnRejectedListener(const OnRejectedFunc& onRejected) {
+    if (std::holds_alternative<TError>(_result)) {
+      // Promise is already rejected! Call the callback immediately
+      onRejected(std::get<TError>(_result));
+    } else {
+      // Promise is not yet rejected, put the listener in our queue.
+      _onRejectedListeners.push_back(onRejected);
     }
   }
 
@@ -281,12 +299,27 @@ public:
       _onResolvedListeners.push_back(std::move(onResolved));
     }
   }
+  void addOnResolvedListener(const OnResolvedFunc& onResolved) {
+    if (_isResolved) {
+      onResolved();
+    } else {
+      _onResolvedListeners.push_back(onResolved);
+    }
+  }
   void addOnRejectedListener(OnRejectedFunc&& onRejected) {
     if (_error.has_value()) {
       onRejected(_error.value());
     } else {
       // Promise is not yet rejected, put the listener in our queue.
       _onRejectedListeners.push_back(std::move(onRejected));
+    }
+  }
+  void addOnRejectedListener(const OnRejectedFunc& onRejected) {
+    if (_error.has_value()) {
+      onRejected(_error.value());
+    } else {
+      // Promise is not yet rejected, put the listener in our queue.
+      _onRejectedListeners.push_back(onRejected);
     }
   }
 

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -119,9 +119,6 @@ public:
       onRejected(std::get<TError>(_result));
     }
   }
-  void reject(std::string message) {
-    reject(std::runtime_error(message));
-  }
 
 public:
   /**

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -172,7 +172,7 @@ public:
 
 public:
   /**
-   * Gets whether this Promise has been successfuly resolved with a result, or not.
+   * Gets whether this Promise has been successfully resolved with a result, or not.
    */
   [[nodiscard]]
   inline bool isResolved() const noexcept {

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -275,9 +275,6 @@ public:
       onRejected(_error.value());
     }
   }
-  void reject(std::string message) {
-    reject(std::runtime_error(message));
-  }
 
 public:
   void addOnResolvedListener(OnResolvedFunc&& onResolved) {

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
@@ -28,8 +28,15 @@ struct JSIConverter<std::shared_ptr<Promise<TResult>>> final {
   static inline std::shared_ptr<Promise<TResult>> fromJSI(jsi::Runtime& runtime, const jsi::Value& value) {
     // Create new Promise and prepare onResolved / onRejected callbacks
     auto promise = Promise<TResult>::create();
-    auto thenCallback =
-        JSIConverter<std::function<void(TResult)>>::toJSI(runtime, [=](const TResult& result) { promise->resolve(result); });
+    auto thenCallback = [&]() {
+      if constexpr (std::is_void_v<TResult>) {
+        // void: resolve()
+        return JSIConverter<std::function<void()>>::toJSI(runtime, [=]() { promise->resolve(); });
+      } else {
+        // T: resolve(T)
+        return JSIConverter<std::function<void(TResult)>>::toJSI(runtime, [=](const TResult& result) { promise->resolve(result); });
+      }
+    }();
     auto catchCallback = JSIConverter<std::function<void(std::exception)>>::toJSI(
         runtime, [=](const std::exception& exception) { promise->reject(exception); });
 

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
@@ -31,7 +31,7 @@ struct JSIConverter<std::shared_ptr<Promise<TResult>>> final {
     auto thenCallback = [&]() {
       if constexpr (std::is_void_v<TResult>) {
         // void: resolve()
-        return JSIConverter<std::function<void()>>::toJSI(runtime, [=]() { promise->resolve(); });
+        return JSIConverter<std::function<void(std::monostate)>>::toJSI(runtime, [=](std::monostate) { promise->resolve(); });
       } else {
         // T: resolve(T)
         return JSIConverter<std::function<void(TResult)>>::toJSI(runtime, [=](const TResult& result) { promise->resolve(result); });

--- a/packages/react-native-nitro-modules/ios/core/RuntimeError.swift
+++ b/packages/react-native-nitro-modules/ios/core/RuntimeError.swift
@@ -15,3 +15,13 @@ import Foundation
 public enum RuntimeError: Error {
   case error(withMessage: String)
 }
+
+public extension Error {
+  /**
+   * Converts this `Error` to a C++ `std::exception`.
+   */
+  func toCpp() -> std.exception {
+    let message = String(describing: self)
+    return margelo.nitro.make_exception(std.string(message))
+  }
+}

--- a/packages/react-native-nitro-modules/ios/core/RuntimeError.swift
+++ b/packages/react-native-nitro-modules/ios/core/RuntimeError.swift
@@ -14,6 +14,14 @@ import Foundation
  */
 public enum RuntimeError: Error {
   case error(withMessage: String)
+  
+  /**
+   * Creates a new `RuntimeError` from the given C++ `std::exception`.
+   */
+  public static func from(cppError: std.exception) -> RuntimeError {
+    let message = margelo.nitro.get_exception_message(cppError)
+    return .error(withMessage: String(message))
+  }
 }
 
 public extension Error {

--- a/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
@@ -1,0 +1,17 @@
+//
+//  RuntimeError.hpp
+//  NitroModules
+//
+//  Created by Marc Rousavy on 19.11.24.
+//
+
+#include <exception>
+#include <string>
+
+namespace margelo::nitro {
+
+std::exception make_exception(const std::string& message) {
+  return std::runtime_error(message);
+}
+
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
@@ -16,4 +16,8 @@ static inline std::exception make_exception(const std::string& message) {
   return std::runtime_error(message);
 }
 
+static inline std::string get_exception_message(const std::exception& exception) {
+  return exception.what();
+}
+
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
@@ -5,12 +5,14 @@
 //  Created by Marc Rousavy on 19.11.24.
 //
 
+#pragma once
+
 #include <exception>
 #include <string>
 
 namespace margelo::nitro {
 
-std::exception make_exception(const std::string& message) {
+static inline std::exception make_exception(const std::string& message) {
   return std::runtime_error(message);
 }
 

--- a/packages/react-native-nitro-modules/ios/utils/SwiftClosure.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/SwiftClosure.hpp
@@ -58,6 +58,10 @@ public:
   const std::function<void()>& getFunction() {
     return _function;
   }
+  
+  std::function<void()> getFunctionCopy() {
+    return _function;
+  }
 };
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/ios/utils/SwiftClosure.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/SwiftClosure.hpp
@@ -58,7 +58,7 @@ public:
   const std::function<void()>& getFunction() {
     return _function;
   }
-  
+
   std::function<void()> getFunctionCopy() {
     return _function;
   }

--- a/packages/react-native-nitro-modules/ios/utils/SwiftClosure.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/SwiftClosure.hpp
@@ -55,11 +55,11 @@ public:
   /**
    * Gets the underlying `std::function`.
    */
-  const std::function<void()>& getFunction() {
+  const std::function<void()>& getFunction() const {
     return _function;
   }
 
-  std::function<void()> getFunctionCopy() {
+  std::function<void()> getFunctionCopy() const {
     return _function;
   }
 };


### PR DESCRIPTION
Same as https://github.com/mrousavy/nitro/pull/354, but now for Swift and Kotlin!!

- Also, refactors `Promise` on Android to use `Throwable` as it's base to keep stacktrace in-tact.
- Add `.then`, `.catch` and `.await` to `Promise` on Android
- Support Promise bi-directionally with callbacks on iOS
- Adds an `ErrorType` (`std::exception`)