### PR TITLE
fix: Fix Promise rejections not having a message by using `std::exception_ptr` to avoid C++ object slicing

### DIFF
--- a/example/src/Testers.ts
+++ b/example/src/Testers.ts
@@ -21,13 +21,19 @@ export class State<T> {
     throw new Error(reason)
   }
 
-  didThrow(): State<T> {
+  didThrow(message?: string): State<T> {
     if (this.errorThrown == null) {
       this.onFailed(
         `Expected test to throw an error, but no error was thrown! Instead it returned a result: ${stringify(this.result)}`
       )
     } else {
-      this.onPassed()
+      if (message == null || stringify(this.errorThrown) === message) {
+        this.onPassed()
+      } else {
+        this.onFailed(
+          `Expected test to throw "${message}", but it threw a different error: "${stringify(this.errorThrown)}"`
+        )
+      }
     }
     return this
   }

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -424,7 +424,9 @@ export function getTests(
 
     // Test errors
     createTest('funcThatThrows()', () =>
-      it(() => testObject.funcThatThrows()).didThrow()
+      it(() => testObject.funcThatThrows()).didThrow(
+        `Error: ${testObject.name}.funcThatThrows(...): This function will only work after sacrificing seven lambs!`
+      )
     ),
 
     // Optional parameters
@@ -449,13 +451,17 @@ export function getTests(
           // @ts-expect-error
           'too many args!'
         )
-      ).didThrow()
+      ).didThrow(
+        `Error: \`${testObject.name}.tryOptionalParams(...)\` expected between 2 and 3 arguments, but received 4!`
+      )
     ),
     createTest('tryOptionalParams(...) one-too-few', () =>
       it(() =>
         // @ts-expect-error
         testObject.tryOptionalParams(13)
-      ).didThrow()
+      ).didThrow(
+        `Error: \`${testObject.name}.tryOptionalParams(...)\` expected between 2 and 3 arguments, but received 1!`
+      )
     ),
     createTest('tryMiddleParam(...)', () =>
       it(() => testObject.tryMiddleParam(13, undefined, 'hello!'))
@@ -502,7 +508,9 @@ export function getTests(
         () =>
           // @ts-expect-error
           (testObject.someVariant = false)
-      ).didThrow()
+      ).didThrow(
+        `Error: ${testObject.name}.someVariant: Cannot convert "false" to any type in variant<std::string, double>!`
+      )
     ),
 
     // More complex variants...
@@ -544,7 +552,9 @@ export function getTests(
           ),
           createTest('getVariantEnum(...) throws at wrong type (string)', () =>
             // @ts-expect-error
-            it(() => testObject.getVariantEnum('string')).didThrow()
+            it(() => testObject.getVariantEnum('string')).didThrow(
+              `Error: ${testObject.name}.getVariantEnum(...): Cannot convert "string" to any type in variant<bool, margelo::nitro::image::OldEnum>!`
+            )
           ),
           createTest('getVariantObjects(...) converts Person', () =>
             it(() => testObject.getVariantObjects(TEST_PERSON))
@@ -567,7 +577,9 @@ export function getTests(
             'getVariantObjects(...) throws at wrong type (string)',
             () =>
               // @ts-expect-error
-              it(() => testObject.getVariantObjects('some-string')).didThrow()
+              it(() => testObject.getVariantObjects('some-string')).didThrow(
+                `Error: ${testObject.name}.getVariantObjects(...): Cannot convert "some-string" to any type in variant<margelo::nitro::image::Car, margelo::nitro::image::Person>!`
+              )
           ),
           createTest(
             'getVariantObjects(...) throws at wrong type (wrong object)',
@@ -575,7 +587,9 @@ export function getTests(
               it(() =>
                 // @ts-expect-error
                 testObject.getVariantObjects({ someValue: 55 })
-              ).didThrow()
+              ).didThrow(
+                `Error: ${testObject.name}.getVariantObjects(...): Cannot convert "[object Object]" to any type in variant<margelo::nitro::image::Car, margelo::nitro::image::Person>!`
+              )
           ),
           createTest('getVariantHybrid(...) converts Hybrid', () =>
             it(() => testObject.getVariantHybrid(testObject))
@@ -592,7 +606,9 @@ export function getTests(
             'getVariantHybrid(...) throws at wrong type (string)',
             () =>
               // @ts-expect-error
-              it(() => testObject.getVariantHybrid('some-string')).didThrow()
+              it(() => testObject.getVariantHybrid('some-string')).didThrow(
+                `Error: ${testObject.name}.getVariantHybrid(...): Cannot convert "some-string" to any type in variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, margelo::nitro::image::Person>!`
+              )
           ),
           createTest(
             'getVariantHybrid(...) throws at wrong type (wrong object)',
@@ -600,7 +616,9 @@ export function getTests(
               it(() =>
                 // @ts-expect-error
                 testObject.getVariantHybrid({ someValue: 55 })
-              ).didThrow()
+              ).didThrow(
+                `Error: ${testObject.name}.getVariantHybrid(...): Cannot convert "[object Object]" to any type in variant<std::shared_ptr<margelo::nitro::image::HybridTestObjectCppSpec>, margelo::nitro::image::Person>!`
+              )
           ),
           createTest('getVariantTuple(...) converts Float2', () =>
             it(() => testObject.getVariantTuple([10, 20]))
@@ -660,7 +678,9 @@ export function getTests(
                 // @ts-expect-error
                 [10, 20]
               )
-            ).didThrow()
+            ).didThrow(
+              `Error: ${testObject.name}.flip(...): The given JS Array has 2 items, but std::tuple<double, double, double> expects 3 items.`
+            )
           ),
           createTest('passTuple(...)', () =>
             it(() => testObject.passTuple([13, 'hello', true]))
@@ -687,7 +707,9 @@ export function getTests(
         .equals(55n)
     ),
     createTest('promiseThrows() throws', async () =>
-      (await it(() => testObject.promiseThrows())).didThrow()
+      (await it(() => testObject.promiseThrows())).didThrow(
+        'Error: Promise throws :)'
+      )
     ),
     createTest('twoPromises can run in parallel', async () =>
       (
@@ -1073,6 +1095,7 @@ export function getTests(
           // @ts-expect-error
           testObject.bounceChild(child)
         } else {
+          // This only throws in __DEV__ - in release it is optimized away and would crash. :)
           throw new Error(
             `This only throws in __DEV__ - in release it is optimized away and would crash. :)`
           )

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -535,8 +535,8 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
   ${parameterName}->addOnResolvedListener([=]() {
     __promise->cthis()->resolve(JUnit::instance());
   });
-  ${parameterName}->addOnRejectedListener([=](const std::exception& __error) {
-    auto __jniError = jni::JCppException::create(__error);
+  ${parameterName}->addOnRejectedListener([=](const std::exception_ptr& __error) {
+    auto __jniError = jni::getJavaExceptionForCppException(__error);
     __promise->cthis()->reject(__jniError);
   });
   return __promise;
@@ -550,8 +550,8 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
   ${parameterName}->addOnResolvedListener([=](const ${resolvingType}& __result) {
     __promise->cthis()->resolve(${indent(bridge.parseFromCppToKotlin('__result', 'c++', true), '    ')});
   });
-  ${parameterName}->addOnRejectedListener([=](const std::exception& __error) {
-    auto __jniError = jni::JCppException::create(__error);
+  ${parameterName}->addOnRejectedListener([=](const std::exception_ptr& __error) {
+    auto __jniError = jni::getJavaExceptionForCppException(__error);
     __promise->cthis()->reject(__jniError);
   });
   return __promise;

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -342,7 +342,7 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
 { () -> ${promise.getCode('swift')} in
   let __promise = ${promise.getCode('swift')}()
   let __resolver = SwiftClosure { __promise.resolve(withResult: ()) }
-  let __rejecter = { (__error: std.exception) in
+  let __rejecter = { (__error: std.exception_ptr) in
     __promise.reject(withError: RuntimeError.from(cppError: __error))
   }
   let __resolverCpp = __resolver.getFunctionCopy()
@@ -371,7 +371,7 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
   let __resolver = { (__result: ${resolvingTypeBridge.getTypeCode('swift')}) in
     __promise.resolve(withResult: ${indent(resolvingTypeBridge.parseFromCppToSwift('__result', 'swift'), '    ')})
   }
-  let __rejecter = { (__error: std.exception) in
+  let __rejecter = { (__error: std.exception_ptr) in
     __promise.reject(withError: RuntimeError.from(cppError: __error))
   }
   let __resolverCpp = ${indent(resolverFuncBridge.parseFromSwiftToCpp('__resolver', 'swift'), '  ')}

--- a/packages/nitrogen/src/syntax/types/ErrorType.ts
+++ b/packages/nitrogen/src/syntax/types/ErrorType.ts
@@ -16,9 +16,9 @@ export class ErrorType implements Type {
   getCode(language: Language): string {
     switch (language) {
       case 'c++':
-        return `std::exception`
+        return `std::exception_ptr`
       case 'swift':
-        return `std.exception`
+        return `std.exception_ptr`
       case 'kotlin':
         return `Throwable`
       default:

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -279,21 +279,21 @@ std::shared_ptr<Promise<double>> HybridTestObjectCpp::getValueFromJSCallbackAndW
 std::shared_ptr<Promise<double>> HybridTestObjectCpp::awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) {
   auto newPromise = Promise<double>::create();
   promise->addOnResolvedListener([=](double result) { newPromise->resolve(result); });
-  promise->addOnRejectedListener([=](const std::exception& error) { newPromise->reject(error); });
+  promise->addOnRejectedListener([=](const std::exception_ptr& error) { newPromise->reject(error); });
   return newPromise;
 }
 
 std::shared_ptr<Promise<Car>> HybridTestObjectCpp::awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) {
   auto newPromise = Promise<Car>::create();
   promise->addOnResolvedListener([=](const Car& result) { newPromise->resolve(result); });
-  promise->addOnRejectedListener([=](const std::exception& error) { newPromise->reject(error); });
+  promise->addOnRejectedListener([=](const std::exception_ptr& error) { newPromise->reject(error); });
   return newPromise;
 }
 
 std::shared_ptr<Promise<void>> HybridTestObjectCpp::awaitPromise(const std::shared_ptr<Promise<void>>& promise) {
   auto newPromise = Promise<void>::create();
   promise->addOnResolvedListener([=]() { newPromise->resolve(); });
-  promise->addOnRejectedListener([=](const std::exception& error) { newPromise->reject(error); });
+  promise->addOnRejectedListener([=](const std::exception_ptr& error) { newPromise->reject(error); });
   return newPromise;
 }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -413,8 +413,8 @@ namespace margelo::nitro::image {
       promise->addOnResolvedListener([=](const double& __result) {
         __promise->cthis()->resolve(jni::JDouble::valueOf(__result));
       });
-      promise->addOnRejectedListener([=](const std::exception& __error) {
-        auto __jniError = jni::JCppException::create(__error);
+      promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
+        auto __jniError = jni::getJavaExceptionForCppException(__error);
         __promise->cthis()->reject(__jniError);
       });
       return __promise;
@@ -439,8 +439,8 @@ namespace margelo::nitro::image {
       promise->addOnResolvedListener([=](const Car& __result) {
         __promise->cthis()->resolve(JCar::fromCpp(__result));
       });
-      promise->addOnRejectedListener([=](const std::exception& __error) {
-        auto __jniError = jni::JCppException::create(__error);
+      promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
+        auto __jniError = jni::getJavaExceptionForCppException(__error);
         __promise->cthis()->reject(__jniError);
       });
       return __promise;
@@ -465,8 +465,8 @@ namespace margelo::nitro::image {
       promise->addOnResolvedListener([=]() {
         __promise->cthis()->resolve(JUnit::instance());
       });
-      promise->addOnRejectedListener([=](const std::exception& __error) {
-        auto __jniError = jni::JCppException::create(__error);
+      promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
+        auto __jniError = jni::getJavaExceptionForCppException(__error);
         __promise->cthis()->reject(__jniError);
       });
       return __promise;

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -314,32 +314,32 @@ namespace margelo::nitro::image::bridge::swift {
     return std::make_shared<Func_void_int64_t_Wrapper>(value);
   }
   
-  // pragma MARK: std::function<void(const std::exception& /* error */)>
+  // pragma MARK: std::function<void(const std::exception_ptr& /* error */)>
   /**
-   * Specialized version of `std::function<void(const std::exception&)>`.
+   * Specialized version of `std::function<void(const std::exception_ptr&)>`.
    */
-  using Func_void_std__exception = std::function<void(const std::exception& /* error */)>;
+  using Func_void_std__exception_ptr = std::function<void(const std::exception_ptr& /* error */)>;
   /**
-   * Wrapper class for a `std::function<void(const std::exception& / * error * /)>`, this can be used from Swift.
+   * Wrapper class for a `std::function<void(const std::exception_ptr& / * error * /)>`, this can be used from Swift.
    */
-  class Func_void_std__exception_Wrapper final {
+  class Func_void_std__exception_ptr_Wrapper final {
   public:
-    explicit Func_void_std__exception_Wrapper(const std::function<void(const std::exception& /* error */)>& func): _function(func) {}
-    explicit Func_void_std__exception_Wrapper(std::function<void(const std::exception& /* error */)>&& func): _function(std::move(func)) {}
-    inline void call(std::exception error) const {
+    explicit Func_void_std__exception_ptr_Wrapper(const std::function<void(const std::exception_ptr& /* error */)>& func): _function(func) {}
+    explicit Func_void_std__exception_ptr_Wrapper(std::function<void(const std::exception_ptr& /* error */)>&& func): _function(std::move(func)) {}
+    inline void call(std::exception_ptr error) const {
       _function(error);
     }
   private:
-    std::function<void(const std::exception& /* error */)> _function;
+    std::function<void(const std::exception_ptr& /* error */)> _function;
   };
-  inline Func_void_std__exception create_Func_void_std__exception(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::exception), void(* _Nonnull destroy)(void* _Nonnull)) {
+  inline Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::exception_ptr), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
-    return Func_void_std__exception([sharedClosureHolder, call](const std::exception& error) -> void {
+    return Func_void_std__exception_ptr([sharedClosureHolder, call](const std::exception_ptr& error) -> void {
       call(sharedClosureHolder.get(), error);
     });
   }
-  inline std::shared_ptr<Func_void_std__exception_Wrapper> share_Func_void_std__exception(const Func_void_std__exception& value) {
-    return std::make_shared<Func_void_std__exception_Wrapper>(value);
+  inline std::shared_ptr<Func_void_std__exception_ptr_Wrapper> share_Func_void_std__exception_ptr(const Func_void_std__exception_ptr& value) {
+    return std::make_shared<Func_void_std__exception_ptr_Wrapper>(value);
   }
   
   // pragma MARK: std::shared_ptr<Promise<void>>

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -640,7 +640,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         let __resolver = { (__result: Double) in
           __promise.resolve(withResult: __result)
         }
-        let __rejecter = { (__error: std.exception) in
+        let __rejecter = { (__error: std.exception_ptr) in
           __promise.reject(withError: RuntimeError.from(cppError: __error))
         }
         let __resolverCpp = { () -> bridge.Func_void_double in
@@ -665,19 +665,19 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         
           return bridge.create_Func_void_double(__closureHolder, __callClosure, __destroyClosure)
         }()
-        let __rejecterCpp = { () -> bridge.Func_void_std__exception in
+        let __rejecterCpp = { () -> bridge.Func_void_std__exception_ptr in
           class ClosureHolder {
-            let closure: ((_ error: std.exception) -> Void)
-            init(wrappingClosure closure: @escaping ((_ error: std.exception) -> Void)) {
+            let closure: ((_ error: std.exception_ptr) -> Void)
+            init(wrappingClosure closure: @escaping ((_ error: std.exception_ptr) -> Void)) {
               self.closure = closure
             }
-            func invoke(_ __error: std.exception) {
+            func invoke(_ __error: std.exception_ptr) {
               self.closure(__error)
             }
           }
         
           let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: __rejecter)).toOpaque()
-          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __error: std.exception) -> Void {
+          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __error: std.exception_ptr) -> Void {
             let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
             closure.invoke(__error)
           }
@@ -685,7 +685,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
             Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
           }
         
-          return bridge.create_Func_void_std__exception(__closureHolder, __callClosure, __destroyClosure)
+          return bridge.create_Func_void_std__exception_ptr(__closureHolder, __callClosure, __destroyClosure)
         }()
         promise.pointee.addOnResolvedListenerCopy(__resolverCpp)
         promise.pointee.addOnRejectedListener(__rejecterCpp)
@@ -712,7 +712,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         let __resolver = { (__result: Car) in
           __promise.resolve(withResult: __result)
         }
-        let __rejecter = { (__error: std.exception) in
+        let __rejecter = { (__error: std.exception_ptr) in
           __promise.reject(withError: RuntimeError.from(cppError: __error))
         }
         let __resolverCpp = { () -> bridge.Func_void_Car in
@@ -737,19 +737,19 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         
           return bridge.create_Func_void_Car(__closureHolder, __callClosure, __destroyClosure)
         }()
-        let __rejecterCpp = { () -> bridge.Func_void_std__exception in
+        let __rejecterCpp = { () -> bridge.Func_void_std__exception_ptr in
           class ClosureHolder {
-            let closure: ((_ error: std.exception) -> Void)
-            init(wrappingClosure closure: @escaping ((_ error: std.exception) -> Void)) {
+            let closure: ((_ error: std.exception_ptr) -> Void)
+            init(wrappingClosure closure: @escaping ((_ error: std.exception_ptr) -> Void)) {
               self.closure = closure
             }
-            func invoke(_ __error: std.exception) {
+            func invoke(_ __error: std.exception_ptr) {
               self.closure(__error)
             }
           }
         
           let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: __rejecter)).toOpaque()
-          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __error: std.exception) -> Void {
+          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __error: std.exception_ptr) -> Void {
             let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
             closure.invoke(__error)
           }
@@ -757,7 +757,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
             Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
           }
         
-          return bridge.create_Func_void_std__exception(__closureHolder, __callClosure, __destroyClosure)
+          return bridge.create_Func_void_std__exception_ptr(__closureHolder, __callClosure, __destroyClosure)
         }()
         promise.pointee.addOnResolvedListener(__resolverCpp)
         promise.pointee.addOnRejectedListener(__rejecterCpp)
@@ -782,23 +782,23 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
       let __result = try self.__implementation.awaitPromise(promise: { () -> Promise<Void> in
         let __promise = Promise<Void>()
         let __resolver = SwiftClosure { __promise.resolve(withResult: ()) }
-        let __rejecter = { (__error: std.exception) in
+        let __rejecter = { (__error: std.exception_ptr) in
           __promise.reject(withError: RuntimeError.from(cppError: __error))
         }
         let __resolverCpp = __resolver.getFunctionCopy()
-        let __rejecterCpp = { () -> bridge.Func_void_std__exception in
+        let __rejecterCpp = { () -> bridge.Func_void_std__exception_ptr in
           class ClosureHolder {
-            let closure: ((_ error: std.exception) -> Void)
-            init(wrappingClosure closure: @escaping ((_ error: std.exception) -> Void)) {
+            let closure: ((_ error: std.exception_ptr) -> Void)
+            init(wrappingClosure closure: @escaping ((_ error: std.exception_ptr) -> Void)) {
               self.closure = closure
             }
-            func invoke(_ __error: std.exception) {
+            func invoke(_ __error: std.exception_ptr) {
               self.closure(__error)
             }
           }
         
           let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: __rejecter)).toOpaque()
-          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __error: std.exception) -> Void {
+          func __callClosure(__closureHolder: UnsafeMutableRawPointer, __error: std.exception_ptr) -> Void {
             let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
             closure.invoke(__error)
           }
@@ -806,7 +806,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
             Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
           }
         
-          return bridge.create_Func_void_std__exception(__closureHolder, __callClosure, __destroyClosure)
+          return bridge.create_Func_void_std__exception_ptr(__closureHolder, __callClosure, __destroyClosure)
         }()
         promise.pointee.addOnResolvedListener(__resolverCpp)
         promise.pointee.addOnRejectedListener(__rejecterCpp)

--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -103,7 +103,7 @@ public:
         // 3. Actually call the method with JSI values as arguments and return a JSI value again.
         //    Internally, this method converts the JSI values to C++ values using `JSIConverter<T>`.
         return callMethod(hybridInstance.get(), method, runtime, args, count, std::index_sequence_for<Args...>{});
-      } catch (const std::exception_ptr& exception) {
+      } catch (const std::exception& exception) {
         // Some exception was thrown - add method name information and re-throw as `JSError`.
         std::string funcName = getHybridFuncFullName<THybrid>(kind, name, hybridInstance.get());
         std::string message = exception.what();

--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -103,7 +103,7 @@ public:
         // 3. Actually call the method with JSI values as arguments and return a JSI value again.
         //    Internally, this method converts the JSI values to C++ values using `JSIConverter<T>`.
         return callMethod(hybridInstance.get(), method, runtime, args, count, std::index_sequence_for<Args...>{});
-      } catch (const std::exception& exception) {
+      } catch (const std::exception_ptr& exception) {
         // Some exception was thrown - add method name information and re-throw as `JSError`.
         std::string funcName = getHybridFuncFullName<THybrid>(kind, name, hybridInstance.get());
         std::string message = exception.what();

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -83,9 +83,9 @@ public:
   /**
    * Creates an immediately rejected Promise.
    */
-  static std::shared_ptr<Promise> rejected(TError&& error) {
+  static std::shared_ptr<Promise> rejected(const std::exception_ptr& error) {
     auto promise = create();
-    promise->reject(std::move(error));
+    promise->reject(error);
     return promise;
   }
 
@@ -121,7 +121,7 @@ public:
 #ifdef NITRO_DEBUG
     assertPromiseState(*this, PromiseTask::WANTS_TO_REJECT);
 #endif
-    _result = std::make_exception_ptr(exception));
+    _result = std::make_exception_ptr(exception);
     for (const auto& onRejected : _onRejectedListeners) {
       onRejected(std::get<std::exception_ptr>(_result));
     }

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
@@ -28,7 +28,7 @@ struct JSIConverter<std::exception> final {
     std::string message = object.getProperty(runtime, "message").asString(runtime).utf8(runtime);
     return std::runtime_error(name + ": " + message);
   }
-  static inline jsi::Value toJSI(jsi::Runtime& runtime, const std::exception& exception) {
+  static inline jsi::Value toJSI(jsi::Runtime& runtime, const std::exception_ptr& exception) {
     jsi::JSError error(runtime, exception.what());
     return jsi::Value(runtime, error.value());
   }

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
@@ -12,6 +12,7 @@ struct JSIConverter;
 
 #include "JSIConverter.hpp"
 
+#include "TypeInfo.hpp"
 #include <exception>
 #include <jsi/jsi.h>
 

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
@@ -37,7 +37,7 @@ struct JSIConverter<std::shared_ptr<Promise<TResult>>> final {
         return JSIConverter<std::function<void(TResult)>>::toJSI(runtime, [=](const TResult& result) { promise->resolve(result); });
       }
     }();
-    auto catchCallback = JSIConverter<std::function<void(std::exception)>>::toJSI(
+    auto catchCallback = JSIConverter<std::function<void(std::exception_ptr)>>::toJSI(
         runtime, [=](const std::exception_ptr& exception) { promise->reject(exception); });
 
     // Chain .then listeners on JS Promise (onResolved and onRejected)

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
@@ -89,7 +89,7 @@ struct JSIConverter<std::shared_ptr<Promise<TResult>>> final {
       // Promise is already rejected - just return immediately
       jsi::Object promiseObject = runtime.global().getPropertyAsObject(runtime, "Promise");
       jsi::Function createRejectedPromise = promiseObject.getPropertyAsFunction(runtime, "reject");
-      jsi::Value error = JSIConverter<std::exception>::toJSI(runtime, promise->getError());
+      jsi::Value error = JSIConverter<std::exception_ptr>::toJSI(runtime, promise->getError());
       return createRejectedPromise.call(runtime, std::move(error));
     } else {
       throw std::runtime_error("Promise has invalid state!");

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
@@ -65,7 +65,7 @@ struct JSIConverter<std::shared_ptr<Promise<TResult>>> final {
           promise->addOnResolvedListener(std::move(resolver));
         }
         // Add rejecter listener
-        auto rejecter = JSIConverter<std::function<void(std::exception)>>::fromJSI(runtime, arguments[1]);
+        auto rejecter = JSIConverter<std::function<void(std::exception_ptr)>>::fromJSI(runtime, arguments[1]);
         promise->addOnRejectedListener(std::move(rejecter));
 
         return jsi::Value::undefined();

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
@@ -38,7 +38,7 @@ struct JSIConverter<std::shared_ptr<Promise<TResult>>> final {
       }
     }();
     auto catchCallback = JSIConverter<std::function<void(std::exception)>>::toJSI(
-        runtime, [=](const std::exception& exception) { promise->reject(exception); });
+        runtime, [=](const std::exception_ptr& exception) { promise->reject(exception); });
 
     // Chain .then listeners on JS Promise (onResolved and onRejected)
     jsi::Object jsPromise = value.asObject(runtime);

--- a/packages/react-native-nitro-modules/cpp/platform/ThreadUtils.hpp
+++ b/packages/react-native-nitro-modules/cpp/platform/ThreadUtils.hpp
@@ -5,6 +5,8 @@
 //  Created by Marc Rousavy on 14.07.24.
 //
 
+#pragma once
+
 #include <string>
 
 namespace margelo::nitro {

--- a/packages/react-native-nitro-modules/cpp/templates/IsSharedPtrTo.hpp
+++ b/packages/react-native-nitro-modules/cpp/templates/IsSharedPtrTo.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <jsi/jsi.h>
 #include <type_traits>
 
 namespace margelo::nitro {

--- a/packages/react-native-nitro-modules/cpp/utils/AssertPromiseState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/AssertPromiseState.hpp
@@ -21,8 +21,8 @@ namespace margelo::nitro {
 
 enum PromiseTask { WANTS_TO_RESOLVE, WANTS_TO_REJECT };
 
-template <typename TResult, typename TError>
-void assertPromiseState(Promise<TResult, TError>& promise, PromiseTask task) {
+template <typename TResult>
+void assertPromiseState(Promise<TResult>& promise, PromiseTask task) {
   if (!promise.isPending()) [[unlikely]] {
     std::string taskString = task == WANTS_TO_RESOLVE ? "resolve" : "reject";
     std::string state = promise.isResolved() ? "resolved" : "rejected";

--- a/packages/react-native-nitro-modules/cpp/utils/AssertPromiseState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/AssertPromiseState.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 namespace margelo::nitro {
-template <typename TResult, typename TError>
+template <typename TResult>
 class Promise;
 } // namespace margelo::nitro
 

--- a/packages/react-native-nitro-modules/cpp/utils/TypeInfo.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/TypeInfo.hpp
@@ -27,7 +27,7 @@ public:
   /**
    * Get the name of the currently thrown exception
    */
-  static inline const char* getCurrentExceptionName() {
+  static inline std::string getCurrentExceptionName() {
 #if __has_include(<cxxabi.h>)
     std::string name = __cxxabiv1::__cxa_current_exception_type()->name();
     return demangleName(name);

--- a/packages/react-native-nitro-modules/cpp/utils/TypeInfo.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/TypeInfo.hpp
@@ -29,7 +29,8 @@ public:
    */
   static inline const char* getCurrentExceptionName() {
 #if __has_include(<cxxabi.h>)
-    return __cxxabiv1::__cxa_current_exception_type()->name();
+    std::string name = __cxxabiv1::__cxa_current_exception_type()->name();
+    return demangleName(name);
 #else
     return "<unknown>";
 #endif

--- a/packages/react-native-nitro-modules/cpp/utils/TypeInfo.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/TypeInfo.hpp
@@ -24,18 +24,6 @@ struct TypeInfo final {
 public:
   TypeInfo() = delete;
 
-  /**
-   * Get the name of the currently thrown exception
-   */
-  static inline std::string getCurrentExceptionName() {
-#if __has_include(<cxxabi.h>)
-    std::string name = __cxxabiv1::__cxa_current_exception_type()->name();
-    return demangleName(name);
-#else
-    return "<unknown>";
-#endif
-  }
-
   static inline std::string replaceRegex(const std::string& original, const std::string& pattern, const std::string& replacement) {
     std::regex re(pattern);
     return std::regex_replace(original, re, replacement);
@@ -112,6 +100,18 @@ public:
     ((stream << TypeInfo::getFriendlyTypename<Types>(removeNamespace) << ", "), ...);
     std::string string = stream.str();
     return string.substr(0, string.length() - 2);
+  }
+
+  /**
+   * Get the name of the currently thrown exception
+   */
+  static inline std::string getCurrentExceptionName() {
+#if __has_include(<cxxabi.h>)
+    std::string name = __cxxabiv1::__cxa_current_exception_type()->name();
+    return demangleName(name);
+#else
+    return "<unknown>";
+#endif
   }
 };
 

--- a/packages/react-native-nitro-modules/ios/core/RuntimeError.swift
+++ b/packages/react-native-nitro-modules/ios/core/RuntimeError.swift
@@ -14,11 +14,11 @@ import Foundation
  */
 public enum RuntimeError: Error {
   case error(withMessage: String)
-  
+
   /**
    * Creates a new `RuntimeError` from the given C++ `std::exception`.
    */
-  public static func from(cppError: std.exception) -> RuntimeError {
+  public static func from(cppError: std.exception_ptr) -> RuntimeError {
     let message = margelo.nitro.get_exception_message(cppError)
     return .error(withMessage: String(message))
   }
@@ -28,7 +28,7 @@ public extension Error {
   /**
    * Converts this `Error` to a C++ `std::exception`.
    */
-  func toCpp() -> std.exception {
+  func toCpp() -> std.exception_ptr {
     let message = String(describing: self)
     return margelo.nitro.make_exception(std.string(message))
   }

--- a/packages/react-native-nitro-modules/ios/core/RuntimeError.swift
+++ b/packages/react-native-nitro-modules/ios/core/RuntimeError.swift
@@ -12,8 +12,15 @@ import Foundation
  *
  * Throw this error in Nitro Modules to provide clear and concise error messages to JS.
  */
-public enum RuntimeError: Error {
+@frozen
+public enum RuntimeError: Error, CustomStringConvertible {
   case error(withMessage: String)
+
+  public var description: String {
+    switch self {
+      case .error(let message): return message
+    }
+  }
 
   /**
    * Creates a new `RuntimeError` from the given C++ `std::exception`.

--- a/packages/react-native-nitro-modules/ios/turbomodule/NativeNitroModules+OldArch.mm
+++ b/packages/react-native-nitro-modules/ios/turbomodule/NativeNitroModules+OldArch.mm
@@ -57,7 +57,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     // 5. Install Nitro
     nitro::install(*runtime, dispatcher);
     return nil;
-  } catch (std::exception& error) {
+  } catch (const std::exception& error) {
     // ?. Any C++ error occurred (probably in nitro::install()?)
     return [NSString stringWithCString:error.what() encoding:kCFStringEncodingUTF8];
   } catch (...) {

--- a/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
@@ -12,12 +12,19 @@
 
 namespace margelo::nitro {
 
-static inline std::exception make_exception(const std::string& message) {
-  return std::runtime_error(message);
+static inline std::exception_ptr make_exception(const std::string& message) {
+  return std::make_exception_ptr(std::runtime_error(message));
 }
 
-static inline std::string get_exception_message(const std::exception& exception) {
-  return exception.what();
+static inline std::string get_exception_message(const std::exception_ptr& exception) {
+  try {
+    std::rethrow_exception(exception);
+  } catch (const std::exception& error) {
+    return error.what();
+  } catch (...) {
+    std::string errorName = TypeInfo::getCurrentExceptionName();
+    return "Unknown " + errorName + " exception";
+  }
 }
 
 } // namespace margelo::nitro


### PR DESCRIPTION
Refactors the `Promise<T>` implementation to use `std::exception_ptr` instead of `std::exception` so it actually preserves the error message.

This cost me more than a full day of debugging - `std::exception` causes object slicing, because it uses the base's copy constructor. It needs to be a pointer to keep it virtual.