### PR TITLE
fix: Check `std::exception_ptr` for null

### DIFF
--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
@@ -30,6 +30,10 @@ struct JSIConverter<std::exception_ptr> final {
     return std::make_exception_ptr(std::runtime_error(name + ": " + message));
   }
   static inline jsi::Value toJSI(jsi::Runtime& runtime, const std::exception_ptr& exception) {
+    if (exception == nullptr) [[unlikely]] {
+      throw std::runtime_error("Cannot convert an empty exception_ptr to a JS Error!");
+    }
+
     try {
       std::rethrow_exception(exception);
     } catch (const std::exception& e) {

--- a/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
@@ -18,6 +18,10 @@ static inline std::exception_ptr make_exception(const std::string& message) {
 }
 
 static inline std::string get_exception_message(const std::exception_ptr& exception) {
+  if (exception == nullptr) [[unlikely]] {
+    throw std::runtime_error("Cannot get error message of an empty exception_ptr!");
+  }
+
   try {
     std::rethrow_exception(exception);
   } catch (const std::exception& error) {


### PR DESCRIPTION
Checks `std::exception_ptr` for `nullptr` before rethrowing it or storing it in `Promise`.