### PR TITLE
fix: Example app ScrollView bottom offset

### DIFF
--- a/example/src/screens/HybridObjectTestsScreen.tsx
+++ b/example/src/screens/HybridObjectTestsScreen.tsx
@@ -207,7 +207,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  scrollContent: {},
+  scrollContent: {
+    paddingBottom: 65,
+  },
   topControls: {
     marginHorizontal: 15,
     marginBottom: 10,


### PR DESCRIPTION
Adds `paddingBottom` to the style of the `ScrollView` in the example app, so that the last test box is not cut off.