### PR TITLE
chore: Remove unused arg names

### DIFF
--- a/packages/nitrogen/src/syntax/c++/CppEnum.ts
+++ b/packages/nitrogen/src/syntax/c++/CppEnum.ts
@@ -59,7 +59,7 @@ namespace margelo::nitro {
       int enumValue = static_cast<int>(arg);
       return JSIConverter<int>::toJSI(runtime, enumValue);
     }
-    static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
+    static inline bool canConvert(jsi::Runtime&, const jsi::Value& value) {
       if (!value.isNumber()) {
         return false;
       }

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -769,7 +769,7 @@ __promise->resolve();
             return `
 [&]() {
   auto __promise = Promise<${actualCppType}>::create();
-  ${parameterName}->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+  ${parameterName}->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& ${resultingType.hasType ? '__boxedResult' : '/* unit */'}) {
     ${indent(resolveBody, '    ')}
   });
   ${parameterName}->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -198,7 +198,7 @@ void HybridTestObjectCpp::throwError(const std::exception_ptr& error) {
   std::rethrow_exception(error);
 }
 
-std::string HybridTestObjectCpp::tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) {
+std::string HybridTestObjectCpp::tryOptionalParams(double /* num */, bool /* boo */, const std::optional<std::string>& str) {
   if (str.has_value()) {
     return str.value();
   } else {
@@ -206,7 +206,7 @@ std::string HybridTestObjectCpp::tryOptionalParams(double num, bool boo, const s
   }
 }
 
-std::string HybridTestObjectCpp::tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) {
+std::string HybridTestObjectCpp::tryMiddleParam(double /* num */, std::optional<bool> /* boo */, const std::string& str) {
   return str;
 }
 
@@ -422,7 +422,7 @@ std::shared_ptr<HybridTestObjectCppSpec> HybridTestObjectCpp::newTestObject() {
   return std::make_shared<HybridTestObjectCpp>();
 }
 
-jsi::Value HybridTestObjectCpp::rawJsiFunc(jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* args, size_t count) {
+jsi::Value HybridTestObjectCpp::rawJsiFunc(jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* args, size_t count) {
   jsi::Array array(runtime, count);
   for (size_t i = 0; i < count; i++) {
     array.setValueAtIndex(runtime, i, jsi::Value(runtime, args[i]));

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -351,7 +351,7 @@ namespace margelo::nitro::image {
     auto __result = method(_javaPart);
     return [&]() {
       auto __promise = Promise<void>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
         __promise->resolve();
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
@@ -406,7 +406,7 @@ namespace margelo::nitro::image {
     auto __result = method(_javaPart, seconds);
     return [&]() {
       auto __promise = Promise<void>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
         __promise->resolve();
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
@@ -421,7 +421,7 @@ namespace margelo::nitro::image {
     auto __result = method(_javaPart);
     return [&]() {
       auto __promise = Promise<void>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
         __promise->resolve();
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
@@ -501,7 +501,7 @@ namespace margelo::nitro::image {
     }());
     return [&]() {
       auto __promise = Promise<void>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
         __promise->resolve();
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
@@ -592,7 +592,7 @@ namespace margelo::nitro::image {
     auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__string__::fromCpp(callback), JFunc_void_std__string::fromCpp(andThenCall));
     return [&]() {
       auto __promise = Promise<void>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
         __promise->resolve();
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/OldEnum.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/OldEnum.hpp
@@ -47,7 +47,7 @@ namespace margelo::nitro {
       int enumValue = static_cast<int>(arg);
       return JSIConverter<int>::toJSI(runtime, enumValue);
     }
-    static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
+    static inline bool canConvert(jsi::Runtime&, const jsi::Value& value) {
       if (!value.isNumber()) {
         return false;
       }

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JArrayBuffer.hpp
@@ -38,8 +38,7 @@ public:
   /**
    * Create a new `JArrayBuffer` that wraps the given `ByteBuffer` from Java.
    */
-  static jni::local_ref<JArrayBuffer::jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis,
-                                                              jni::alias_ref<jni::JByteBuffer> buffer) {
+  static jni::local_ref<JArrayBuffer::jhybriddata> initHybrid(jni::alias_ref<jhybridobject>, jni::alias_ref<jni::JByteBuffer> buffer) {
     return makeCxxInstance(buffer);
   }
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.cpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.cpp
@@ -12,7 +12,7 @@
 
 namespace margelo::nitro {
 
-void JHybridObjectRegistry::registerHybridObjectConstructor(jni::alias_ref<jni::JClass> clazz, std::string hybridObjectName,
+void JHybridObjectRegistry::registerHybridObjectConstructor(jni::alias_ref<jni::JClass>, std::string hybridObjectName,
                                                             jni::alias_ref<JHybridObjectInitializer> constructorFn) {
   auto sharedInitializer = jni::make_global(constructorFn);
   HybridObjectRegistry::registerHybridObjectConstructor(

--- a/packages/react-native-nitro-modules/android/src/main/cpp/utils/JNISharedPtr.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/utils/JNISharedPtr.hpp
@@ -15,7 +15,7 @@ template <typename T>
 struct GlobalRefDeleter {
   explicit GlobalRefDeleter(jni::global_ref<typename T::javaobject> ref) : _ref(ref) {}
 
-  void operator()(T* ptr) {
+  void operator()(T* /* cthis */) {
     if (_ref) {
       _ref.release();
     }

--- a/packages/react-native-nitro-modules/cpp/core/BoxedHybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/BoxedHybridObject.cpp
@@ -19,8 +19,9 @@ jsi::Value BoxedHybridObject::get(jsi::Runtime& runtime, const jsi::PropNameID& 
   if (name == "unbox") {
     return jsi::Function::createFromHostFunction(
         runtime, jsi::PropNameID::forUtf8(runtime, "unbox"), 0,
-        [hybridObject = _hybridObject](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args,
-                                       size_t count) -> jsi::Value { return hybridObject->toObject(runtime); });
+        [hybridObject = _hybridObject](jsi::Runtime& runtime, const jsi::Value&, const jsi::Value*, size_t) -> jsi::Value {
+          return hybridObject->toObject(runtime);
+        });
   }
 
   return jsi::Value::undefined();

--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -23,7 +23,7 @@ bool HybridObject::equals(std::shared_ptr<HybridObject> other) {
   return this == other.get();
 }
 
-jsi::Value HybridObject::disposeRaw(jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args, size_t count) {
+jsi::Value HybridObject::disposeRaw(jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value*, size_t) {
   // 1. Dispose any resources - this might be overridden by child classes to perform manual cleanup.
   dispose();
   // 2. Remove the NativeState from `this`

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Function.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Function.hpp
@@ -68,8 +68,8 @@ struct JSIConverter<std::function<ReturnType(Args...)>> final {
   }
 
   static inline jsi::Value toJSI(jsi::Runtime& runtime, std::function<ReturnType(Args...)>&& function) {
-    jsi::HostFunctionType jsFunction = [function = std::move(function)](jsi::Runtime& runtime, const jsi::Value& thisValue,
-                                                                        const jsi::Value* args, size_t count) -> jsi::Value {
+    jsi::HostFunctionType jsFunction = [function = std::move(function)](jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* args,
+                                                                        size_t count) -> jsi::Value {
       if (count != sizeof...(Args)) [[unlikely]] {
         throw jsi::JSError(runtime, "Function expected " + std::to_string(sizeof...(Args)) + " arguments, but received " +
                                         std::to_string(count) + "!");

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
@@ -52,8 +52,8 @@ struct JSIConverter<std::shared_ptr<Promise<TResult>>> final {
     if (promise->isPending()) {
       // Get Promise ctor from global
       jsi::Function promiseCtor = runtime.global().getPropertyAsFunction(runtime, "Promise");
-      jsi::HostFunctionType executor = [promise](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments,
-                                                 size_t count) -> jsi::Value {
+      jsi::HostFunctionType executor = [promise](jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* arguments,
+                                                 size_t) -> jsi::Value {
         // Add resolver listener
         if constexpr (std::is_void_v<TResult>) {
           // It's resolving to void.

--- a/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.hpp
+++ b/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.hpp
@@ -79,7 +79,7 @@ protected:
    * **Do not conditionally register hybrid methods, getters or setter!**
    */
   template <typename Derived>
-  inline void registerHybrids(Derived* thisInstance, RegisterFn registerFunc) {
+  inline void registerHybrids(Derived* /* this */, RegisterFn registerFunc) {
     const std::shared_ptr<Prototype>& prototype = _prototypeChain.extendPrototype<Derived>();
 
     if (!prototype->hasHybrids()) {

--- a/packages/react-native-nitro-modules/ios/core/RuntimeError.swift
+++ b/packages/react-native-nitro-modules/ios/core/RuntimeError.swift
@@ -26,7 +26,7 @@ public enum RuntimeError: Error, CustomStringConvertible {
    * Creates a new `RuntimeError` from the given C++ `std::exception`.
    */
   public static func from(cppError: std.exception_ptr) -> RuntimeError {
-    let message = margelo.nitro.get_exception_message(cppError)
+    let message = margelo.nitro.getExceptionMessage(cppError)
     return .error(withMessage: String(message))
   }
 }
@@ -37,6 +37,6 @@ public extension Error {
    */
   func toCpp() -> std.exception_ptr {
     let message = String(describing: self)
-    return margelo.nitro.make_exception(std.string(message))
+    return margelo.nitro.makeException(std.string(message))
   }
 }

--- a/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
@@ -13,11 +13,11 @@
 
 namespace margelo::nitro {
 
-static inline std::exception_ptr make_exception(const std::string& message) {
+static inline std::exception_ptr makeException(const std::string& message) {
   return std::make_exception_ptr(std::runtime_error(message));
 }
 
-static inline std::string get_exception_message(const std::exception_ptr& exception) {
+static inline std::string getExceptionMessage(const std::exception_ptr& exception) {
   if (exception == nullptr) [[unlikely]] {
     throw std::runtime_error("Cannot get error message of an empty exception_ptr!");
   }


### PR DESCRIPTION
fixes a lot of warnings in the compiler output