### PR TITLE
fix: Add workaround for error messages on Android (`std::runtime_error`)

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -108,6 +108,14 @@ public:
         std::string funcName = getHybridFuncFullName<THybrid>(kind, name, hybridInstance.get());
         std::string message = exception.what();
         throw jsi::JSError(runtime, funcName + ": " + message);
+#ifdef ANDROID
+        // Workaround for https://github.com/mrousavy/nitro/issues/382
+      } catch (const std::runtime_error& exception) {
+        // Some exception was thrown - add method name information and re-throw as `JSError`.
+        std::string funcName = getHybridFuncFullName<THybrid>(kind, name, hybridInstance.get());
+        std::string message = exception.what();
+        throw jsi::JSError(runtime, funcName + ": " + message);
+#endif
       } catch (...) {
         // Some unknown exception was thrown - add method name information and re-throw as `JSError`.
         std::string funcName = getHybridFuncFullName<THybrid>(kind, name, hybridInstance.get());

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
@@ -39,6 +39,12 @@ struct JSIConverter<std::exception_ptr> final {
     } catch (const std::exception& e) {
       jsi::JSError error(runtime, e.what());
       return jsi::Value(runtime, error.value());
+#ifdef ANDROID
+      // Workaround for https://github.com/mrousavy/nitro/issues/382
+    } catch (const std::exception& e) {
+      jsi::JSError error(runtime, e.what());
+      return jsi::Value(runtime, error.value());
+#endif
     } catch (...) {
       // Some unknown exception was thrown - maybe an Objective-C error?
       std::string errorName = TypeInfo::getCurrentExceptionName();


### PR DESCRIPTION
Because error messages are broken in react-native core, we need to add a workaround to explicitly catch `std::runtime_error` errors in a `catch` block so we can get the error message. 

This is reported in https://github.com/mrousavy/nitro/issues/382 (and https://github.com/facebook/react-native/issues/48027).

Unfortunately we have to add this workaround on Android now, even if it is nasty and won't work for all errors.

