### PR TITLE
perf: Mark all types that are used only in `std::shared_ptr<T>` as `SWIFT_NONCOPYABLE`

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -377,7 +377,7 @@ public:
   }
 private:
   ${actualType} _function;
-} SWIFT_UNSAFE_REFERENCE;
+} SWIFT_NONCOPYABLE;
 inline ${name} create_${name}(void* _Nonnull closureHolder, ${functionPointerParam}, void(* _Nonnull destroy)(void* _Nonnull)) {
   std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
   return ${name}([sharedClosureHolder = std::move(sharedClosureHolder), call](${paramsSignature.join(', ')}) -> ${type.returnType.getCode('c++')} {

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -377,7 +377,7 @@ public:
   }
 private:
   ${actualType} _function;
-};
+} SWIFT_UNSAFE_REFERENCE;
 inline ${name} create_${name}(void* _Nonnull closureHolder, ${functionPointerParam}, void(* _Nonnull destroy)(void* _Nonnull)) {
   std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
   return ${name}([sharedClosureHolder = std::move(sharedClosureHolder), call](${paramsSignature.join(', ')}) -> ${type.returnType.getCode('c++')} {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -91,7 +91,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(const std::string& /* path */)> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_void_std__string create_Func_void_std__string(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::string), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__string([sharedClosureHolder = std::move(sharedClosureHolder), call](const std::string& path) -> void {
@@ -271,7 +271,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(const std::vector<Powertrain>& /* array */)> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::vector<Powertrain>), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__vector_Powertrain_([sharedClosureHolder = std::move(sharedClosureHolder), call](const std::vector<Powertrain>& array) -> void {
@@ -308,7 +308,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void()> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_void create_Func_void(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void([sharedClosureHolder = std::move(sharedClosureHolder), call]() -> void {
@@ -336,7 +336,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(const std::exception_ptr& /* error */)> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::exception_ptr), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__exception_ptr([sharedClosureHolder = std::move(sharedClosureHolder), call](const std::exception_ptr& error) -> void {
@@ -411,7 +411,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(int64_t /* result */)> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_void_int64_t create_Func_void_int64_t(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, int64_t), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_int64_t([sharedClosureHolder = std::move(sharedClosureHolder), call](int64_t result) -> void {
@@ -448,7 +448,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(double /* result */)> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_void_double create_Func_void_double(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, double), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_double([sharedClosureHolder = std::move(sharedClosureHolder), call](double result) -> void {
@@ -494,7 +494,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(const Car& /* result */)> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_void_Car create_Func_void_Car(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, Car), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_Car([sharedClosureHolder = std::move(sharedClosureHolder), call](const Car& result) -> void {
@@ -531,7 +531,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(std::optional<double> /* maybe */)> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::optional<double>), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__optional_double_([sharedClosureHolder = std::move(sharedClosureHolder), call](std::optional<double> maybe) -> void {
@@ -560,7 +560,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<std::shared_ptr<Promise<double>>()> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_std__shared_ptr_Promise_double__ create_Func_std__shared_ptr_Promise_double__(void* _Nonnull closureHolder, std::shared_ptr<Promise<double>>(* _Nonnull call)(void* _Nonnull /* closureHolder */), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__shared_ptr_Promise_double__([sharedClosureHolder = std::move(sharedClosureHolder), call]() -> std::shared_ptr<Promise<double>> {
@@ -590,7 +590,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<std::shared_ptr<Promise<std::string>>()> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_std__shared_ptr_Promise_std__string__ create_Func_std__shared_ptr_Promise_std__string__(void* _Nonnull closureHolder, std::shared_ptr<Promise<std::string>>(* _Nonnull call)(void* _Nonnull /* closureHolder */), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__shared_ptr_Promise_std__string__([sharedClosureHolder = std::move(sharedClosureHolder), call]() -> std::shared_ptr<Promise<std::string>> {
@@ -637,7 +637,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)> _function;
-  } SWIFT_UNSAFE_REFERENCE;
+  } SWIFT_NONCOPYABLE;
   inline Func_void_std__shared_ptr_ArrayBuffer_ create_Func_void_std__shared_ptr_ArrayBuffer_(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, ArrayBufferHolder), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__shared_ptr_ArrayBuffer_([sharedClosureHolder = std::move(sharedClosureHolder), call](const std::shared_ptr<ArrayBuffer>& result) -> void {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -91,7 +91,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(const std::string& /* path */)> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_void_std__string create_Func_void_std__string(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::string), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__string([sharedClosureHolder = std::move(sharedClosureHolder), call](const std::string& path) -> void {
@@ -271,7 +271,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(const std::vector<Powertrain>& /* array */)> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::vector<Powertrain>), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__vector_Powertrain_([sharedClosureHolder = std::move(sharedClosureHolder), call](const std::vector<Powertrain>& array) -> void {
@@ -308,7 +308,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void()> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_void create_Func_void(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void([sharedClosureHolder = std::move(sharedClosureHolder), call]() -> void {
@@ -336,7 +336,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(const std::exception_ptr& /* error */)> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::exception_ptr), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__exception_ptr([sharedClosureHolder = std::move(sharedClosureHolder), call](const std::exception_ptr& error) -> void {
@@ -411,7 +411,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(int64_t /* result */)> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_void_int64_t create_Func_void_int64_t(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, int64_t), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_int64_t([sharedClosureHolder = std::move(sharedClosureHolder), call](int64_t result) -> void {
@@ -448,7 +448,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(double /* result */)> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_void_double create_Func_void_double(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, double), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_double([sharedClosureHolder = std::move(sharedClosureHolder), call](double result) -> void {
@@ -494,7 +494,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(const Car& /* result */)> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_void_Car create_Func_void_Car(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, Car), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_Car([sharedClosureHolder = std::move(sharedClosureHolder), call](const Car& result) -> void {
@@ -531,7 +531,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(std::optional<double> /* maybe */)> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, std::optional<double>), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__optional_double_([sharedClosureHolder = std::move(sharedClosureHolder), call](std::optional<double> maybe) -> void {
@@ -560,7 +560,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<std::shared_ptr<Promise<double>>()> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_std__shared_ptr_Promise_double__ create_Func_std__shared_ptr_Promise_double__(void* _Nonnull closureHolder, std::shared_ptr<Promise<double>>(* _Nonnull call)(void* _Nonnull /* closureHolder */), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__shared_ptr_Promise_double__([sharedClosureHolder = std::move(sharedClosureHolder), call]() -> std::shared_ptr<Promise<double>> {
@@ -590,7 +590,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<std::shared_ptr<Promise<std::string>>()> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_std__shared_ptr_Promise_std__string__ create_Func_std__shared_ptr_Promise_std__string__(void* _Nonnull closureHolder, std::shared_ptr<Promise<std::string>>(* _Nonnull call)(void* _Nonnull /* closureHolder */), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_std__shared_ptr_Promise_std__string__([sharedClosureHolder = std::move(sharedClosureHolder), call]() -> std::shared_ptr<Promise<std::string>> {
@@ -637,7 +637,7 @@ namespace margelo::nitro::image::bridge::swift {
     }
   private:
     std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)> _function;
-  };
+  } SWIFT_UNSAFE_REFERENCE;
   inline Func_void_std__shared_ptr_ArrayBuffer_ create_Func_void_std__shared_ptr_ArrayBuffer_(void* _Nonnull closureHolder, void(* _Nonnull call)(void* _Nonnull /* closureHolder */, ArrayBufferHolder), void(* _Nonnull destroy)(void* _Nonnull)) {
     std::shared_ptr<void> sharedClosureHolder(closureHolder, destroy);
     return Func_void_std__shared_ptr_ArrayBuffer_([sharedClosureHolder = std::move(sharedClosureHolder), call](const std::shared_ptr<ArrayBuffer>& result) -> void {

--- a/packages/react-native-nitro-modules/cpp/core/AnyMap.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/AnyMap.hpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include "NitroDefines.hpp"
 
 namespace margelo::nitro {
 
@@ -199,6 +200,6 @@ public:
 
 private:
   std::unordered_map<std::string, AnyValue> _map;
-};
+} SWIFT_UNSAFE_REFERENCE;
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/core/AnyMap.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/AnyMap.hpp
@@ -200,6 +200,6 @@ public:
 
 private:
   std::unordered_map<std::string, AnyValue> _map;
-} SWIFT_UNSAFE_REFERENCE;
+} SWIFT_NONCOPYABLE;
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/core/AnyMap.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/AnyMap.hpp
@@ -4,13 +4,13 @@
 
 #pragma once
 
+#include "NitroDefines.hpp"
 #include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <variant>
 #include <vector>
-#include "NitroDefines.hpp"
 
 namespace margelo::nitro {
 

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -253,7 +253,7 @@ private:
   std::vector<OnResolvedFunc> _onResolvedListeners;
   std::vector<OnRejectedFunc> _onRejectedListeners;
   std::unique_ptr<std::mutex> _mutex;
-};
+} SWIFT_UNSAFE_REFERENCE;
 
 // Specialization for void
 template <>
@@ -405,6 +405,6 @@ private:
   std::exception_ptr _error;
   std::vector<OnResolvedFunc> _onResolvedListeners;
   std::vector<OnRejectedFunc> _onRejectedListeners;
-};
+} SWIFT_UNSAFE_REFERENCE;
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -253,7 +253,7 @@ private:
   std::vector<OnResolvedFunc> _onResolvedListeners;
   std::vector<OnRejectedFunc> _onRejectedListeners;
   std::unique_ptr<std::mutex> _mutex;
-} SWIFT_UNSAFE_REFERENCE;
+} SWIFT_NONCOPYABLE;
 
 // Specialization for void
 template <>
@@ -405,6 +405,6 @@ private:
   std::exception_ptr _error;
   std::vector<OnResolvedFunc> _onResolvedListeners;
   std::vector<OnRejectedFunc> _onRejectedListeners;
-} SWIFT_UNSAFE_REFERENCE;
+} SWIFT_NONCOPYABLE;
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
@@ -31,24 +31,22 @@
 #define _CXX_INTEROP_HAS_ATTRIBUTE(x) 0
 #endif
 
-#if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
-// Rename Type for Swift
-#define SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
-// Make Swift type private
-#define SWIFT_PRIVATE __attribute__((swift_private))
-// Make getter + setter a computed property
-#define SWIFT_COMPUTED_PROPERTY __attribute__((swift_attr("import_computed_property")))
-#else
-#define SWIFT_NAME(_name)
-#define SWIFT_PRIVATE
-#define SWIFT_COMPUTED_PROPERTY
-#endif
-
 #if _CXX_INTEROP_HAS_ATTRIBUTE(enum_extensibility)
 // Enum is marked as closed/not extensible
 #define CLOSED_ENUM __attribute__((enum_extensibility(closed)))
 #else
 #define CLOSED_ENUM
+#endif
+
+#if __has_include(<swift/bridging>)
+// Swift's bridging header defines those things
+#include <swift/bridging>
+#else
+// If we don't have Swift bridging header, those macros do nothing
+#define SWIFT_NAME(_name)
+#define SWIFT_PRIVATE
+#define SWIFT_COMPUTED_PROPERTY
+#define SWIFT_UNSAFE_REFERENCE
 #endif
 
 #endif /* NitroDefines_h */

--- a/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
@@ -41,6 +41,7 @@
 #if __has_include(<swift/bridging>)
 // Swift's bridging header defines those things
 #include <swift/bridging>
+#define SWIFT_PRIVATE __attribute__((swift_private))
 #else
 // If we don't have Swift bridging header, those macros do nothing
 #define SWIFT_NAME(_name)

--- a/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
@@ -47,7 +47,7 @@
 #define SWIFT_NAME(_name)
 #define SWIFT_PRIVATE
 #define SWIFT_COMPUTED_PROPERTY
-#define SWIFT_UNSAFE_REFERENCE
+#define SWIFT_NONCOPYABLE
 #endif
 
 #endif /* NitroDefines_h */

--- a/packages/react-native-nitro-modules/ios/core/ArrayBufferHolder.hpp
+++ b/packages/react-native-nitro-modules/ios/core/ArrayBufferHolder.hpp
@@ -8,9 +8,9 @@
 #pragma once
 
 #include "ArrayBuffer.hpp"
+#include "NitroDefines.hpp"
 #include "SwiftClosure.hpp"
 #include <memory>
-#include <swift/bridging>
 
 namespace margelo::nitro {
 
@@ -75,6 +75,6 @@ public:
 
 private:
   std::shared_ptr<ArrayBuffer> _arrayBuffer;
-} SWIFT_UNSAFE_REFERENCE;
+};
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/ios/core/ArrayBufferHolder.hpp
+++ b/packages/react-native-nitro-modules/ios/core/ArrayBufferHolder.hpp
@@ -75,6 +75,6 @@ public:
 
 private:
   std::shared_ptr<ArrayBuffer> _arrayBuffer;
-};
+} SWIFT_UNSAFE_REFERENCE;
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/ios/core/ArrayBufferHolder.swift
+++ b/packages/react-native-nitro-modules/ios/core/ArrayBufferHolder.swift
@@ -50,7 +50,7 @@ public extension ArrayBufferHolder {
   /**
    * Copy the given `ArrayBufferHolder` into a new **owning** `ArrayBufferHolder`.
    */
-  static func copy(of other: ArrayBufferHolder) -> ArrayBufferHolder {
+  static func copy(of other: borrowing ArrayBufferHolder) -> ArrayBufferHolder {
     let data = UnsafeMutablePointer<UInt8>.allocate(capacity: other.size)
     let pointer = other.data.assumingMemoryBound(to: UInt8.self)
     data.initialize(from: pointer, count: other.size)


### PR DESCRIPTION
### Summary

This PR avoids copying a few C++ types when using them in Swift, effectively speeding up the codebase by a few factors depending on how heavy the types were to copy. 🔥 

### Problem

Swift imports all C++ types as value types, so every time you get, use, or pass a C++ type around in Swift, **it will make a copy.**

Not only is this slow, but sometimes it isn't even expected and might destroy internal state if the C++ class has unsafe pointers inside that are not ref-counted! ⚠️ ❌ 


`std::shared_ptr<T>` is one of these cases - if you use `shared_ptr.pointee`, it will actually return the pointer this shared_ptr wraps **by value** - so **it will copy** `T`!! ❌ 

```swift
func someSwiftFunc(shared: std.shared_ptr<T>) {
  shared.pointee.doFirst()
  shared.pointee.doSecond()
  shared.pointee.doThird()
  // 3x copy, 3x destructors!! ❌ ❌ ❌ 
}
```

### Solution

So this PR changes this - every type we use inside of a `std::shared_ptr` is now marked as a `SWIFT_NONCOPYABLE`, meaning Swift will not copy this type. It is like `SWIFT_IMMORTAL_REFERENCE`, but a bit more explicit on the usage.

Right now, the following types are affected and have been improved with this PR;

- `Promise<T>`
- `ArrayBuffer`
- Callbacks / `std::function`

### Future

Every type that is not expected to be copied directly should have `SWIFT_NONCOPYABLE` on it, so that's;
- Extrusively reference-counted types (aka every type in a `shared_ptr<T>`, `unique_ptr<T>` or `weak_ptr<T>`)
- `const &` types
- Unsafe pointers

Then Swift can use borrowing magic.

Also, I guess an even better solution would be to have a `borrowing T` accessor instead of just `T` on the Swift shared_ptr type. I created a feature request for this here: https://github.com/swiftlang/swift/issues/78296