### PR TITLE
feat: Default-calculate `getSizeOf(...)` so the user doesn't have to

### DIFF
--- a/docs/docs/hybrid-objects.md
+++ b/docs/docs/hybrid-objects.md
@@ -325,7 +325,7 @@ class HybridImage : HybridImageSpec {
   private var cgImage: CGImage
   public var memorySize: Int {
     let imageSize = cgImage.width * cgImage.height * cgImage.bytesPerPixel
-    return getSizeOf(self) + imageSize
+    return imageSize
   }
 }
 ```

--- a/docs/docs/performance-tips.md
+++ b/docs/docs/performance-tips.md
@@ -224,7 +224,7 @@ class HybridImage : HybridImageSpec {
   private var cgImage: CGImage
   public var memorySize: Int {
     let imageSize = cgImage.width * cgImage.height * cgImage.bytesPerPixel
-    return getSizeOf(self) + imageSize
+    return imageSize
   }
 }
 ```

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -42,7 +42,7 @@ public ${hasBaseClass ? 'override func' : 'func'} getCxxWrapper() -> ${name.Hybr
   if (!hasBaseClass) {
     // It doesn't have a base class - implement the `HybridObjectSpec` base protocol
     classBaseClasses.push('HybridObjectSpec')
-    baseMembers.push(`public var memorySize: Int { return getSizeOf(self) }`)
+    baseMembers.push(`public var memorySize: Int { return 0 }`)
   }
 
   const protocolCode = `

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -177,7 +177,7 @@ ${hasBase ? `public class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : 
    */
   @inline(__always)
   public ${hasBase ? 'override var' : 'var'} memorySize: Int {
-    return self.__implementation.memorySize
+    return MemoryHelper.getSizeOf(self.__implementation) + self.__implementation.memorySize
   }
 
   // Properties

--- a/packages/react-native-nitro-image/ios/HybridImage.swift
+++ b/packages/react-native-nitro-image/ios/HybridImage.swift
@@ -26,7 +26,7 @@ class HybridImage : HybridImageSpec {
    * can efficiently garbage collect it when needed.
    */
   public override var memorySize: Int {
-    return getSizeOf(self) + uiImage.memorySize
+    return uiImage.memorySize
   }
 
   /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -34,7 +34,7 @@ public class HybridBaseSpec_base: HybridObjectSpec {
       return cxxWrapper
     }
   }
-  public var memorySize: Int { return getSizeOf(self) }
+  public var memorySize: Int { return 0 }
 }
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
@@ -93,7 +93,7 @@ public class HybridBaseSpec_cxx {
    */
   @inline(__always)
   public var memorySize: Int {
-    return self.__implementation.memorySize
+    return MemoryHelper.getSizeOf(self.__implementation) + self.__implementation.memorySize
   }
 
   // Properties

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
@@ -96,7 +96,7 @@ public class HybridChildSpec_cxx : HybridBaseSpec_cxx {
    */
   @inline(__always)
   public override var memorySize: Int {
-    return self.__implementation.memorySize
+    return MemoryHelper.getSizeOf(self.__implementation) + self.__implementation.memorySize
   }
 
   // Properties

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -37,7 +37,7 @@ public class HybridImageFactorySpec_base: HybridObjectSpec {
       return cxxWrapper
     }
   }
-  public var memorySize: Int { return getSizeOf(self) }
+  public var memorySize: Int { return 0 }
 }
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec_cxx.swift
@@ -93,7 +93,7 @@ public class HybridImageFactorySpec_cxx {
    */
   @inline(__always)
   public var memorySize: Int {
-    return self.__implementation.memorySize
+    return MemoryHelper.getSizeOf(self.__implementation) + self.__implementation.memorySize
   }
 
   // Properties

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -37,7 +37,7 @@ public class HybridImageSpec_base: HybridObjectSpec {
       return cxxWrapper
     }
   }
-  public var memorySize: Int { return getSizeOf(self) }
+  public var memorySize: Int { return 0 }
 }
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec_cxx.swift
@@ -93,7 +93,7 @@ public class HybridImageSpec_cxx {
    */
   @inline(__always)
   public var memorySize: Int {
-    return self.__implementation.memorySize
+    return MemoryHelper.getSizeOf(self.__implementation) + self.__implementation.memorySize
   }
 
   // Properties

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -88,7 +88,7 @@ public class HybridTestObjectSwiftKotlinSpec_base: HybridObjectSpec {
       return cxxWrapper
     }
   }
-  public var memorySize: Int { return getSizeOf(self) }
+  public var memorySize: Int { return 0 }
 }
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -93,7 +93,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
    */
   @inline(__always)
   public var memorySize: Int {
-    return self.__implementation.memorySize
+    return MemoryHelper.getSizeOf(self.__implementation) + self.__implementation.memorySize
   }
 
   // Properties

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObject.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObject.kt
@@ -26,7 +26,7 @@ abstract class HybridObject: ExtendableHybridClass {
      * val memorySize: ULong
      *   get() {
      *     val imageSize = this.bitmap.bytesPerRow * this.bitmap.height
-     *     return getSizeOf(this) + imageSize
+     *     return imageSize
      *   }
      * ```
      */

--- a/packages/react-native-nitro-modules/ios/core/HybridObjectSpec.swift
+++ b/packages/react-native-nitro-modules/ios/core/HybridObjectSpec.swift
@@ -28,3 +28,10 @@ public protocol HybridObjectSpec: AnyObject {
    */
   var memorySize: Int { get }
 }
+
+public extension HybridObjectSpec {
+  @available(*, deprecated, message: "getSizeOf(...) will now be default-computed. Please remove getSizeOf() from your code.")
+  func getSizeOf<T: AnyObject>(_ instance: T) -> Int {
+    return 0
+  }
+}

--- a/packages/react-native-nitro-modules/ios/core/HybridObjectSpec.swift
+++ b/packages/react-native-nitro-modules/ios/core/HybridObjectSpec.swift
@@ -22,20 +22,9 @@ public protocol HybridObjectSpec: AnyObject {
    * ```swift
    * var memorySize: Int {
    *   let imageSize = self.uiImage.bytesPerRow * self.uiImage.height
-   *   return getSizeOf(self) + imageSize
+   *   return imageSize
    * }
    * ```
    */
   var memorySize: Int { get }
-}
-
-public extension HybridObjectSpec {
-  /**
-   * Get the memory size of the given instance.
-   * This only accounts for stack allocated member variables,
-   * not for externally allocated heap allocations like images or buffers.
-   */
-  func getSizeOf<T: AnyObject>(_ instance: T) -> Int {
-    return malloc_size(Unmanaged.passUnretained(instance).toOpaque())
-  }
 }

--- a/packages/react-native-nitro-modules/ios/utils/MemoryHelper.swift
+++ b/packages/react-native-nitro-modules/ios/utils/MemoryHelper.swift
@@ -9,9 +9,11 @@ import Foundation
 
 public final class MemoryHelper {
   /**
-   * Get the memory size of the given instance.
-   * This only accounts for stack allocated member variables,
-   * not for externally allocated heap allocations like images or buffers.
+   * Get the amount of memory that was allocated using a `malloc`-like allocator
+   * for the given instance, in bytes.
+   * When allocating resources differently (e.g. GPU buffers, or `UIImage`) you
+   * should add their byte sizes to the result of this function to get an object's
+   * total memory footprint.
    */
   public static func getSizeOf(_ instance: AnyObject) -> Int {
     return malloc_size(Unmanaged.passUnretained(instance).toOpaque())

--- a/packages/react-native-nitro-modules/ios/utils/MemoryHelper.swift
+++ b/packages/react-native-nitro-modules/ios/utils/MemoryHelper.swift
@@ -1,0 +1,19 @@
+//
+//  MemoryHelper.swift
+//  NitroModules
+//
+//  Created by Marc Rousavy on 17.12.2024.
+//
+
+import Foundation
+
+public final class MemoryHelper {
+  /**
+   * Get the memory size of the given instance.
+   * This only accounts for stack allocated member variables,
+   * not for externally allocated heap allocations like images or buffers.
+   */
+  public static func getSizeOf(_ instance: AnyObject) -> Int {
+    return malloc_size(Unmanaged.passUnretained(instance).toOpaque())
+  }
+}


### PR DESCRIPTION
The `getSizeOf(self)` function is now default-calculated, so the user doesn't have to calculate that. There's no point in calculating that, I don't know why I added that in the beginning tbh.

Replace:

```diff
 class MyHybrid: MyHybridSpec {
   public override var memorySize: Int {
-    return getSizeOf(self)
+    return 0
   }
 }
```

..or better yet;

```diff
 class MyHybrid: MyHybridSpec {
-  public override var memorySize: Int {
-    return getSizeOf(self)
-    return 0
-  }
 }
```

..if you just return `0` anyways. `0` is already the default.

But if you calculate size;

```swift
 class MyHybrid: MyHybridSpec {
   public override var memorySize: Int {
     return myImage.height * myImage.bytesPerRow
   }
 }
```

No need for `getSizeOf(self)` anymore. **It is deprecated and will be removed in a future Nitro version.**