### PR TITLE
docs: :memo: add explicitly call to HybridObject constructor

### DIFF
--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -234,6 +234,8 @@ To implement `Math` now, you just need to implement the spec:
         ```cpp title="HybridMath.hpp"
         class HybridMath: public HybridMathSpec {
         public:
+          HybridMath(): HybridObject(TAG) {}
+        public:
           double add(double a, double b) override;
         };
         ```


### PR DESCRIPTION
Hi, it seems like that [from version 0.6.0](https://github.com/mrousavy/nitro/issues/93) it's required to call `HybridObject` constructor since it's virtual, this PR add this suggestions inside the docs.

Maybe would be also helpful to specify it somewhere in the doc so we can avoid this error at runtime, if someone have any suggestion I can it ofc:

```
Cannot default-construct HybridObject!
```