### PR TITLE
docs: Update docs to no longer use `hybridContext`

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -18,8 +18,7 @@ body:
       render: tsx
       placeholder: >
         class HybridMath: HybridMathSpec {
-          var hybridContext = margelo.nitro.HybridContext()
-          var memorySize: Int { return 0 }
+          ...
         }
     validations:
       required: true

--- a/docs/docs/hybrid-objects.md
+++ b/docs/docs/hybrid-objects.md
@@ -112,9 +112,8 @@ Hybrid Objects can be implemented in C++, Swift or Kotlin:
     <TabItem value="swift" label="Swift" default>
       ```swift title="HybridMath.swift"
       class HybridMath : HybridMathSpec {
-        public var hybridContext = margelo.nitro.HybridContext()
-        public var memorySize: Int {
-          return getSizeOf(self)
+        public override var memorySize: Int {
+          return 0
         }
 
         public var pi: Double {

--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -206,9 +206,8 @@ To implement `Math` now, you just need to implement the spec:
   <TabItem value="swift" label="Swift" default>
     ```swift title="HybridMath.swift"
     class HybridMath : HybridMathSpec {
-      var hybridContext = margelo.nitro.HybridContext()
-      var memorySize: Int {
-        return getSizeOf(self)
+      public override var memorySize: Int {
+        return 0
       }
 
       public func add(a: Double, b: Double) throws -> Double {

--- a/docs/docs/using-nitro-in-your-app.md
+++ b/docs/docs/using-nitro-in-your-app.md
@@ -211,9 +211,8 @@ After installing Nitro, you can start creating your [Hybrid Objects](hybrid-obje
     <TabItem value="swift" label="Swift" default>
       ```swift title="HybridMath.swift"
       class HybridMath : HybridMathSpec {
-        public var hybridContext = margelo.nitro.HybridContext()
-        public var memorySize: Int {
-          return getSizeOf(self)
+        public override var memorySize: Int {
+          return 0
         }
 
         public var pi: Double {

--- a/docs/docs/view-components.md
+++ b/docs/docs/view-components.md
@@ -163,9 +163,8 @@ Now implement `NitroImageViewManager` in Swift and Kotlin, and assume it has to 
   <TabItem value="swift" label="iOS (Swift)" default>
     ```swift
     class HybridNitroImageViewManager: HybridNitroImageViewManagerSpec {
-      public var hybridContext = margelo.nitro.HybridContext()
-      public var memorySize: Int {
-        return getSizeOf(self)
+      public override var memorySize: Int {
+        return 0
       }
       private var nitroId: Double? = nil
       private var view: NitroImageView? {


### PR DESCRIPTION
It now has a default value.