### PR TITLE
feat: Implement proper type-erasure inheritance in Swift

### DIFF
--- a/example/src/Testers.ts
+++ b/example/src/Testers.ts
@@ -82,8 +82,6 @@ export class State<T> {
     ) {
       this.onPassed()
     } else {
-      console.log(this.result)
-      console.log(this.result?.toString?.())
       this.onFailed(
         `Expected "${stringify(this.result)}" (${typeof this.result}) to contain ${String(key)}, but it didn't! Keys: ${Object.keys(this.result as any)}`
       )

--- a/example/src/Testers.ts
+++ b/example/src/Testers.ts
@@ -82,6 +82,8 @@ export class State<T> {
     ) {
       this.onPassed()
     } else {
+      console.log(this.result)
+      console.log(this.result?.toString?.())
       this.onFailed(
         `Expected "${stringify(this.result)}" (${typeof this.result}) to contain ${String(key)}, but it didn't! Keys: ${Object.keys(this.result as any)}`
       )

--- a/packages/nitrogen/src/syntax/c++/CppHybridObject.ts
+++ b/packages/nitrogen/src/syntax/c++/CppHybridObject.ts
@@ -29,7 +29,7 @@ export function createCppHybridObject(spec: HybridObjectSpec): SourceFile[] {
 
   const bases = ['public virtual HybridObject']
   for (const base of spec.baseTypes) {
-    const hybridObject = new HybridObjectType(base.name, spec.language)
+    const hybridObject = new HybridObjectType(base)
     bases.push(`public virtual ${getHybridObjectName(base.name).HybridTSpec}`)
     const imports = hybridObject.getRequiredImports()
     cppForwardDeclarations.push(

--- a/packages/nitrogen/src/syntax/createType.ts
+++ b/packages/nitrogen/src/syntax/createType.ts
@@ -290,7 +290,12 @@ export function createType(
     } else if (extendsHybridObject(type, true)) {
       // It is another HybridObject being referenced!
       const typename = type.getSymbolOrThrow().getEscapedName()
-      return new HybridObjectType(typename, language)
+      const baseTypes = type
+        .getBaseTypes()
+        .filter((t) => extendsHybridObject(t, true))
+        .map((b) => createType(language, b, false))
+      const baseHybrids = baseTypes.filter((b) => b instanceof HybridObjectType)
+      return new HybridObjectType(typename, language, baseHybrids)
     } else if (isDirectlyHybridObject(type)) {
       // It is a HybridObject directly/literally. Base type
       return new HybridObjectBaseType()

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -584,14 +584,12 @@ case ${i}:
       case 'hybrid-object': {
         const bridge = this.getBridgeOrThrow()
         const name = getTypeHybridObjectName(this.type)
-        const makeFunc = `bridge.${bridge.funcName}`
         switch (language) {
           case 'swift':
             return `
 { () -> bridge.${bridge.specializationName} in
   let __cxxWrapped = ${name.HybridTSpecCxx}(${swiftParameterName})
-  let __pointer = __cxxWrapped.toUnsafe()
-  return ${makeFunc}(__pointer)
+  return __cxxWrapped.getCxxPart()
 }()`.trim()
           default:
             return swiftParameterName

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -583,12 +583,11 @@ case ${i}:
         }
       case 'hybrid-object': {
         const bridge = this.getBridgeOrThrow()
-        const name = getTypeHybridObjectName(this.type)
         switch (language) {
           case 'swift':
             return `
 { () -> bridge.${bridge.specializationName} in
-  let __cxxWrapped = ${name.HybridTSpecCxx}(${swiftParameterName})
+  let __cxxWrapped = ${swiftParameterName}.getCxxWrapper()
   return __cxxWrapped.getCxxPart()
 }()`.trim()
           default:

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -144,15 +144,16 @@ function createCxxUpcastHelper(
 ): SwiftCxxHelper {
   const cppBaseType = baseType.getCode('c++')
   const cppChildType = childType.getCode('c++')
-  const specializationName = escapeCppName(`${cppChildType}_to_${cppBaseType}`)
+  const funcName = escapeCppName(
+    `upcast_${childType.hybridObjectName}_to_${baseType.hybridObjectName}`
+  )
   return {
     cxxType: cppBaseType,
-    funcName: 'upcast',
-    specializationName: specializationName,
+    funcName: funcName,
+    specializationName: funcName,
     cxxHeader: {
       code: `
-using ${specializationName} = ${cppBaseType};
-inline ${specializationName} upcast(${cppChildType} child) { return child; }
+inline ${cppBaseType} ${funcName}(${cppChildType} child) { return child; }
 `.trim(),
       requiredIncludes: [],
     },

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -72,6 +72,11 @@ function createCxxHybridObjectSwiftHelper(
   const swiftWrappingType = NitroConfig.getCxxNamespace('c++', HybridTSpecSwift)
   const swiftPartType = `${modulename}::${HybridTSpecCxx}`
   const name = escapeCppName(actualType)
+
+  const upcastHelpers = type.baseTypes.map((base) =>
+    createCxxUpcastHelper(base, type)
+  )
+
   return {
     cxxType: actualType,
     funcName: `create_${name}`,
@@ -128,6 +133,28 @@ void* _Nonnull get_${name}(${name} cppType) {
           space: 'user',
         },
       ],
+    },
+    dependencies: [...upcastHelpers],
+  }
+}
+
+function createCxxUpcastHelper(
+  baseType: HybridObjectType,
+  childType: HybridObjectType
+): SwiftCxxHelper {
+  const cppBaseType = baseType.getCode('c++')
+  const cppChildType = childType.getCode('c++')
+  const specializationName = escapeCppName(`${cppChildType}_to_${cppBaseType}`)
+  return {
+    cxxType: cppBaseType,
+    funcName: 'upcast',
+    specializationName: specializationName,
+    cxxHeader: {
+      code: `
+using ${specializationName} = ${cppBaseType};
+inline ${specializationName} upcast(${cppChildType} child) { return child; }
+`.trim(),
+      requiredIncludes: [],
     },
     dependencies: [],
   }

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -24,6 +24,11 @@ export function createSwiftHybridObject(spec: HybridObjectSpec): SourceFile[] {
   baseMembers.push(
     `
 public ${hasBaseClass ? 'override func' : 'func'} getCxxWrapper() -> ${name.HybridTSpecCxx} {
+#if DEBUG
+  guard self is ${name.HybridTSpec} else {
+    fatalError("\`self\` is not a \`${name.HybridTSpec}\`! Did you accidentally inherit from \`${name.HybridTSpec}_base\` instead of \`${name.HybridTSpec}\`?")
+  }
+#endif
   return ${name.HybridTSpecCxx}(self as! ${name.HybridTSpec})
 }`.trim()
   )

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -19,10 +19,18 @@ export function createSwiftHybridObject(spec: HybridObjectSpec): SourceFile[] {
     classBaseClasses.push(`${baseName.HybridTSpec}_base`)
   }
 
+  const hasBaseClass = classBaseClasses.length > 0
   const baseMembers: string[] = []
-  if (classBaseClasses.length === 0) {
+  baseMembers.push(
+    `
+public ${hasBaseClass ? 'override func' : 'func'} getCxxWrapper() -> ${name.HybridTSpecCxx} {
+  return ${name.HybridTSpecCxx}(self as! ${name.HybridTSpec})
+}`.trim()
+  )
+  if (!hasBaseClass) {
     // It doesn't have a base class - implement hybridContext
     classBaseClasses.push('HybridObjectSpec')
+
     baseMembers.push(`public var hybridContext = margelo.nitro.HybridContext()`)
     baseMembers.push(`public var memorySize: Int { return getSizeOf(self) }`)
   }

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -21,6 +21,7 @@ export function createSwiftHybridObject(spec: HybridObjectSpec): SourceFile[] {
 
   const hasBaseClass = classBaseClasses.length > 0
   const baseMembers: string[] = []
+  baseMembers.push(`private weak var cxxWrapper: ${name.HybridTSpecCxx}? = nil`)
   baseMembers.push(
     `
 public ${hasBaseClass ? 'override func' : 'func'} getCxxWrapper() -> ${name.HybridTSpecCxx} {
@@ -29,7 +30,13 @@ public ${hasBaseClass ? 'override func' : 'func'} getCxxWrapper() -> ${name.Hybr
     fatalError("\`self\` is not a \`${name.HybridTSpec}\`! Did you accidentally inherit from \`${name.HybridTSpec}_base\` instead of \`${name.HybridTSpec}\`?")
   }
 #endif
-  return ${name.HybridTSpecCxx}(self as! ${name.HybridTSpec})
+  if let cxxWrapper = self.cxxWrapper {
+    return cxxWrapper
+  } else {
+    let cxxWrapper = ${name.HybridTSpecCxx}(self as! ${name.HybridTSpec})
+    self.cxxWrapper = cxxWrapper
+    return cxxWrapper
+  }
 }`.trim()
   )
   if (!hasBaseClass) {

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -104,7 +104,7 @@ ${hasBase ? `public class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : 
    * Gets (or creates) the C++ part of this Hybrid Object.
    * The C++ part is a \`${bridge.cxxType}\`.
    */
-  public ${hasBase ? 'override func' : 'func'} getCxxPart() -> bridge.${bridge.specializationName} {
+  public func getCxxPart() -> bridge.${bridge.specializationName} {
     return bridge.${bridge.funcName}(self.toUnsafe())
   }
 

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -81,7 +81,7 @@ ${hasBase ? `public class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : 
    * Create a new \`${name.HybridTSpecCxx}\` that wraps the given \`${name.HybridTSpec}\`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: some ${name.HybridTSpec}) {
+  public init(_ implementation: any ${name.HybridTSpec}) {
     self.__implementation = implementation
     ${hasBase ? 'super.init(implementation)' : '/* no base class */'}
   }
@@ -103,20 +103,20 @@ ${hasBase ? `public class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : 
   }
 
   /**
-   * Gets (or creates) the C++ part of this Hybrid Object.
-   * The C++ part is a \`${bridge.cxxType}\`.
-   */
-  public func getCxxPart() -> bridge.${bridge.specializationName} {
-    return bridge.${bridge.funcName}(self.toUnsafe())
-  }
-
-  /**
    * Casts an unsafe pointer to a \`${name.HybridTSpecCxx}\`.
    * The pointer has to be a retained opaque \`Unmanaged<${name.HybridTSpecCxx}>\`.
    * This removes one strong reference from the object!
    */
   public ${hasBase ? 'override class func' : 'class func'} fromUnsafe(_ pointer: UnsafeMutableRawPointer) -> ${name.HybridTSpecCxx} {
     return Unmanaged<${name.HybridTSpecCxx}>.fromOpaque(pointer).takeRetainedValue()
+  }
+
+  /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a \`${bridge.cxxType}\`.
+   */
+  public func getCxxPart() -> bridge.${bridge.specializationName} {
+    return bridge.${bridge.funcName}(self.toUnsafe())
   }
 
   /**

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -43,9 +43,7 @@ export function createSwiftHybridObjectCxxBridge(
   })
   const hasBase = baseClasses.length > 0
 
-  const bridgedType = new SwiftCxxBridgedType(
-    new HybridObjectType(spec.name, spec.language)
-  )
+  const bridgedType = new SwiftCxxBridgedType(new HybridObjectType(spec))
   const bridge = bridgedType.getRequiredBridge()
   if (bridge == null) throw new Error(`HybridObject Type should have a bridge!`)
 

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -43,9 +43,11 @@ export function createSwiftHybridObjectCxxBridge(
   })
   const hasBase = baseClasses.length > 0
 
-  const bridgedType = new SwiftCxxBridgedType(new HybridObjectType(spec.name, spec.language))
+  const bridgedType = new SwiftCxxBridgedType(
+    new HybridObjectType(spec.name, spec.language)
+  )
   const bridge = bridgedType.getRequiredBridge()
-  if ( bridge == null) throw new Error(`HybridObject Type should have a bridge!`)
+  if (bridge == null) throw new Error(`HybridObject Type should have a bridge!`)
 
   const swiftCxxWrapperCode = `
 ${createFileMetadataString(`${name.HybridTSpecCxx}.swift`)}

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectRegistration.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectRegistration.ts
@@ -31,7 +31,7 @@ export function createSwiftHybridObjectRegistration({
   const { HybridTSpecCxx, HybridTSpecSwift, HybridTSpec } =
     getHybridObjectName(hybridObjectName)
 
-  const type = new HybridObjectType(hybridObjectName, 'swift')
+  const type = new HybridObjectType(hybridObjectName, 'swift', [])
   const bridge = new SwiftCxxBridgedType(type)
 
   return {

--- a/packages/nitrogen/src/syntax/types/HybridObjectType.ts
+++ b/packages/nitrogen/src/syntax/types/HybridObjectType.ts
@@ -2,16 +2,43 @@ import { NitroConfig } from '../../config/NitroConfig.js'
 import type { Language } from '../../getPlatformSpecs.js'
 import { getForwardDeclaration } from '../c++/getForwardDeclaration.js'
 import { getHybridObjectName } from '../getHybridObjectName.js'
+import type { HybridObjectSpec } from '../HybridObjectSpec.js'
 import type { SourceFile, SourceImport } from '../SourceFile.js'
 import type { Type, TypeKind } from './Type.js'
 
 export class HybridObjectType implements Type {
   readonly hybridObjectName: string
   readonly implementationLanguage: Language
+  readonly baseTypes: HybridObjectType[]
 
-  constructor(hybridObjectName: string, implementationLanguage: Language) {
-    this.hybridObjectName = hybridObjectName
-    this.implementationLanguage = implementationLanguage
+  constructor(
+    hybridObjectName: string,
+    implementationLanguage: Language,
+    baseTypes: HybridObjectType[]
+  )
+  constructor(spec: HybridObjectSpec)
+  constructor(
+    ...args:
+      | [
+          hybridObjectName: string,
+          implementationLanguage: Language,
+          baseTypes: HybridObjectType[],
+        ]
+      | [HybridObjectSpec]
+  ) {
+    if (args.length === 1) {
+      const [spec] = args
+
+      this.hybridObjectName = spec.name
+      this.implementationLanguage = spec.language
+      this.baseTypes = spec.baseTypes.map((b) => new HybridObjectType(b))
+    } else {
+      const [hybridObjectName, implementationLanguage, baseTypes] = args
+
+      this.hybridObjectName = hybridObjectName
+      this.implementationLanguage = implementationLanguage
+      this.baseTypes = baseTypes
+    }
 
     if (this.hybridObjectName.startsWith('__')) {
       throw new Error(

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
@@ -66,22 +66,6 @@ namespace margelo::nitro::image::bridge::swift {
     return swiftPart.toUnsafe();
   }
   
-  // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridChildSpec>
-  std::shared_ptr<margelo::nitro::image::HybridChildSpec> create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(void* _Nonnull swiftUnsafePointer) {
-    NitroImage::HybridChildSpec_cxx swiftPart = NitroImage::HybridChildSpec_cxx::fromUnsafe(swiftUnsafePointer);
-    return HybridContext::getOrCreate<margelo::nitro::image::HybridChildSpecSwift>(swiftPart);
-  }
-  void* _Nonnull get_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(std__shared_ptr_margelo__nitro__image__HybridChildSpec_ cppType) {
-    std::shared_ptr<margelo::nitro::image::HybridChildSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::image::HybridChildSpecSwift>(cppType);
-  #ifdef NITRO_DEBUG
-    if (swiftWrapper == nullptr) [[unlikely]] {
-      throw std::runtime_error("Class \"HybridChildSpec\" is not implemented in Swift!");
-    }
-  #endif
-    NitroImage::HybridChildSpec_cxx swiftPart = swiftWrapper->getSwiftPart();
-    return swiftPart.toUnsafe();
-  }
-  
   // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridBaseSpec>
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(void* _Nonnull swiftUnsafePointer) {
     NitroImage::HybridBaseSpec_cxx swiftPart = NitroImage::HybridBaseSpec_cxx::fromUnsafe(swiftUnsafePointer);
@@ -95,6 +79,22 @@ namespace margelo::nitro::image::bridge::swift {
     }
   #endif
     NitroImage::HybridBaseSpec_cxx swiftPart = swiftWrapper->getSwiftPart();
+    return swiftPart.toUnsafe();
+  }
+  
+  // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridChildSpec>
+  std::shared_ptr<margelo::nitro::image::HybridChildSpec> create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(void* _Nonnull swiftUnsafePointer) {
+    NitroImage::HybridChildSpec_cxx swiftPart = NitroImage::HybridChildSpec_cxx::fromUnsafe(swiftUnsafePointer);
+    return HybridContext::getOrCreate<margelo::nitro::image::HybridChildSpecSwift>(swiftPart);
+  }
+  void* _Nonnull get_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(std__shared_ptr_margelo__nitro__image__HybridChildSpec_ cppType) {
+    std::shared_ptr<margelo::nitro::image::HybridChildSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::image::HybridChildSpecSwift>(cppType);
+  #ifdef NITRO_DEBUG
+    if (swiftWrapper == nullptr) [[unlikely]] {
+      throw std::runtime_error("Class \"HybridChildSpec\" is not implemented in Swift!");
+    }
+  #endif
+    NitroImage::HybridChildSpec_cxx swiftPart = swiftWrapper->getSwiftPart();
     return swiftPart.toUnsafe();
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -620,5 +620,9 @@ namespace margelo::nitro::image::bridge::swift {
   using std__shared_ptr_margelo__nitro__image__HybridChildSpec_ = std::shared_ptr<margelo::nitro::image::HybridChildSpec>;
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(void* _Nonnull swiftUnsafePointer);
   void* _Nonnull get_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(std__shared_ptr_margelo__nitro__image__HybridChildSpec_ cppType);
+  
+  // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridBaseSpec>
+  using std__shared_ptr_margelo__nitro__image__HybridChildSpec__to_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ = std::shared_ptr<margelo::nitro::image::HybridBaseSpec>;
+  inline std__shared_ptr_margelo__nitro__image__HybridChildSpec__to_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ upcast(std::shared_ptr<margelo::nitro::image::HybridChildSpec> child) { return child; }
 
 } // namespace margelo::nitro::image::bridge::swift

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -605,14 +605,6 @@ namespace margelo::nitro::image::bridge::swift {
     return std::make_shared<Func_void_std__shared_ptr_ArrayBuffer__Wrapper>(value);
   }
   
-  // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridChildSpec>
-  /**
-   * Specialized version of `std::shared_ptr<margelo::nitro::image::HybridChildSpec>`.
-   */
-  using std__shared_ptr_margelo__nitro__image__HybridChildSpec_ = std::shared_ptr<margelo::nitro::image::HybridChildSpec>;
-  std::shared_ptr<margelo::nitro::image::HybridChildSpec> create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(std__shared_ptr_margelo__nitro__image__HybridChildSpec_ cppType);
-  
   // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridBaseSpec>
   /**
    * Specialized version of `std::shared_ptr<margelo::nitro::image::HybridBaseSpec>`.
@@ -620,5 +612,13 @@ namespace margelo::nitro::image::bridge::swift {
   using std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ = std::shared_ptr<margelo::nitro::image::HybridBaseSpec>;
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(void* _Nonnull swiftUnsafePointer);
   void* _Nonnull get_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ cppType);
+  
+  // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridChildSpec>
+  /**
+   * Specialized version of `std::shared_ptr<margelo::nitro::image::HybridChildSpec>`.
+   */
+  using std__shared_ptr_margelo__nitro__image__HybridChildSpec_ = std::shared_ptr<margelo::nitro::image::HybridChildSpec>;
+  std::shared_ptr<margelo::nitro::image::HybridChildSpec> create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(void* _Nonnull swiftUnsafePointer);
+  void* _Nonnull get_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(std__shared_ptr_margelo__nitro__image__HybridChildSpec_ cppType);
 
 } // namespace margelo::nitro::image::bridge::swift

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -622,7 +622,6 @@ namespace margelo::nitro::image::bridge::swift {
   void* _Nonnull get_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(std__shared_ptr_margelo__nitro__image__HybridChildSpec_ cppType);
   
   // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridBaseSpec>
-  using std__shared_ptr_margelo__nitro__image__HybridChildSpec__to_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ = std::shared_ptr<margelo::nitro::image::HybridBaseSpec>;
-  inline std__shared_ptr_margelo__nitro__image__HybridChildSpec__to_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ upcast(std::shared_ptr<margelo::nitro::image::HybridChildSpec> child) { return child; }
+  inline std::shared_ptr<margelo::nitro::image::HybridBaseSpec> upcast_Child_to_Base(std::shared_ptr<margelo::nitro::image::HybridChildSpec> child) { return child; }
 
 } // namespace margelo::nitro::image::bridge::swift

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImageAutolinking.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImageAutolinking.swift
@@ -18,7 +18,7 @@ public final class NitroImageAutolinking {
   public static func createImageFactory() -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_ {
     let hybridObject = HybridImageFactory()
     return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_ in
-      let __cxxWrapped = HybridImageFactorySpec_cxx(hybridObject)
+      let __cxxWrapped = hybridObject.getCxxWrapper()
       return __cxxWrapped.getCxxPart()
     }()
   }
@@ -33,7 +33,7 @@ public final class NitroImageAutolinking {
   public static func createTestObjectSwiftKotlin() -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ {
     let hybridObject = HybridTestObjectSwift()
     return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ in
-      let __cxxWrapped = HybridTestObjectSwiftKotlinSpec_cxx(hybridObject)
+      let __cxxWrapped = hybridObject.getCxxWrapper()
       return __cxxWrapped.getCxxPart()
     }()
   }
@@ -48,7 +48,7 @@ public final class NitroImageAutolinking {
   public static func createBase() -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ {
     let hybridObject = HybridBase()
     return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ in
-      let __cxxWrapped = HybridBaseSpec_cxx(hybridObject)
+      let __cxxWrapped = hybridObject.getCxxWrapper()
       return __cxxWrapped.getCxxPart()
     }()
   }
@@ -63,7 +63,7 @@ public final class NitroImageAutolinking {
   public static func createChild() -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ {
     let hybridObject = HybridChild()
     return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ in
-      let __cxxWrapped = HybridChildSpec_cxx(hybridObject)
+      let __cxxWrapped = hybridObject.getCxxWrapper()
       return __cxxWrapped.getCxxPart()
     }()
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImageAutolinking.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImageAutolinking.swift
@@ -19,8 +19,7 @@ public final class NitroImageAutolinking {
     let hybridObject = HybridImageFactory()
     return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_ in
       let __cxxWrapped = HybridImageFactorySpec_cxx(hybridObject)
-      let __pointer = __cxxWrapped.toUnsafe()
-      return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_(__pointer)
+      return __cxxWrapped.getCxxPart()
     }()
   }
   
@@ -35,8 +34,7 @@ public final class NitroImageAutolinking {
     let hybridObject = HybridTestObjectSwift()
     return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ in
       let __cxxWrapped = HybridTestObjectSwiftKotlinSpec_cxx(hybridObject)
-      let __pointer = __cxxWrapped.toUnsafe()
-      return bridge.create_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_(__pointer)
+      return __cxxWrapped.getCxxPart()
     }()
   }
   
@@ -51,8 +49,7 @@ public final class NitroImageAutolinking {
     let hybridObject = HybridBase()
     return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ in
       let __cxxWrapped = HybridBaseSpec_cxx(hybridObject)
-      let __pointer = __cxxWrapped.toUnsafe()
-      return bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(__pointer)
+      return __cxxWrapped.getCxxPart()
     }()
   }
   
@@ -67,8 +64,7 @@ public final class NitroImageAutolinking {
     let hybridObject = HybridChild()
     return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ in
       let __cxxWrapped = HybridChildSpec_cxx(hybridObject)
-      let __pointer = __cxxWrapped.toUnsafe()
-      return bridge.create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(__pointer)
+      return __cxxWrapped.getCxxPart()
     }()
   }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -20,6 +20,11 @@ public protocol HybridBaseSpec_protocol: AnyObject {
 /// See ``HybridBaseSpec``
 public class HybridBaseSpec_base: HybridObjectSpec {
   public func getCxxWrapper() -> HybridBaseSpec_cxx {
+  #if DEBUG
+    guard self is HybridBaseSpec else {
+      fatalError("`self` is not a `HybridBaseSpec`! Did you accidentally inherit from `HybridBaseSpec_base` instead of `HybridBaseSpec`?")
+    }
+  #endif
     return HybridBaseSpec_cxx(self as! HybridBaseSpec)
   }
   public var hybridContext = margelo.nitro.HybridContext()

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -19,13 +19,20 @@ public protocol HybridBaseSpec_protocol: AnyObject {
 
 /// See ``HybridBaseSpec``
 public class HybridBaseSpec_base: HybridObjectSpec {
+  private weak var cxxWrapper: HybridBaseSpec_cxx? = nil
   public func getCxxWrapper() -> HybridBaseSpec_cxx {
   #if DEBUG
     guard self is HybridBaseSpec else {
       fatalError("`self` is not a `HybridBaseSpec`! Did you accidentally inherit from `HybridBaseSpec_base` instead of `HybridBaseSpec`?")
     }
   #endif
-    return HybridBaseSpec_cxx(self as! HybridBaseSpec)
+    if let cxxWrapper = self.cxxWrapper {
+      return cxxWrapper
+    } else {
+      let cxxWrapper = HybridBaseSpec_cxx(self as! HybridBaseSpec)
+      self.cxxWrapper = cxxWrapper
+      return cxxWrapper
+    }
   }
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -19,6 +19,9 @@ public protocol HybridBaseSpec_protocol: AnyObject {
 
 /// See ``HybridBaseSpec``
 public class HybridBaseSpec_base: HybridObjectSpec {
+  public func getCxxWrapper() -> HybridBaseSpec_cxx {
+    return HybridBaseSpec_cxx(self as! HybridBaseSpec)
+  }
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
@@ -56,6 +56,14 @@ public class HybridBaseSpec_cxx {
   }
 
   /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridBaseSpec>`.
+   */
+  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ {
+    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(self.toUnsafe())
+  }
+
+  /**
    * Casts an unsafe pointer to a `HybridBaseSpec_cxx`.
    * The pointer has to be a retained opaque `Unmanaged<HybridBaseSpec_cxx>`.
    * This removes one strong reference from the object!

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
@@ -34,7 +34,7 @@ public class HybridBaseSpec_cxx {
    * Create a new `HybridBaseSpec_cxx` that wraps the given `HybridBaseSpec`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: some HybridBaseSpec) {
+  public init(_ implementation: any HybridBaseSpec) {
     self.__implementation = implementation
     /* no base class */
   }
@@ -56,20 +56,20 @@ public class HybridBaseSpec_cxx {
   }
 
   /**
-   * Gets (or creates) the C++ part of this Hybrid Object.
-   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridBaseSpec>`.
-   */
-  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ {
-    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(self.toUnsafe())
-  }
-
-  /**
    * Casts an unsafe pointer to a `HybridBaseSpec_cxx`.
    * The pointer has to be a retained opaque `Unmanaged<HybridBaseSpec_cxx>`.
    * This removes one strong reference from the object!
    */
   public class func fromUnsafe(_ pointer: UnsafeMutableRawPointer) -> HybridBaseSpec_cxx {
     return Unmanaged<HybridBaseSpec_cxx>.fromOpaque(pointer).takeRetainedValue()
+  }
+
+  /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridBaseSpec>`.
+   */
+  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ {
+    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(self.toUnsafe())
   }
 
   /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
@@ -72,6 +72,8 @@ public class HybridBaseSpec_cxx {
     return bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(self.toUnsafe())
   }
 
+  
+
   /**
    * Contains a (weak) reference to the C++ HybridObject to cache it.
    */

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -19,13 +19,20 @@ public protocol HybridChildSpec_protocol: AnyObject, HybridBaseSpec_protocol {
 
 /// See ``HybridChildSpec``
 public class HybridChildSpec_base: HybridBaseSpec_base {
+  private weak var cxxWrapper: HybridChildSpec_cxx? = nil
   public override func getCxxWrapper() -> HybridChildSpec_cxx {
   #if DEBUG
     guard self is HybridChildSpec else {
       fatalError("`self` is not a `HybridChildSpec`! Did you accidentally inherit from `HybridChildSpec_base` instead of `HybridChildSpec`?")
     }
   #endif
-    return HybridChildSpec_cxx(self as! HybridChildSpec)
+    if let cxxWrapper = self.cxxWrapper {
+      return cxxWrapper
+    } else {
+      let cxxWrapper = HybridChildSpec_cxx(self as! HybridChildSpec)
+      self.cxxWrapper = cxxWrapper
+      return cxxWrapper
+    }
   }
 }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -19,7 +19,9 @@ public protocol HybridChildSpec_protocol: AnyObject, HybridBaseSpec_protocol {
 
 /// See ``HybridChildSpec``
 public class HybridChildSpec_base: HybridBaseSpec_base {
-  /* inherited */
+  public override func getCxxWrapper() -> HybridChildSpec_cxx {
+    return HybridChildSpec_cxx(self as! HybridChildSpec)
+  }
 }
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -20,6 +20,11 @@ public protocol HybridChildSpec_protocol: AnyObject, HybridBaseSpec_protocol {
 /// See ``HybridChildSpec``
 public class HybridChildSpec_base: HybridBaseSpec_base {
   public override func getCxxWrapper() -> HybridChildSpec_cxx {
+  #if DEBUG
+    guard self is HybridChildSpec else {
+      fatalError("`self` is not a `HybridChildSpec`! Did you accidentally inherit from `HybridChildSpec_base` instead of `HybridChildSpec`?")
+    }
+  #endif
     return HybridChildSpec_cxx(self as! HybridChildSpec)
   }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
@@ -72,6 +72,11 @@ public class HybridChildSpec_cxx : HybridBaseSpec_cxx {
     return bridge.create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(self.toUnsafe())
   }
 
+  public override func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ {
+    let ownCxxPart = bridge.create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(self.toUnsafe())
+    return bridge.upcast(ownCxxPart)
+  }
+
   /**
    * Contains a (weak) reference to the C++ HybridObject to cache it.
    */

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
@@ -56,6 +56,14 @@ public class HybridChildSpec_cxx : HybridBaseSpec_cxx {
   }
 
   /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridChildSpec>`.
+   */
+  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ {
+    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(self.toUnsafe())
+  }
+
+  /**
    * Casts an unsafe pointer to a `HybridChildSpec_cxx`.
    * The pointer has to be a retained opaque `Unmanaged<HybridChildSpec_cxx>`.
    * This removes one strong reference from the object!

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
@@ -74,7 +74,7 @@ public class HybridChildSpec_cxx : HybridBaseSpec_cxx {
 
   public override func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ {
     let ownCxxPart = bridge.create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(self.toUnsafe())
-    return bridge.upcast(ownCxxPart)
+    return bridge.upcast_Child_to_Base(ownCxxPart)
   }
 
   /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
@@ -34,7 +34,7 @@ public class HybridChildSpec_cxx : HybridBaseSpec_cxx {
    * Create a new `HybridChildSpec_cxx` that wraps the given `HybridChildSpec`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: some HybridChildSpec) {
+  public init(_ implementation: any HybridChildSpec) {
     self.__implementation = implementation
     super.init(implementation)
   }
@@ -56,20 +56,20 @@ public class HybridChildSpec_cxx : HybridBaseSpec_cxx {
   }
 
   /**
-   * Gets (or creates) the C++ part of this Hybrid Object.
-   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridChildSpec>`.
-   */
-  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ {
-    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(self.toUnsafe())
-  }
-
-  /**
    * Casts an unsafe pointer to a `HybridChildSpec_cxx`.
    * The pointer has to be a retained opaque `Unmanaged<HybridChildSpec_cxx>`.
    * This removes one strong reference from the object!
    */
   public override class func fromUnsafe(_ pointer: UnsafeMutableRawPointer) -> HybridChildSpec_cxx {
     return Unmanaged<HybridChildSpec_cxx>.fromOpaque(pointer).takeRetainedValue()
+  }
+
+  /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridChildSpec>`.
+   */
+  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ {
+    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(self.toUnsafe())
   }
 
   /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -22,6 +22,9 @@ public protocol HybridImageFactorySpec_protocol: AnyObject {
 
 /// See ``HybridImageFactorySpec``
 public class HybridImageFactorySpec_base: HybridObjectSpec {
+  public func getCxxWrapper() -> HybridImageFactorySpec_cxx {
+    return HybridImageFactorySpec_cxx(self as! HybridImageFactorySpec)
+  }
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -23,6 +23,11 @@ public protocol HybridImageFactorySpec_protocol: AnyObject {
 /// See ``HybridImageFactorySpec``
 public class HybridImageFactorySpec_base: HybridObjectSpec {
   public func getCxxWrapper() -> HybridImageFactorySpec_cxx {
+  #if DEBUG
+    guard self is HybridImageFactorySpec else {
+      fatalError("`self` is not a `HybridImageFactorySpec`! Did you accidentally inherit from `HybridImageFactorySpec_base` instead of `HybridImageFactorySpec`?")
+    }
+  #endif
     return HybridImageFactorySpec_cxx(self as! HybridImageFactorySpec)
   }
   public var hybridContext = margelo.nitro.HybridContext()

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -22,13 +22,20 @@ public protocol HybridImageFactorySpec_protocol: AnyObject {
 
 /// See ``HybridImageFactorySpec``
 public class HybridImageFactorySpec_base: HybridObjectSpec {
+  private weak var cxxWrapper: HybridImageFactorySpec_cxx? = nil
   public func getCxxWrapper() -> HybridImageFactorySpec_cxx {
   #if DEBUG
     guard self is HybridImageFactorySpec else {
       fatalError("`self` is not a `HybridImageFactorySpec`! Did you accidentally inherit from `HybridImageFactorySpec_base` instead of `HybridImageFactorySpec`?")
     }
   #endif
-    return HybridImageFactorySpec_cxx(self as! HybridImageFactorySpec)
+    if let cxxWrapper = self.cxxWrapper {
+      return cxxWrapper
+    } else {
+      let cxxWrapper = HybridImageFactorySpec_cxx(self as! HybridImageFactorySpec)
+      self.cxxWrapper = cxxWrapper
+      return cxxWrapper
+    }
   }
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec_cxx.swift
@@ -56,6 +56,14 @@ public class HybridImageFactorySpec_cxx {
   }
 
   /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridImageFactorySpec>`.
+   */
+  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_ {
+    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_(self.toUnsafe())
+  }
+
+  /**
    * Casts an unsafe pointer to a `HybridImageFactorySpec_cxx`.
    * The pointer has to be a retained opaque `Unmanaged<HybridImageFactorySpec_cxx>`.
    * This removes one strong reference from the object!
@@ -97,8 +105,7 @@ public class HybridImageFactorySpec_cxx {
       let __result = try self.__implementation.loadImageFromFile(path: String(path))
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ in
         let __cxxWrapped = HybridImageSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"
@@ -112,8 +119,7 @@ public class HybridImageFactorySpec_cxx {
       let __result = try self.__implementation.loadImageFromURL(path: String(path))
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ in
         let __cxxWrapped = HybridImageSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"
@@ -127,8 +133,7 @@ public class HybridImageFactorySpec_cxx {
       let __result = try self.__implementation.loadImageFromSystemName(path: String(path))
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ in
         let __cxxWrapped = HybridImageSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"
@@ -146,8 +151,7 @@ public class HybridImageFactorySpec_cxx {
       }())
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ in
         let __cxxWrapped = HybridImageSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec_cxx.swift
@@ -72,6 +72,8 @@ public class HybridImageFactorySpec_cxx {
     return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_(self.toUnsafe())
   }
 
+  
+
   /**
    * Contains a (weak) reference to the C++ HybridObject to cache it.
    */

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec_cxx.swift
@@ -34,7 +34,7 @@ public class HybridImageFactorySpec_cxx {
    * Create a new `HybridImageFactorySpec_cxx` that wraps the given `HybridImageFactorySpec`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: some HybridImageFactorySpec) {
+  public init(_ implementation: any HybridImageFactorySpec) {
     self.__implementation = implementation
     /* no base class */
   }
@@ -56,20 +56,20 @@ public class HybridImageFactorySpec_cxx {
   }
 
   /**
-   * Gets (or creates) the C++ part of this Hybrid Object.
-   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridImageFactorySpec>`.
-   */
-  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_ {
-    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_(self.toUnsafe())
-  }
-
-  /**
    * Casts an unsafe pointer to a `HybridImageFactorySpec_cxx`.
    * The pointer has to be a retained opaque `Unmanaged<HybridImageFactorySpec_cxx>`.
    * This removes one strong reference from the object!
    */
   public class func fromUnsafe(_ pointer: UnsafeMutableRawPointer) -> HybridImageFactorySpec_cxx {
     return Unmanaged<HybridImageFactorySpec_cxx>.fromOpaque(pointer).takeRetainedValue()
+  }
+
+  /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridImageFactorySpec>`.
+   */
+  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_ {
+    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageFactorySpec_(self.toUnsafe())
   }
 
   /**
@@ -104,7 +104,7 @@ public class HybridImageFactorySpec_cxx {
     do {
       let __result = try self.__implementation.loadImageFromFile(path: String(path))
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ in
-        let __cxxWrapped = HybridImageSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {
@@ -118,7 +118,7 @@ public class HybridImageFactorySpec_cxx {
     do {
       let __result = try self.__implementation.loadImageFromURL(path: String(path))
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ in
-        let __cxxWrapped = HybridImageSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {
@@ -132,7 +132,7 @@ public class HybridImageFactorySpec_cxx {
     do {
       let __result = try self.__implementation.loadImageFromSystemName(path: String(path))
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ in
-        let __cxxWrapped = HybridImageSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {
@@ -150,7 +150,7 @@ public class HybridImageFactorySpec_cxx {
         return __instance.getHybridImageSpec()
       }())
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ in
-        let __cxxWrapped = HybridImageSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -22,13 +22,20 @@ public protocol HybridImageSpec_protocol: AnyObject {
 
 /// See ``HybridImageSpec``
 public class HybridImageSpec_base: HybridObjectSpec {
+  private weak var cxxWrapper: HybridImageSpec_cxx? = nil
   public func getCxxWrapper() -> HybridImageSpec_cxx {
   #if DEBUG
     guard self is HybridImageSpec else {
       fatalError("`self` is not a `HybridImageSpec`! Did you accidentally inherit from `HybridImageSpec_base` instead of `HybridImageSpec`?")
     }
   #endif
-    return HybridImageSpec_cxx(self as! HybridImageSpec)
+    if let cxxWrapper = self.cxxWrapper {
+      return cxxWrapper
+    } else {
+      let cxxWrapper = HybridImageSpec_cxx(self as! HybridImageSpec)
+      self.cxxWrapper = cxxWrapper
+      return cxxWrapper
+    }
   }
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -23,6 +23,11 @@ public protocol HybridImageSpec_protocol: AnyObject {
 /// See ``HybridImageSpec``
 public class HybridImageSpec_base: HybridObjectSpec {
   public func getCxxWrapper() -> HybridImageSpec_cxx {
+  #if DEBUG
+    guard self is HybridImageSpec else {
+      fatalError("`self` is not a `HybridImageSpec`! Did you accidentally inherit from `HybridImageSpec_base` instead of `HybridImageSpec`?")
+    }
+  #endif
     return HybridImageSpec_cxx(self as! HybridImageSpec)
   }
   public var hybridContext = margelo.nitro.HybridContext()

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -22,6 +22,9 @@ public protocol HybridImageSpec_protocol: AnyObject {
 
 /// See ``HybridImageSpec``
 public class HybridImageSpec_base: HybridObjectSpec {
+  public func getCxxWrapper() -> HybridImageSpec_cxx {
+    return HybridImageSpec_cxx(self as! HybridImageSpec)
+  }
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec_cxx.swift
@@ -72,6 +72,8 @@ public class HybridImageSpec_cxx {
     return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageSpec_(self.toUnsafe())
   }
 
+  
+
   /**
    * Contains a (weak) reference to the C++ HybridObject to cache it.
    */

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec_cxx.swift
@@ -56,6 +56,14 @@ public class HybridImageSpec_cxx {
   }
 
   /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridImageSpec>`.
+   */
+  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ {
+    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageSpec_(self.toUnsafe())
+  }
+
+  /**
    * Casts an unsafe pointer to a `HybridImageSpec_cxx`.
    * The pointer has to be a retained opaque `Unmanaged<HybridImageSpec_cxx>`.
    * This removes one strong reference from the object!

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec_cxx.swift
@@ -34,7 +34,7 @@ public class HybridImageSpec_cxx {
    * Create a new `HybridImageSpec_cxx` that wraps the given `HybridImageSpec`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: some HybridImageSpec) {
+  public init(_ implementation: any HybridImageSpec) {
     self.__implementation = implementation
     /* no base class */
   }
@@ -56,20 +56,20 @@ public class HybridImageSpec_cxx {
   }
 
   /**
-   * Gets (or creates) the C++ part of this Hybrid Object.
-   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridImageSpec>`.
-   */
-  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ {
-    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageSpec_(self.toUnsafe())
-  }
-
-  /**
    * Casts an unsafe pointer to a `HybridImageSpec_cxx`.
    * The pointer has to be a retained opaque `Unmanaged<HybridImageSpec_cxx>`.
    * This removes one strong reference from the object!
    */
   public class func fromUnsafe(_ pointer: UnsafeMutableRawPointer) -> HybridImageSpec_cxx {
     return Unmanaged<HybridImageSpec_cxx>.fromOpaque(pointer).takeRetainedValue()
+  }
+
+  /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridImageSpec>`.
+   */
+  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridImageSpec_ {
+    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridImageSpec_(self.toUnsafe())
   }
 
   /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -74,6 +74,11 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
 /// See ``HybridTestObjectSwiftKotlinSpec``
 public class HybridTestObjectSwiftKotlinSpec_base: HybridObjectSpec {
   public func getCxxWrapper() -> HybridTestObjectSwiftKotlinSpec_cxx {
+  #if DEBUG
+    guard self is HybridTestObjectSwiftKotlinSpec else {
+      fatalError("`self` is not a `HybridTestObjectSwiftKotlinSpec`! Did you accidentally inherit from `HybridTestObjectSwiftKotlinSpec_base` instead of `HybridTestObjectSwiftKotlinSpec`?")
+    }
+  #endif
     return HybridTestObjectSwiftKotlinSpec_cxx(self as! HybridTestObjectSwiftKotlinSpec)
   }
   public var hybridContext = margelo.nitro.HybridContext()

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -73,6 +73,9 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
 
 /// See ``HybridTestObjectSwiftKotlinSpec``
 public class HybridTestObjectSwiftKotlinSpec_base: HybridObjectSpec {
+  public func getCxxWrapper() -> HybridTestObjectSwiftKotlinSpec_cxx {
+    return HybridTestObjectSwiftKotlinSpec_cxx(self as! HybridTestObjectSwiftKotlinSpec)
+  }
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -73,13 +73,20 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
 
 /// See ``HybridTestObjectSwiftKotlinSpec``
 public class HybridTestObjectSwiftKotlinSpec_base: HybridObjectSpec {
+  private weak var cxxWrapper: HybridTestObjectSwiftKotlinSpec_cxx? = nil
   public func getCxxWrapper() -> HybridTestObjectSwiftKotlinSpec_cxx {
   #if DEBUG
     guard self is HybridTestObjectSwiftKotlinSpec else {
       fatalError("`self` is not a `HybridTestObjectSwiftKotlinSpec`! Did you accidentally inherit from `HybridTestObjectSwiftKotlinSpec_base` instead of `HybridTestObjectSwiftKotlinSpec`?")
     }
   #endif
-    return HybridTestObjectSwiftKotlinSpec_cxx(self as! HybridTestObjectSwiftKotlinSpec)
+    if let cxxWrapper = self.cxxWrapper {
+      return cxxWrapper
+    } else {
+      let cxxWrapper = HybridTestObjectSwiftKotlinSpec_cxx(self as! HybridTestObjectSwiftKotlinSpec)
+      self.cxxWrapper = cxxWrapper
+      return cxxWrapper
+    }
   }
   public var hybridContext = margelo.nitro.HybridContext()
   public var memorySize: Int { return getSizeOf(self) }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -72,6 +72,8 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     return bridge.create_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_(self.toUnsafe())
   }
 
+  
+
   /**
    * Contains a (weak) reference to the C++ HybridObject to cache it.
    */

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -56,6 +56,14 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   }
 
   /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec>`.
+   */
+  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ {
+    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_(self.toUnsafe())
+  }
+
+  /**
    * Casts an unsafe pointer to a `HybridTestObjectSwiftKotlinSpec_cxx`.
    * The pointer has to be a retained opaque `Unmanaged<HybridTestObjectSwiftKotlinSpec_cxx>`.
    * This removes one strong reference from the object!
@@ -93,8 +101,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     get {
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ in
         let __cxxWrapped = HybridTestObjectSwiftKotlinSpec_cxx(self.__implementation.thisObject)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     }
   }
@@ -106,8 +113,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
         if let __unwrappedValue = self.__implementation.optionalHybrid {
           return bridge.create_std__optional_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec__({ () -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ in
             let __cxxWrapped = HybridTestObjectSwiftKotlinSpec_cxx(__unwrappedValue)
-            let __pointer = __cxxWrapped.toUnsafe()
-            return bridge.create_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_(__pointer)
+            return __cxxWrapped.getCxxPart()
           }())
         } else {
           return .init()
@@ -342,8 +348,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
       let __result = try self.__implementation.newTestObject()
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ in
         let __cxxWrapped = HybridTestObjectSwiftKotlinSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"
@@ -1149,8 +1154,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
       let __result = try self.__implementation.createChild()
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ in
         let __cxxWrapped = HybridChildSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"
@@ -1164,8 +1168,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
       let __result = try self.__implementation.createBase()
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ in
         let __cxxWrapped = HybridBaseSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"
@@ -1179,8 +1182,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
       let __result = try self.__implementation.createBaseActualChild()
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ in
         let __cxxWrapped = HybridBaseSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"
@@ -1198,8 +1200,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
       }())
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ in
         let __cxxWrapped = HybridChildSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"
@@ -1217,8 +1218,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
       }())
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ in
         let __cxxWrapped = HybridBaseSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"
@@ -1236,8 +1236,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
       }())
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ in
         let __cxxWrapped = HybridBaseSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"
@@ -1255,8 +1254,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
       }())
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ in
         let __cxxWrapped = HybridChildSpec_cxx(__result)
-        let __pointer = __cxxWrapped.toUnsafe()
-        return bridge.create_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(__pointer)
+        return __cxxWrapped.getCxxPart()
       }()
     } catch {
       let __message = "\(error.localizedDescription)"

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -34,7 +34,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
    * Create a new `HybridTestObjectSwiftKotlinSpec_cxx` that wraps the given `HybridTestObjectSwiftKotlinSpec`.
    * All properties and methods bridge to C++ types.
    */
-  public init(_ implementation: some HybridTestObjectSwiftKotlinSpec) {
+  public init(_ implementation: any HybridTestObjectSwiftKotlinSpec) {
     self.__implementation = implementation
     /* no base class */
   }
@@ -56,20 +56,20 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   }
 
   /**
-   * Gets (or creates) the C++ part of this Hybrid Object.
-   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec>`.
-   */
-  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ {
-    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_(self.toUnsafe())
-  }
-
-  /**
    * Casts an unsafe pointer to a `HybridTestObjectSwiftKotlinSpec_cxx`.
    * The pointer has to be a retained opaque `Unmanaged<HybridTestObjectSwiftKotlinSpec_cxx>`.
    * This removes one strong reference from the object!
    */
   public class func fromUnsafe(_ pointer: UnsafeMutableRawPointer) -> HybridTestObjectSwiftKotlinSpec_cxx {
     return Unmanaged<HybridTestObjectSwiftKotlinSpec_cxx>.fromOpaque(pointer).takeRetainedValue()
+  }
+
+  /**
+   * Gets (or creates) the C++ part of this Hybrid Object.
+   * The C++ part is a `std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec>`.
+   */
+  public func getCxxPart() -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ {
+    return bridge.create_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_(self.toUnsafe())
   }
 
   /**
@@ -100,7 +100,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     @inline(__always)
     get {
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ in
-        let __cxxWrapped = HybridTestObjectSwiftKotlinSpec_cxx(self.__implementation.thisObject)
+        let __cxxWrapped = self.__implementation.thisObject.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     }
@@ -112,7 +112,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
       return { () -> bridge.std__optional_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec__ in
         if let __unwrappedValue = self.__implementation.optionalHybrid {
           return bridge.create_std__optional_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec__({ () -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ in
-            let __cxxWrapped = HybridTestObjectSwiftKotlinSpec_cxx(__unwrappedValue)
+            let __cxxWrapped = __unwrappedValue.getCxxWrapper()
             return __cxxWrapped.getCxxPart()
           }())
         } else {
@@ -347,7 +347,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     do {
       let __result = try self.__implementation.newTestObject()
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec_ in
-        let __cxxWrapped = HybridTestObjectSwiftKotlinSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {
@@ -1153,7 +1153,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     do {
       let __result = try self.__implementation.createChild()
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ in
-        let __cxxWrapped = HybridChildSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {
@@ -1167,7 +1167,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     do {
       let __result = try self.__implementation.createBase()
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ in
-        let __cxxWrapped = HybridBaseSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {
@@ -1181,7 +1181,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     do {
       let __result = try self.__implementation.createBaseActualChild()
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ in
-        let __cxxWrapped = HybridBaseSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {
@@ -1199,7 +1199,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
         return __instance.getHybridChildSpec()
       }())
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ in
-        let __cxxWrapped = HybridChildSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {
@@ -1217,7 +1217,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
         return __instance.getHybridBaseSpec()
       }())
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ in
-        let __cxxWrapped = HybridBaseSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {
@@ -1235,7 +1235,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
         return __instance.getHybridChildSpec()
       }())
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridBaseSpec_ in
-        let __cxxWrapped = HybridBaseSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {
@@ -1253,7 +1253,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
         return __instance.getHybridBaseSpec()
       }())
       return { () -> bridge.std__shared_ptr_margelo__nitro__image__HybridChildSpec_ in
-        let __cxxWrapped = HybridChildSpec_cxx(__result)
+        let __cxxWrapped = __result.getCxxWrapper()
         return __cxxWrapped.getCxxPart()
       }()
     } catch {


### PR DESCRIPTION

Consider the following code:

```ts
interface Base ... {}
interface Child extends Base ... {}
interface SomeHybrid extends HybridObject<{ ios: 'swift' }> {
  createChild(): Base
}
```

Previously this did **NOT** work and the returned object would have the `Base` prototype and only methods from `Base`, even if it is a `Child` on the Swift side.

Now it finally works - because if you create a `Child` it will always be a `Child`, even if the type is erased to `Base`. You can confirm this by console.logging `.__type` - previously it was `Base`, now it's `Child`.

1. Instead of statically calling `bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(__swiftPart.toUnsafe())`, we now call `bridge.create_std__shared_ptr_margelo__nitro__image__HybridBaseSpec_(self.toUnsafe())` inside of the Cxx Wrapper class.
2. Instead of statically creating the Cxx Wrapper (`BaseCxx(__swiftPart)`), we create it inside the Swift base class (which we now have thanks to #420) as `__swiftPart.getCxxWrapper()`, which is now overridable and returns the proper child class.
3. Instead of returning the same base class, we can now upcast it using `upcast_Child_to_Base(..)`

This makes it overridable and FINALLY allows for proper inheritance even with type-erasure (aka dealing with base types) in Swift 🥳  
