### PR TITLE
fix: Generate a shadow `ordinal` field for Kotlin Enums

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinEnum.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinEnum.ts
@@ -21,7 +21,11 @@ import com.facebook.proguard.annotations.DoNotStrip
 @DoNotStrip
 @Keep
 enum class ${enumType.enumName} {
-  ${indent(members.join(',\n'), '  ')}
+  ${indent(members.join(',\n'), '  ')};
+
+  @DoNotStrip
+  @Keep
+  private val _ordinal = ordinal
 }
   `.trim()
 
@@ -58,7 +62,7 @@ namespace ${cxxNamespace} {
     [[maybe_unused]]
     ${enumType.enumName} toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("ordinal");
+      static const auto fieldOrdinal = clazz->getField<int>("_ordinal");
       int ordinal = this->getFieldValue(fieldOrdinal);
       return static_cast<${enumType.enumName}>(ordinal);
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JImageFormat.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JImageFormat.hpp
@@ -28,7 +28,7 @@ namespace margelo::nitro::image {
     [[maybe_unused]]
     ImageFormat toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("ordinal");
+      static const auto fieldOrdinal = clazz->getField<int>("_ordinal");
       int ordinal = this->getFieldValue(fieldOrdinal);
       return static_cast<ImageFormat>(ordinal);
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JOldEnum.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JOldEnum.hpp
@@ -28,7 +28,7 @@ namespace margelo::nitro::image {
     [[maybe_unused]]
     OldEnum toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("ordinal");
+      static const auto fieldOrdinal = clazz->getField<int>("_ordinal");
       int ordinal = this->getFieldValue(fieldOrdinal);
       return static_cast<OldEnum>(ordinal);
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPixelFormat.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPixelFormat.hpp
@@ -28,7 +28,7 @@ namespace margelo::nitro::image {
     [[maybe_unused]]
     PixelFormat toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("ordinal");
+      static const auto fieldOrdinal = clazz->getField<int>("_ordinal");
       int ordinal = this->getFieldValue(fieldOrdinal);
       return static_cast<PixelFormat>(ordinal);
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPowertrain.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPowertrain.hpp
@@ -28,7 +28,7 @@ namespace margelo::nitro::image {
     [[maybe_unused]]
     Powertrain toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("ordinal");
+      static const auto fieldOrdinal = clazz->getField<int>("_ordinal");
       int ordinal = this->getFieldValue(fieldOrdinal);
       return static_cast<Powertrain>(ordinal);
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/ImageFormat.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/ImageFormat.kt
@@ -17,5 +17,9 @@ import com.facebook.proguard.annotations.DoNotStrip
 @Keep
 enum class ImageFormat {
   JPG,
-  PNG
+  PNG;
+
+  @DoNotStrip
+  @Keep
+  private val _ordinal = ordinal
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/OldEnum.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/OldEnum.kt
@@ -18,5 +18,9 @@ import com.facebook.proguard.annotations.DoNotStrip
 enum class OldEnum {
   FIRST,
   SECOND,
-  THIRD
+  THIRD;
+
+  @DoNotStrip
+  @Keep
+  private val _ordinal = ordinal
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/PixelFormat.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/PixelFormat.kt
@@ -18,5 +18,9 @@ import com.facebook.proguard.annotations.DoNotStrip
 enum class PixelFormat {
   RGB,
   YUV_8BIT,
-  YUV_10BIT
+  YUV_10BIT;
+
+  @DoNotStrip
+  @Keep
+  private val _ordinal = ordinal
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Powertrain.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Powertrain.kt
@@ -18,5 +18,9 @@ import com.facebook.proguard.annotations.DoNotStrip
 enum class Powertrain {
   ELECTRIC,
   GAS,
-  HYBRID
+  HYBRID;
+
+  @DoNotStrip
+  @Keep
+  private val _ordinal = ordinal
 }


### PR DESCRIPTION
Generates an added `_ordinal` field for every Kotlin Enum that can be accessed through fbjni.

Previously, we accessed [`ordinal`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-enum/ordinal.html), which should've been available in every Kotlin enum, but apparently some people had issues with this (@Szymon20000 & @shovel-kun) - maybe it got compiled out? Maybe it was an older Kotlin version? Maybe it got replaced with a `ordinal()` method for some reason? I don't know. **I couldn't reproduce this bug.**

Anyways; the smartest solution I can find that didn't degrade performance (calling `ordinal()` method thru JNI is slower than accessing a field) is that we just create a shadow-property on the Kotlin enum called `_ordinal` which mirrors whatever state the parent `ordinal` **value or method** has.

This can then be accessed directly from JNI as a field.