### PR TITLE
feat: Remove `hybridContext` and `memorySize` from Swift HybridObjects (make them optional)

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -788,7 +788,7 @@ case ${i}:
             const createFunc = `bridge.${bridge.funcName}`
             return `
 { () -> bridge.${bridge.specializationName} in
-  class ClosureHolder {
+  final class ClosureHolder {
     let closure: ${func.getCode('swift')}
     init(wrappingClosure closure: @escaping ${func.getCode('swift')}) {
       self.closure = closure

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -24,7 +24,7 @@ export function createSwiftHybridObject(spec: HybridObjectSpec): SourceFile[] {
     // It doesn't have a base class - implement hybridContext
     classBaseClasses.push('HybridObjectSpec')
     baseMembers.push(`public var hybridContext = margelo.nitro.HybridContext()`)
-    baseMembers.push(`public var memorySize: Int { return 0 }`)
+    baseMembers.push(`public var memorySize: Int { return getSizeOf(self) }`)
   }
 
   const protocolCode = `

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -33,10 +33,7 @@ ${createFileMetadataString(`${protocolName}.swift`)}
 import Foundation
 import NitroModules
 
-/**
- * A Swift protocol representing the ${spec.name} HybridObject.
- * Implement this protocol to create Swift-based instances of ${spec.name}.
- */
+/// See \`\`${protocolName}\`\`
 public protocol ${protocolName}_protocol: ${protocolBaseClasses.join(', ')} {
   // Properties
   ${indent(properties, '  ')}
@@ -45,10 +42,20 @@ public protocol ${protocolName}_protocol: ${protocolBaseClasses.join(', ')} {
   ${indent(methods, '  ')}
 }
 
+/// See \`\`${protocolName}\`\`
 public class ${protocolName}_base: ${classBaseClasses.join(', ')} {
   ${indent(baseMembers.join('\n'), '  ')}
 }
 
+/**
+ * A Swift base-protocol representing the ${spec.name} HybridObject.
+ * Implement this protocol to create Swift-based instances of ${spec.name}.
+ * \`\`\`swift
+ * class ${name.HybridT} : ${protocolName} {
+ *   // ...
+ * }
+ * \`\`\`
+ */
 public typealias ${protocolName} = ${protocolName}_protocol & ${protocolName}_base
   `
 

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -11,10 +11,20 @@ export function createSwiftHybridObject(spec: HybridObjectSpec): SourceFile[] {
   const properties = spec.properties.map((p) => p.getCode('swift')).join('\n')
   const methods = spec.methods.map((p) => p.getCode('swift')).join('\n')
 
-  const baseClasses = ['HybridObjectSpec']
+  const protocolBaseClasses = ['AnyObject']
+  const classBaseClasses: string[] = []
   for (const base of spec.baseTypes) {
     const baseName = getHybridObjectName(base.name)
-    baseClasses.push(baseName.HybridTSpec)
+    protocolBaseClasses.push(`${baseName.HybridTSpec}_protocol`)
+    classBaseClasses.push(`${baseName.HybridTSpec}_base`)
+  }
+
+  const baseMembers: string[] = []
+  if (classBaseClasses.length === 0) {
+    // It doesn't have a base class - implement hybridContext
+    classBaseClasses.push('HybridObjectSpec')
+    baseMembers.push(`public var hybridContext = margelo.nitro.HybridContext()`)
+    baseMembers.push(`public var memorySize: Int { return 0 }`)
   }
 
   const protocolCode = `
@@ -26,29 +36,20 @@ import NitroModules
 /**
  * A Swift protocol representing the ${spec.name} HybridObject.
  * Implement this protocol to create Swift-based instances of ${spec.name}.
- *
- * When implementing this protocol, make sure to initialize \`hybridContext\` - example:
- * \`\`\`
- * public class ${name.HybridT} : ${protocolName} {
- *   // Initialize HybridContext
- *   var hybridContext = margelo.nitro.HybridContext()
- *
- *   // Return size of the instance to inform JS GC about memory pressure
- *   var memorySize: Int {
- *     return getSizeOf(self)
- *   }
- *
- *   // ...
- * }
- * \`\`\`
  */
-public protocol ${protocolName}: AnyObject, ${baseClasses.join(', ')} {
+public protocol ${protocolName}_protocol: ${protocolBaseClasses.join(', ')} {
   // Properties
   ${indent(properties, '  ')}
 
   // Methods
   ${indent(methods, '  ')}
 }
+
+public class ${protocolName}_base: ${classBaseClasses.join(', ')} {
+  ${indent(baseMembers.join('\n'), '  ')}
+}
+
+public typealias ${protocolName} = ${protocolName}_protocol & ${protocolName}_base
   `
 
   const swiftBridge = createSwiftHybridObjectCxxBridge(spec)

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -44,7 +44,7 @@ public protocol ${protocolName}_protocol: ${protocolBaseClasses.join(', ')} {
 
 /// See \`\`${protocolName}\`\`
 public class ${protocolName}_base: ${classBaseClasses.join(', ')} {
-  ${indent(baseMembers.join('\n'), '  ')}
+  ${baseMembers.length > 0 ? indent(baseMembers.join('\n'), '  ') : `/* inherited */`}
 }
 
 /**

--- a/packages/react-native-nitro-image/ios/HybridBase.swift
+++ b/packages/react-native-nitro-image/ios/HybridBase.swift
@@ -8,11 +8,6 @@
 import Foundation
 
 class HybridBase : HybridBaseSpec {
-  var hybridContext = margelo.nitro.HybridContext()
-  var memorySize: Int {
-    return getSizeOf(self)
-  }
-
   var baseValue: Double {
     return 10
   }

--- a/packages/react-native-nitro-image/ios/HybridChild.swift
+++ b/packages/react-native-nitro-image/ios/HybridChild.swift
@@ -8,11 +8,6 @@
 import Foundation
 
 class HybridChild : HybridChildSpec {
-  var hybridContext = margelo.nitro.HybridContext()
-  var memorySize: Int {
-    return getSizeOf(self)
-  }
-  
   var baseValue: Double {
     return 20
   }

--- a/packages/react-native-nitro-image/ios/HybridImage.swift
+++ b/packages/react-native-nitro-image/ios/HybridImage.swift
@@ -22,14 +22,10 @@ class HybridImage : HybridImageSpec {
    */
   private let uiImage: UIImage
   /**
-   * Just default initialize HybridContext - this holds the C++ state.
-   */
-  public var hybridContext = margelo.nitro.HybridContext()
-  /**
    * Get the memory size of the Swift class, and the `UIImage` we allocated so JS
    * can efficiently garbage collect it when needed.
    */
-  public var memorySize: Int {
+  public override var memorySize: Int {
     return getSizeOf(self) + uiImage.memorySize
   }
 

--- a/packages/react-native-nitro-image/ios/HybridImageFactory.swift
+++ b/packages/react-native-nitro-image/ios/HybridImageFactory.swift
@@ -9,12 +9,6 @@ import Foundation
 import NitroModules
 
 class HybridImageFactory : HybridImageFactorySpec {
-  var hybridContext = margelo.nitro.HybridContext()
-
-  var memorySize: Int {
-    return getSizeOf(self)
-  }
-
   func loadImageFromFile(path: String) throws -> any HybridImageSpec {
     guard let uiImage = UIImage(contentsOfFile: path) else {
       throw RuntimeError.error(withMessage: "Failed to load UIImage from \(path)!")

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -9,11 +9,6 @@ import Foundation
 import NitroModules
 
 class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
-  var hybridContext: margelo.nitro.HybridContext = .init()
-  var memorySize: Int {
-    return 0
-  }
-
   var optionalArray: [String]? = []
 
   var someVariant: Variant_String_Double = .someDouble(55)

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -8,10 +8,7 @@
 import Foundation
 import NitroModules
 
-/**
- * A Swift protocol representing the Base HybridObject.
- * Implement this protocol to create Swift-based instances of Base.
- */
+/// See ``HybridBaseSpec``
 public protocol HybridBaseSpec_protocol: AnyObject {
   // Properties
   var baseValue: Double { get }
@@ -20,9 +17,19 @@ public protocol HybridBaseSpec_protocol: AnyObject {
   
 }
 
+/// See ``HybridBaseSpec``
 public class HybridBaseSpec_base: HybridObjectSpec {
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }
 }
 
+/**
+ * A Swift base-protocol representing the Base HybridObject.
+ * Implement this protocol to create Swift-based instances of Base.
+ * ```swift
+ * class HybridBase : HybridBaseSpec {
+ *   // ...
+ * }
+ * ```
+ */
 public typealias HybridBaseSpec = HybridBaseSpec_protocol & HybridBaseSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -22,7 +22,7 @@ public protocol HybridBaseSpec_protocol: AnyObject {
 
 public class HybridBaseSpec_base: HybridObjectSpec {
   public var hybridContext = margelo.nitro.HybridContext()
-  public var memorySize: Int { return 0 }
+  public var memorySize: Int { return getSizeOf(self) }
 }
 
 public typealias HybridBaseSpec = HybridBaseSpec_protocol & HybridBaseSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -11,26 +11,18 @@ import NitroModules
 /**
  * A Swift protocol representing the Base HybridObject.
  * Implement this protocol to create Swift-based instances of Base.
- *
- * When implementing this protocol, make sure to initialize `hybridContext` - example:
- * ```
- * public class HybridBase : HybridBaseSpec {
- *   // Initialize HybridContext
- *   var hybridContext = margelo.nitro.HybridContext()
- *
- *   // Return size of the instance to inform JS GC about memory pressure
- *   var memorySize: Int {
- *     return getSizeOf(self)
- *   }
- *
- *   // ...
- * }
- * ```
  */
-public protocol HybridBaseSpec: AnyObject, HybridObjectSpec {
+public protocol HybridBaseSpec_protocol: AnyObject {
   // Properties
   var baseValue: Double { get }
 
   // Methods
   
 }
+
+public class HybridBaseSpec_base: HybridObjectSpec {
+  public var hybridContext = margelo.nitro.HybridContext()
+  public var memorySize: Int { return 0 }
+}
+
+public typealias HybridBaseSpec = HybridBaseSpec_protocol & HybridBaseSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -8,10 +8,7 @@
 import Foundation
 import NitroModules
 
-/**
- * A Swift protocol representing the Child HybridObject.
- * Implement this protocol to create Swift-based instances of Child.
- */
+/// See ``HybridChildSpec``
 public protocol HybridChildSpec_protocol: AnyObject, HybridBaseSpec_protocol {
   // Properties
   var childValue: Double { get }
@@ -20,8 +17,18 @@ public protocol HybridChildSpec_protocol: AnyObject, HybridBaseSpec_protocol {
   
 }
 
+/// See ``HybridChildSpec``
 public class HybridChildSpec_base: HybridBaseSpec_base {
   
 }
 
+/**
+ * A Swift base-protocol representing the Child HybridObject.
+ * Implement this protocol to create Swift-based instances of Child.
+ * ```swift
+ * class HybridChild : HybridChildSpec {
+ *   // ...
+ * }
+ * ```
+ */
 public typealias HybridChildSpec = HybridChildSpec_protocol & HybridChildSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -19,7 +19,7 @@ public protocol HybridChildSpec_protocol: AnyObject, HybridBaseSpec_protocol {
 
 /// See ``HybridChildSpec``
 public class HybridChildSpec_base: HybridBaseSpec_base {
-  
+  /* inherited */
 }
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -11,26 +11,17 @@ import NitroModules
 /**
  * A Swift protocol representing the Child HybridObject.
  * Implement this protocol to create Swift-based instances of Child.
- *
- * When implementing this protocol, make sure to initialize `hybridContext` - example:
- * ```
- * public class HybridChild : HybridChildSpec {
- *   // Initialize HybridContext
- *   var hybridContext = margelo.nitro.HybridContext()
- *
- *   // Return size of the instance to inform JS GC about memory pressure
- *   var memorySize: Int {
- *     return getSizeOf(self)
- *   }
- *
- *   // ...
- * }
- * ```
  */
-public protocol HybridChildSpec: AnyObject, HybridObjectSpec, HybridBaseSpec {
+public protocol HybridChildSpec_protocol: AnyObject, HybridBaseSpec_protocol {
   // Properties
   var childValue: Double { get }
 
   // Methods
   
 }
+
+public class HybridChildSpec_base: HybridBaseSpec_base {
+  
+}
+
+public typealias HybridChildSpec = HybridChildSpec_protocol & HybridChildSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -25,7 +25,7 @@ public protocol HybridImageFactorySpec_protocol: AnyObject {
 
 public class HybridImageFactorySpec_base: HybridObjectSpec {
   public var hybridContext = margelo.nitro.HybridContext()
-  public var memorySize: Int { return 0 }
+  public var memorySize: Int { return getSizeOf(self) }
 }
 
 public typealias HybridImageFactorySpec = HybridImageFactorySpec_protocol & HybridImageFactorySpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -11,23 +11,8 @@ import NitroModules
 /**
  * A Swift protocol representing the ImageFactory HybridObject.
  * Implement this protocol to create Swift-based instances of ImageFactory.
- *
- * When implementing this protocol, make sure to initialize `hybridContext` - example:
- * ```
- * public class HybridImageFactory : HybridImageFactorySpec {
- *   // Initialize HybridContext
- *   var hybridContext = margelo.nitro.HybridContext()
- *
- *   // Return size of the instance to inform JS GC about memory pressure
- *   var memorySize: Int {
- *     return getSizeOf(self)
- *   }
- *
- *   // ...
- * }
- * ```
  */
-public protocol HybridImageFactorySpec: AnyObject, HybridObjectSpec {
+public protocol HybridImageFactorySpec_protocol: AnyObject {
   // Properties
   
 
@@ -37,3 +22,10 @@ public protocol HybridImageFactorySpec: AnyObject, HybridObjectSpec {
   func loadImageFromSystemName(path: String) throws -> (any HybridImageSpec)
   func bounceBack(image: (any HybridImageSpec)) throws -> (any HybridImageSpec)
 }
+
+public class HybridImageFactorySpec_base: HybridObjectSpec {
+  public var hybridContext = margelo.nitro.HybridContext()
+  public var memorySize: Int { return 0 }
+}
+
+public typealias HybridImageFactorySpec = HybridImageFactorySpec_protocol & HybridImageFactorySpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -8,10 +8,7 @@
 import Foundation
 import NitroModules
 
-/**
- * A Swift protocol representing the ImageFactory HybridObject.
- * Implement this protocol to create Swift-based instances of ImageFactory.
- */
+/// See ``HybridImageFactorySpec``
 public protocol HybridImageFactorySpec_protocol: AnyObject {
   // Properties
   
@@ -23,9 +20,19 @@ public protocol HybridImageFactorySpec_protocol: AnyObject {
   func bounceBack(image: (any HybridImageSpec)) throws -> (any HybridImageSpec)
 }
 
+/// See ``HybridImageFactorySpec``
 public class HybridImageFactorySpec_base: HybridObjectSpec {
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }
 }
 
+/**
+ * A Swift base-protocol representing the ImageFactory HybridObject.
+ * Implement this protocol to create Swift-based instances of ImageFactory.
+ * ```swift
+ * class HybridImageFactory : HybridImageFactorySpec {
+ *   // ...
+ * }
+ * ```
+ */
 public typealias HybridImageFactorySpec = HybridImageFactorySpec_protocol & HybridImageFactorySpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -8,10 +8,7 @@
 import Foundation
 import NitroModules
 
-/**
- * A Swift protocol representing the Image HybridObject.
- * Implement this protocol to create Swift-based instances of Image.
- */
+/// See ``HybridImageSpec``
 public protocol HybridImageSpec_protocol: AnyObject {
   // Properties
   var size: ImageSize { get }
@@ -23,9 +20,19 @@ public protocol HybridImageSpec_protocol: AnyObject {
   func saveToFile(path: String, onFinished: @escaping ((_ path: String) -> Void)) throws -> Void
 }
 
+/// See ``HybridImageSpec``
 public class HybridImageSpec_base: HybridObjectSpec {
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }
 }
 
+/**
+ * A Swift base-protocol representing the Image HybridObject.
+ * Implement this protocol to create Swift-based instances of Image.
+ * ```swift
+ * class HybridImage : HybridImageSpec {
+ *   // ...
+ * }
+ * ```
+ */
 public typealias HybridImageSpec = HybridImageSpec_protocol & HybridImageSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -25,7 +25,7 @@ public protocol HybridImageSpec_protocol: AnyObject {
 
 public class HybridImageSpec_base: HybridObjectSpec {
   public var hybridContext = margelo.nitro.HybridContext()
-  public var memorySize: Int { return 0 }
+  public var memorySize: Int { return getSizeOf(self) }
 }
 
 public typealias HybridImageSpec = HybridImageSpec_protocol & HybridImageSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -11,23 +11,8 @@ import NitroModules
 /**
  * A Swift protocol representing the Image HybridObject.
  * Implement this protocol to create Swift-based instances of Image.
- *
- * When implementing this protocol, make sure to initialize `hybridContext` - example:
- * ```
- * public class HybridImage : HybridImageSpec {
- *   // Initialize HybridContext
- *   var hybridContext = margelo.nitro.HybridContext()
- *
- *   // Return size of the instance to inform JS GC about memory pressure
- *   var memorySize: Int {
- *     return getSizeOf(self)
- *   }
- *
- *   // ...
- * }
- * ```
  */
-public protocol HybridImageSpec: AnyObject, HybridObjectSpec {
+public protocol HybridImageSpec_protocol: AnyObject {
   // Properties
   var size: ImageSize { get }
   var pixelFormat: PixelFormat { get }
@@ -37,3 +22,10 @@ public protocol HybridImageSpec: AnyObject, HybridObjectSpec {
   func toArrayBuffer(format: ImageFormat) throws -> Double
   func saveToFile(path: String, onFinished: @escaping ((_ path: String) -> Void)) throws -> Void
 }
+
+public class HybridImageSpec_base: HybridObjectSpec {
+  public var hybridContext = margelo.nitro.HybridContext()
+  public var memorySize: Int { return 0 }
+}
+
+public typealias HybridImageSpec = HybridImageSpec_protocol & HybridImageSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -11,23 +11,8 @@ import NitroModules
 /**
  * A Swift protocol representing the TestObjectSwiftKotlin HybridObject.
  * Implement this protocol to create Swift-based instances of TestObjectSwiftKotlin.
- *
- * When implementing this protocol, make sure to initialize `hybridContext` - example:
- * ```
- * public class HybridTestObjectSwiftKotlin : HybridTestObjectSwiftKotlinSpec {
- *   // Initialize HybridContext
- *   var hybridContext = margelo.nitro.HybridContext()
- *
- *   // Return size of the instance to inform JS GC about memory pressure
- *   var memorySize: Int {
- *     return getSizeOf(self)
- *   }
- *
- *   // ...
- * }
- * ```
  */
-public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
+public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
   // Properties
   var thisObject: (any HybridTestObjectSwiftKotlinSpec) { get }
   var optionalHybrid: (any HybridTestObjectSwiftKotlinSpec)? { get set }
@@ -88,3 +73,10 @@ public protocol HybridTestObjectSwiftKotlinSpec: AnyObject, HybridObjectSpec {
   func bounceChildBase(child: (any HybridChildSpec)) throws -> (any HybridBaseSpec)
   func castBase(base: (any HybridBaseSpec)) throws -> (any HybridChildSpec)
 }
+
+public class HybridTestObjectSwiftKotlinSpec_base: HybridObjectSpec {
+  public var hybridContext = margelo.nitro.HybridContext()
+  public var memorySize: Int { return 0 }
+}
+
+public typealias HybridTestObjectSwiftKotlinSpec = HybridTestObjectSwiftKotlinSpec_protocol & HybridTestObjectSwiftKotlinSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -76,7 +76,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
 
 public class HybridTestObjectSwiftKotlinSpec_base: HybridObjectSpec {
   public var hybridContext = margelo.nitro.HybridContext()
-  public var memorySize: Int { return 0 }
+  public var memorySize: Int { return getSizeOf(self) }
 }
 
 public typealias HybridTestObjectSwiftKotlinSpec = HybridTestObjectSwiftKotlinSpec_protocol & HybridTestObjectSwiftKotlinSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -8,10 +8,7 @@
 import Foundation
 import NitroModules
 
-/**
- * A Swift protocol representing the TestObjectSwiftKotlin HybridObject.
- * Implement this protocol to create Swift-based instances of TestObjectSwiftKotlin.
- */
+/// See ``HybridTestObjectSwiftKotlinSpec``
 public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
   // Properties
   var thisObject: (any HybridTestObjectSwiftKotlinSpec) { get }
@@ -74,9 +71,19 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
   func castBase(base: (any HybridBaseSpec)) throws -> (any HybridChildSpec)
 }
 
+/// See ``HybridTestObjectSwiftKotlinSpec``
 public class HybridTestObjectSwiftKotlinSpec_base: HybridObjectSpec {
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }
 }
 
+/**
+ * A Swift base-protocol representing the TestObjectSwiftKotlin HybridObject.
+ * Implement this protocol to create Swift-based instances of TestObjectSwiftKotlin.
+ * ```swift
+ * class HybridTestObjectSwiftKotlin : HybridTestObjectSwiftKotlinSpec {
+ *   // ...
+ * }
+ * ```
+ */
 public typealias HybridTestObjectSwiftKotlinSpec = HybridTestObjectSwiftKotlinSpec_protocol & HybridTestObjectSwiftKotlinSpec_base

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpecCxx.swift
@@ -655,7 +655,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
           __promise.reject(withError: __error)
         }
         let __resolverCpp = { () -> bridge.Func_void_double in
-          class ClosureHolder {
+          final class ClosureHolder {
             let closure: ((_ result: Double) -> Void)
             init(wrappingClosure closure: @escaping ((_ result: Double) -> Void)) {
               self.closure = closure
@@ -677,7 +677,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
           return bridge.create_Func_void_double(__closureHolder, __callClosure, __destroyClosure)
         }()
         let __rejecterCpp = { () -> bridge.Func_void_std__exception_ptr in
-          class ClosureHolder {
+          final class ClosureHolder {
             let closure: ((_ error: Error) -> Void)
             init(wrappingClosure closure: @escaping ((_ error: Error) -> Void)) {
               self.closure = closure
@@ -727,7 +727,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
           __promise.reject(withError: __error)
         }
         let __resolverCpp = { () -> bridge.Func_void_Car in
-          class ClosureHolder {
+          final class ClosureHolder {
             let closure: ((_ result: Car) -> Void)
             init(wrappingClosure closure: @escaping ((_ result: Car) -> Void)) {
               self.closure = closure
@@ -749,7 +749,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
           return bridge.create_Func_void_Car(__closureHolder, __callClosure, __destroyClosure)
         }()
         let __rejecterCpp = { () -> bridge.Func_void_std__exception_ptr in
-          class ClosureHolder {
+          final class ClosureHolder {
             let closure: ((_ error: Error) -> Void)
             init(wrappingClosure closure: @escaping ((_ error: Error) -> Void)) {
               self.closure = closure
@@ -798,7 +798,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
         }
         let __resolverCpp = __resolver.getFunctionCopy()
         let __rejecterCpp = { () -> bridge.Func_void_std__exception_ptr in
-          class ClosureHolder {
+          final class ClosureHolder {
             let closure: ((_ error: Error) -> Void)
             init(wrappingClosure closure: @escaping ((_ error: Error) -> Void)) {
               self.closure = closure
@@ -916,7 +916,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
               __promise.reject(withError: __error)
             }
             let __resolverCpp = { () -> bridge.Func_void_double in
-              class ClosureHolder {
+              final class ClosureHolder {
                 let closure: ((_ result: Double) -> Void)
                 init(wrappingClosure closure: @escaping ((_ result: Double) -> Void)) {
                   self.closure = closure
@@ -938,7 +938,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
               return bridge.create_Func_void_double(__closureHolder, __callClosure, __destroyClosure)
             }()
             let __rejecterCpp = { () -> bridge.Func_void_std__exception_ptr in
-              class ClosureHolder {
+              final class ClosureHolder {
                 let closure: ((_ error: Error) -> Void)
                 init(wrappingClosure closure: @escaping ((_ error: Error) -> Void)) {
                   self.closure = closure
@@ -994,7 +994,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
               __promise.reject(withError: __error)
             }
             let __resolverCpp = { () -> bridge.Func_void_std__string in
-              class ClosureHolder {
+              final class ClosureHolder {
                 let closure: ((_ result: String) -> Void)
                 init(wrappingClosure closure: @escaping ((_ result: String) -> Void)) {
                   self.closure = closure
@@ -1016,7 +1016,7 @@ public class HybridTestObjectSwiftKotlinSpecCxx {
               return bridge.create_Func_void_std__string(__closureHolder, __callClosure, __destroyClosure)
             }()
             let __rejecterCpp = { () -> bridge.Func_void_std__exception_ptr in
-              class ClosureHolder {
+              final class ClosureHolder {
                 let closure: ((_ error: Error) -> Void)
                 init(wrappingClosure closure: @escaping ((_ error: Error) -> Void)) {
                   self.closure = closure


### PR DESCRIPTION
In Swift Hybrid Objects we previously always required the user to fill in `hybridContext` and `memorySize` because Swift protocols don't allow default values, and there's no abstract class in Swift.

I found a solution with a `typealias` tho, and now we can pre-fill `hybridContext` and `memorySize`!

For library users, this now means you can remove those fields from your Swift class;

```diff
 class HybridMath: HybridMathSpec {
-  var hybridContext: margelo.nitro.HybridContext = .init()
-  var memorySize: Int { return getSizeOf(self) }  
    var pi: Double { return 3.1415 } 
 }
```

If you have a custom type that is heavy on memory, it is still recommended to **override** `memorySize`;

```swift
class HybridImage: HybridImageSpec {
  override var memorySize: Int { return nativeImage.height * nativeImage.bytesPerRow }  
}
```

**THIS IS A BREAKING CHANGE**