### PR TITLE
test: Add test where a callback is called multiple times

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -872,6 +872,11 @@ export function getTests(
         .didNotThrow()
         .equals(3)
     ),
+    createTest('callSumUpNTimes(...)', async () =>
+      (await it(async () => await testObject.callSumUpNTimes(() => 7, 5)))
+        .didNotThrow()
+        .equals(7 * 5 /* = 35 */)
+    ),
 
     // Objects
     createTest('getCar()', () =>

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -191,6 +191,17 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
         third()
     }
 
+    override fun callSumUpNTimes(callback: () -> Promise<Double>, n: Double): Promise<Double> {
+        var result = 0
+        return Promise.async {
+            for (i in 1..n) {
+                val current = callback().await()
+                result += current
+            }
+            return@async result
+        }
+    }
+
     override fun getCar(): Car {
         return Car(2018.0, "Lamborghini", "Huracán", 640.0, Powertrain.GAS, null, true)
     }

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -275,6 +275,18 @@ void HybridTestObjectCpp::callWithOptional(std::optional<double> value,
   callback(value);
 }
 
+std::shared_ptr<Promise<double>> HybridTestObjectCpp::callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) {
+  return Promise<double>::async([=]() {
+    double result = 0;
+    for (size_t i = 0; i < n; i++) {
+      std::future<double> future = callback().await();
+      double current = future.get();
+      result += current;
+    }
+    return result;
+  });
+}
+
 std::shared_ptr<Promise<double>>
 HybridTestObjectCpp::getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) {
   return Promise<double>::async([=]() -> double {

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -112,6 +112,7 @@ public:
   std::shared_ptr<Promise<double>>
   getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) override;
   void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) override;
+  std::shared_ptr<Promise<double>> callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) override;
   std::shared_ptr<Promise<void>>
   getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback,
                          const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) override;

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -71,6 +71,17 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     }
   }
 
+  func callSumUpNTimes(callback: @escaping (() -> Promise<Double>), n: Double) throws -> Promise<Double> {
+    var result = 0
+    return Promise.async {
+      for i in 1..n {
+        let current = try await callback().await()
+        result += current
+      }
+      return result
+    }
+  }
+
 
   func bounceStrings(array: [String]) throws -> [String] {
     return array

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -46,6 +46,7 @@ int initialize(JavaVM* vm) {
     margelo::nitro::image::JFunc_void::registerNatives();
     margelo::nitro::image::JFunc_void_std__optional_double_::registerNatives();
     margelo::nitro::image::JFunc_std__shared_ptr_Promise_double__::registerNatives();
+    margelo::nitro::image::JFunc_std__shared_ptr_Promise_double__::registerNatives();
     margelo::nitro::image::JFunc_std__shared_ptr_Promise_std__string__::registerNatives();
     margelo::nitro::image::JFunc_void_std__string::registerNatives();
     margelo::nitro::image::JHybridBaseSpec::registerNatives();

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -521,6 +521,22 @@ namespace margelo::nitro::image {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JDouble> /* value */, jni::alias_ref<JFunc_void_std__optional_double_::javaobject> /* callback */)>("callWithOptional");
     method(_javaPart, value.has_value() ? jni::JDouble::valueOf(value.value()) : nullptr, JFunc_void_std__optional_double_::fromCpp(callback));
   }
+  std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* callback */, double /* n */)>("callSumUpNTimes");
+    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double__::fromCpp(callback), n);
+    return [&]() {
+      auto __promise = Promise<double>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+        __promise->resolve(__result->value());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* getValue */)>("getValueFromJSCallbackAndWait");
     auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double__::fromCpp(getValue));

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -103,6 +103,7 @@ namespace margelo::nitro::image {
     void callCallback(const std::function<void()>& callback) override;
     void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) override;
     void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) override;
+    std::shared_ptr<Promise<double>> callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) override;
     std::shared_ptr<Promise<double>> getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) override;
     std::shared_ptr<Promise<void>> getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) override;
     Car getCar() override;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -257,6 +257,17 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun callSumUpNTimes(callback: () -> Promise<Double>, n: Double): Promise<Double>
+  
+  @DoNotStrip
+  @Keep
+  private fun callSumUpNTimes(callback: Func_std__shared_ptr_Promise_double__, n: Double): Promise<Double> {
+    val __result = callSumUpNTimes(callback.toLambda(), n)
+    return __result
+  }
+  
+  @DoNotStrip
+  @Keep
   abstract fun getValueFromJSCallbackAndWait(getValue: () -> Promise<Double>): Promise<Double>
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -383,6 +383,14 @@ namespace margelo::nitro::image {
         std::rethrow_exception(__result.error());
       }
     }
+    inline std::shared_ptr<Promise<double>> callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) override {
+      auto __result = _swiftPart.callSumUpNTimes(callback, std::forward<decltype(n)>(n));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::shared_ptr<Promise<double>> getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) override {
       auto __result = _swiftPart.getValueFromJSCallbackAndWait(getValue);
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -54,6 +54,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
   func callCallback(callback: @escaping (() -> Void)) throws -> Void
   func callAll(first: @escaping (() -> Void), second: @escaping (() -> Void), third: @escaping (() -> Void)) throws -> Void
   func callWithOptional(value: Double?, callback: @escaping ((_ maybe: Double?) -> Void)) throws -> Void
+  func callSumUpNTimes(callback: @escaping (() -> Promise<Double>), n: Double) throws -> Promise<Double>
   func getValueFromJSCallbackAndWait(getValue: @escaping (() -> Promise<Double>)) throws -> Promise<Double>
   func getValueFromJsCallback(callback: @escaping (() -> Promise<String>), andThenCall: @escaping ((_ valueFromJs: String) -> Void)) throws -> Promise<Void>
   func getCar() throws -> Car

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -938,6 +938,85 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   }
   
   @inline(__always)
+  public func callSumUpNTimes(callback: bridge.Func_std__shared_ptr_Promise_double__, n: Double) -> bridge.Result_std__shared_ptr_Promise_double___ {
+    do {
+      let __result = try self.__implementation.callSumUpNTimes(callback: { () -> (() -> Promise<Double>) in
+        let __sharedClosure = bridge.share_Func_std__shared_ptr_Promise_double__(callback)
+        return { () -> Promise<Double> in
+          let __result = __sharedClosure.pointee.call()
+          return { () -> Promise<Double> in
+            let __promise = Promise<Double>()
+            let __resolver = { (__result: Double) in
+              __promise.resolve(withResult: __result)
+            }
+            let __rejecter = { (__error: Error) in
+              __promise.reject(withError: __error)
+            }
+            let __resolverCpp = { () -> bridge.Func_void_double in
+              final class ClosureHolder {
+                let closure: ((_ result: Double) -> Void)
+                init(wrappingClosure closure: @escaping ((_ result: Double) -> Void)) {
+                  self.closure = closure
+                }
+                func invoke(_ __result: Double) {
+                  self.closure(__result)
+                }
+              }
+            
+              let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: __resolver)).toOpaque()
+              func __callClosure(__closureHolder: UnsafeMutableRawPointer, __result: Double) -> Void {
+                let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
+                closure.invoke(__result)
+              }
+              func __destroyClosure(_ __closureHolder: UnsafeMutableRawPointer) -> Void {
+                Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
+              }
+            
+              return bridge.create_Func_void_double(__closureHolder, __callClosure, __destroyClosure)
+            }()
+            let __rejecterCpp = { () -> bridge.Func_void_std__exception_ptr in
+              final class ClosureHolder {
+                let closure: ((_ error: Error) -> Void)
+                init(wrappingClosure closure: @escaping ((_ error: Error) -> Void)) {
+                  self.closure = closure
+                }
+                func invoke(_ __error: Error) {
+                  self.closure(__error)
+                }
+              }
+            
+              let __closureHolder = Unmanaged.passRetained(ClosureHolder(wrappingClosure: __rejecter)).toOpaque()
+              func __callClosure(__closureHolder: UnsafeMutableRawPointer, __error: std.exception_ptr) -> Void {
+                let closure = Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).takeUnretainedValue()
+                closure.invoke(RuntimeError.from(cppError: __error))
+              }
+              func __destroyClosure(_ __closureHolder: UnsafeMutableRawPointer) -> Void {
+                Unmanaged<ClosureHolder>.fromOpaque(__closureHolder).release()
+              }
+            
+              return bridge.create_Func_void_std__exception_ptr(__closureHolder, __callClosure, __destroyClosure)
+            }()
+            __result.pointee.addOnResolvedListenerCopy(__resolverCpp)
+            __result.pointee.addOnRejectedListener(__rejecterCpp)
+            return __promise
+          }()
+        }
+      }(), n: n)
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_double__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_double__()
+        __result
+          .then({ __result in __promise.pointee.resolve(__result) })
+          .catch({ __error in __promise.pointee.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_double___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_double___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public func getValueFromJSCallbackAndWait(getValue: bridge.Func_std__shared_ptr_Promise_double__) -> bridge.Result_std__shared_ptr_Promise_double___ {
     do {
       let __result = try self.__implementation.getValueFromJSCallbackAndWait(getValue: { () -> (() -> Promise<Double>) in

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -76,6 +76,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("callCallback", &HybridTestObjectCppSpec::callCallback);
       prototype.registerHybridMethod("callAll", &HybridTestObjectCppSpec::callAll);
       prototype.registerHybridMethod("callWithOptional", &HybridTestObjectCppSpec::callWithOptional);
+      prototype.registerHybridMethod("callSumUpNTimes", &HybridTestObjectCppSpec::callSumUpNTimes);
       prototype.registerHybridMethod("getValueFromJSCallbackAndWait", &HybridTestObjectCppSpec::getValueFromJSCallbackAndWait);
       prototype.registerHybridMethod("getValueFromJsCallback", &HybridTestObjectCppSpec::getValueFromJsCallback);
       prototype.registerHybridMethod("getCar", &HybridTestObjectCppSpec::getCar);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -143,6 +143,7 @@ namespace margelo::nitro::image {
       virtual void callCallback(const std::function<void()>& callback) = 0;
       virtual void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) = 0;
       virtual void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) = 0;
+      virtual std::shared_ptr<Promise<double>> callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) = 0;
       virtual std::shared_ptr<Promise<double>> getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) = 0;
       virtual std::shared_ptr<Promise<void>> getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) = 0;
       virtual Car getCar() = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -67,6 +67,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("callCallback", &HybridTestObjectSwiftKotlinSpec::callCallback);
       prototype.registerHybridMethod("callAll", &HybridTestObjectSwiftKotlinSpec::callAll);
       prototype.registerHybridMethod("callWithOptional", &HybridTestObjectSwiftKotlinSpec::callWithOptional);
+      prototype.registerHybridMethod("callSumUpNTimes", &HybridTestObjectSwiftKotlinSpec::callSumUpNTimes);
       prototype.registerHybridMethod("getValueFromJSCallbackAndWait", &HybridTestObjectSwiftKotlinSpec::getValueFromJSCallbackAndWait);
       prototype.registerHybridMethod("getValueFromJsCallback", &HybridTestObjectSwiftKotlinSpec::getValueFromJsCallback);
       prototype.registerHybridMethod("getCar", &HybridTestObjectSwiftKotlinSpec::getCar);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -133,6 +133,7 @@ namespace margelo::nitro::image {
       virtual void callCallback(const std::function<void()>& callback) = 0;
       virtual void callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) = 0;
       virtual void callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) = 0;
+      virtual std::shared_ptr<Promise<double>> callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) = 0;
       virtual std::shared_ptr<Promise<double>> getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) = 0;
       virtual std::shared_ptr<Promise<void>> getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) = 0;
       virtual Car getCar() = 0;

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -103,6 +103,7 @@ interface SharedTestObjectProps {
     value: number | undefined,
     callback: (maybe: number | undefined) => void
   ): void
+  callSumUpNTimes(callback: () => number, n: number): Promise<number>
 
   // Callbacks that return values
   getValueFromJSCallbackAndWait(getValue: () => number): Promise<number>


### PR DESCRIPTION
Adds a test to the example app where a callback that returns a value is called multiple times, and the results of that callback (numbers) are then summed up.