### PR TITLE
feat: add macOS and tvOS support

### DIFF
--- a/packages/react-native-nitro-modules/NitroModules.podspec
+++ b/packages/react-native-nitro-modules/NitroModules.podspec
@@ -12,7 +12,12 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
+  s.platforms    = { 
+    :ios => min_ios_version_supported,
+    :visionos => 1.0,
+    :macos => 10.13,
+    :tvos => 13.4,
+  }
   s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
 
   # VisionCamera Core C++ bindings

--- a/packages/react-native-nitro-modules/package.json
+++ b/packages/react-native-nitro-modules/package.json
@@ -28,6 +28,8 @@
     "ios",
     "android",
     "visionOS",
+    "tvOS",
+    "macOS",
     "cpp",
     "framework",
     "react",


### PR DESCRIPTION
## Summary
Adds support for macOS and tvOS support

## Description
I have successfully run my nitro library (react-native-video v7) on macOS and tvOS by only changing podspec of `react-native-nitro-modules`! 

I have set min required version for macOS & tvOS same as in `react-native-macos` 0.75 & `react-native-tvos` 0.75 (as Nitro requires react-native >= 0.75)

- Added `macos` & `tvos` to platforms
- Added `macOS` & `tvOS` keyword to package.json