### PR TITLE
perf: Only enable `-O2` in release, use `-O0` in debug

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -76,6 +76,11 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
           name: 'NitroModules/JArrayBuffer.hpp',
           space: 'system',
         })
+        imports.push({
+          language: 'c++',
+          name: 'NitroModules/JUnit.hpp',
+          space: 'system',
+        })
         break
       case 'promise':
         imports.push({
@@ -99,16 +104,6 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
           name: `J${variantName}.hpp`,
           space: 'user',
         })
-        break
-      case 'promise':
-        const promise = getTypeAs(this.type, PromiseType)
-        if (promise.resultingType.kind === 'void') {
-          imports.push({
-            language: 'c++',
-            name: 'NitroModules/JUnit.hpp',
-            space: 'system',
-          })
-        }
         break
       case 'hybrid-object': {
         const hybridObjectType = getTypeAs(this.type, HybridObjectType)

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -100,6 +100,16 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
           space: 'user',
         })
         break
+      case 'promise':
+        const promise = getTypeAs(this.type, PromiseType)
+        if (promise.resultingType.kind === 'void') {
+          imports.push({
+            language: 'c++',
+            name: 'NitroModules/JUnit.hpp',
+            space: 'system',
+          })
+        }
+        break
       case 'hybrid-object': {
         const hybridObjectType = getTypeAs(this.type, HybridObjectType)
         const name = getHybridObjectName(hybridObjectType.hybridObjectName)
@@ -528,7 +538,7 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
 [&]() {
   jni::local_ref<JPromise::javaobject> __promise = JPromise::create();
   ${parameterName}->addOnResolvedListener([=]() {
-    __promise->cthis()->resolve(nullptr);
+    __promise->cthis()->resolve(JUnit::instance());
   });
   ${parameterName}->addOnRejectedListener([=](const std::exception& __error) {
     auto __jniError = jni::JCppException::create(__error);

--- a/packages/react-native-nitro-image/android/build.gradle
+++ b/packages/react-native-nitro-image/android/build.gradle
@@ -47,9 +47,18 @@ android {
 
     externalNativeBuild {
       cmake {
-        cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
+        cppFlags "-frtti -fexceptions -Wall"
         arguments "-DANDROID_STL=c++_shared"
         abiFilters (*reactNativeArchitectures())
+
+        buildTypes {
+          debug {
+            cppFlags "-O0 -fstack-protector-all"
+          }
+          release {
+            cppFlags "-O2"
+          }
+        }
       }
     }
   }
@@ -88,7 +97,7 @@ android {
 
   buildTypes {
     release {
-      minifyEnabled false
+      minifyEnabled true
     }
   }
 

--- a/packages/react-native-nitro-image/android/build.gradle
+++ b/packages/react-native-nitro-image/android/build.gradle
@@ -97,7 +97,7 @@ android {
 
   buildTypes {
     release {
-      minifyEnabled true
+      minifyEnabled false
     }
   }
 

--- a/packages/react-native-nitro-image/android/build.gradle
+++ b/packages/react-native-nitro-image/android/build.gradle
@@ -47,13 +47,13 @@ android {
 
     externalNativeBuild {
       cmake {
-        cppFlags "-frtti -fexceptions -Wall"
+        cppFlags "-frtti -fexceptions -Wall -Wextra -fstack-protector-all"
         arguments "-DANDROID_STL=c++_shared"
         abiFilters (*reactNativeArchitectures())
 
         buildTypes {
           debug {
-            cppFlags "-O0 -fstack-protector-all"
+            cppFlags "-O1 -g"
           }
           release {
             cppFlags "-O2"

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -49,6 +49,7 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include "JCar.hpp"
 #include <NitroModules/ArrayBuffer.hpp>
 #include <NitroModules/JArrayBuffer.hpp>
+#include <NitroModules/JUnit.hpp>
 #include "HybridChildSpec.hpp"
 #include "JHybridChildSpec.hpp"
 #include "HybridBaseSpec.hpp"

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -462,7 +462,7 @@ namespace margelo::nitro::image {
     auto __result = method(_javaPart, [&]() {
       jni::local_ref<JPromise::javaobject> __promise = JPromise::create();
       promise->addOnResolvedListener([=]() {
-        __promise->cthis()->resolve(nullptr);
+        __promise->cthis()->resolve(JUnit::instance());
       });
       promise->addOnRejectedListener([=](const std::exception& __error) {
         auto __jniError = jni::JCppException::create(__error);

--- a/packages/react-native-nitro-modules/android/build.gradle
+++ b/packages/react-native-nitro-modules/android/build.gradle
@@ -48,9 +48,18 @@ android {
 
     externalNativeBuild {
       cmake {
-        cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
+        cppFlags "-frtti -fexceptions -Wall"
         arguments "-DANDROID_STL=c++_shared"
         abiFilters (*reactNativeArchitectures())
+
+        buildTypes {
+          debug {
+            cppFlags "-O0 -fstack-protector-all"
+          }
+          release {
+            cppFlags "-O2"
+          }
+        }
       }
     }
   }

--- a/packages/react-native-nitro-modules/android/build.gradle
+++ b/packages/react-native-nitro-modules/android/build.gradle
@@ -105,7 +105,7 @@ android {
 
   buildTypes {
     release {
-      minifyEnabled true
+      minifyEnabled false
     }
   }
 

--- a/packages/react-native-nitro-modules/android/build.gradle
+++ b/packages/react-native-nitro-modules/android/build.gradle
@@ -48,13 +48,13 @@ android {
 
     externalNativeBuild {
       cmake {
-        cppFlags "-frtti -fexceptions -Wall"
+        cppFlags "-frtti -fexceptions -Wall -Wextra -fstack-protector-all"
         arguments "-DANDROID_STL=c++_shared"
         abiFilters (*reactNativeArchitectures())
 
         buildTypes {
           debug {
-            cppFlags "-O0 -fstack-protector-all"
+            cppFlags "-O1 -g"
           }
           release {
             cppFlags "-O2"

--- a/packages/react-native-nitro-modules/android/build.gradle
+++ b/packages/react-native-nitro-modules/android/build.gradle
@@ -105,7 +105,7 @@ android {
 
   buildTypes {
     release {
-      minifyEnabled false
+      minifyEnabled true
     }
   }
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
@@ -17,7 +17,7 @@ using namespace facebook;
 
 struct JOnResolvedCallback : public jni::JavaClass<JOnResolvedCallback> {
   static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/Promise$OnResolvedCallback;";
-  void onResolved(jni::alias_ref<jni::JObject> result) const {
+  void onResolved(const jni::alias_ref<jni::JObject>& result) const {
     static const auto method = javaClassLocal()->getMethod<void(jni::alias_ref<jni::JObject>)>("onResolved");
     method(self(), result);
   }
@@ -25,7 +25,7 @@ struct JOnResolvedCallback : public jni::JavaClass<JOnResolvedCallback> {
 
 struct JOnRejectedCallback : public jni::JavaClass<JOnRejectedCallback> {
   static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/Promise$OnRejectedCallback;";
-  void onRejected(jni::alias_ref<jni::JThrowable> error) const {
+  void onRejected(const jni::alias_ref<jni::JThrowable>& error) const {
     static const auto method = javaClassLocal()->getMethod<void(jni::alias_ref<jni::JThrowable>)>("onRejected");
     method(self(), error);
   }
@@ -103,7 +103,7 @@ private:
     } else {
       // Promise is not yet resolved, put the listener in our queue.
       auto sharedCallback = jni::make_global(callback);
-      _onResolvedListeners.push_back([=](const auto& result) { sharedCallback->onResolved(result); });
+      _onResolvedListeners.emplace_back([=](const auto& result) { sharedCallback->onResolved(result); });
     }
   }
   void addOnRejectedListenerJava(jni::alias_ref<JOnRejectedCallback> callback) {
@@ -114,7 +114,7 @@ private:
     } else {
       // Promise is not yet rejected, put the listener in our queue.
       auto sharedCallback = jni::make_global(callback);
-      _onRejectedListeners.push_back([=](const auto& error) { sharedCallback->onRejected(error); });
+      _onRejectedListeners.emplace_back([=](const auto& error) { sharedCallback->onRejected(error); });
     }
   }
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/utils/JUnit.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/utils/JUnit.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "NitroLogger.hpp"
 #include <fbjni/fbjni.h>
 
 namespace margelo::nitro {
@@ -17,15 +18,20 @@ using namespace facebook;
  * Represents a `Unit` from Kotlin.
  * This is similar to `void` for Java, but is actually an `Object`.
  */
-class JUnit final : public jni::HybridClass<JAnyMap> {
+class JUnit final {
 public:
-  static auto constexpr kJavaDescriptor = "Lkotlin/Unit;";
-
-  static jni::alias_ref<JUnit::javaobject> instance() {
-      static const auto clazz = JUnit::javaClassStatic();
-      static const auto field = clazz->getStaticField<JUnit::javaobject>("INSTANCE");
-      static const auto sharedInstance = clazz->getStaticFieldValue(field);
-      return sharedInstance;
+  /**
+   * Gets the shared instance to `Unit`. This is always a static global.
+   */
+  static jni::alias_ref<jni::JObject> instance() {
+    static jni::global_ref<jni::JObject> sharedInstance = nullptr;
+    if (sharedInstance == nullptr) {
+      jni::alias_ref<jni::JClass> clazz = jni::findClassStatic("java/lang/Object");
+      jni::JConstructor<jobject()> constructor = clazz->getConstructor<jobject()>();
+      jni::local_ref<jobject> instance = clazz->newObject(constructor);
+      sharedInstance = jni::make_global(instance);
+    }
+    return sharedInstance;
   }
 };
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/utils/JUnit.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/utils/JUnit.hpp
@@ -1,0 +1,32 @@
+//
+//  JUnit.hpp
+//  react-native-nitro
+//
+//  Created by Marc Rousavy on 19.11.24.
+//
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace margelo::nitro {
+
+using namespace facebook;
+
+/**
+ * Represents a `Unit` from Kotlin.
+ * This is similar to `void` for Java, but is actually an `Object`.
+ */
+class JUnit final : public jni::HybridClass<JAnyMap> {
+public:
+  static auto constexpr kJavaDescriptor = "Lkotlin/Unit;";
+
+  static jni::alias_ref<JUnit::javaobject> instance() {
+      static const auto clazz = JUnit::javaClassStatic();
+      static const auto field = clazz->getStaticField<JUnit::javaobject>("INSTANCE");
+      static const auto sharedInstance = clazz->getStaticFieldValue(field);
+      return sharedInstance;
+  }
+};
+
+} // namespace margelo::nitro

--- a/packages/template/android/build.gradle
+++ b/packages/template/android/build.gradle
@@ -47,9 +47,18 @@ android {
 
     externalNativeBuild {
       cmake {
-        cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
+        cppFlags "-frtti -fexceptions -Wall"
         arguments "-DANDROID_STL=c++_shared"
         abiFilters (*reactNativeArchitectures())
+
+        buildTypes {
+          debug {
+            cppFlags "-O0 -fstack-protector-all"
+          }
+          release {
+            cppFlags "-O2"
+          }
+        }
       }
     }
   }
@@ -88,7 +97,7 @@ android {
 
   buildTypes {
     release {
-      minifyEnabled false
+      minifyEnabled true
     }
   }
 

--- a/packages/template/android/build.gradle
+++ b/packages/template/android/build.gradle
@@ -97,7 +97,7 @@ android {
 
   buildTypes {
     release {
-      minifyEnabled true
+      minifyEnabled false
     }
   }
 

--- a/packages/template/android/build.gradle
+++ b/packages/template/android/build.gradle
@@ -47,13 +47,13 @@ android {
 
     externalNativeBuild {
       cmake {
-        cppFlags "-frtti -fexceptions -Wall"
+        cppFlags "-frtti -fexceptions -Wall -Wextra -fstack-protector-all"
         arguments "-DANDROID_STL=c++_shared"
         abiFilters (*reactNativeArchitectures())
 
         buildTypes {
           debug {
-            cppFlags "-O0 -fstack-protector-all"
+            cppFlags "-O1 -g"
           }
           release {
             cppFlags "-O2"


### PR DESCRIPTION
- Uses optimization flag `-O2` in release builds
- Uses optimization flag `-O0` in debug builds
- Fixes `Promise<void>` not resolving in Kotlin