### PR TITLE
fix: Reject Promise with timeout if it gets destroyed

### DIFF
--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -74,7 +74,7 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
   func callSumUpNTimes(callback: @escaping (() -> Promise<Double>), n: Double) throws -> Promise<Double> {
     var result = 0.0
     return Promise.async {
-      for i in 1...Int(n) {
+      for _ in 1...Int(n) {
         let current = try await callback().await()
         result += current
       }

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JPromise.hpp
@@ -57,6 +57,16 @@ public:
   }
 
 public:
+  ~JPromise() override {
+    if (_result == nullptr && _error == nullptr) [[unlikely]] {
+      jni::ThreadScope::WithClassLoader([&]() {
+        std::runtime_error error("Timeouted: JPromise was destroyed!");
+        this->reject(jni::getJavaExceptionForCppException(std::make_exception_ptr(error)));
+      });
+    }
+  }
+
+public:
   void resolve(jni::alias_ref<jni::JObject> result) {
     std::unique_lock lock(_mutex);
     _result = jni::make_global(result);

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -35,7 +35,7 @@ private:
 public:
   ~Promise() {
     if (isPending()) [[unlikely]] {
-      auto message = std::string("Timeouted: Promise<") + TypeInfo::getFriendlyTypename<T>() + "> was destroyed!";
+      auto message = std::string("Timeouted: Promise<") + TypeInfo::getFriendlyTypename<TResult>() + "> was destroyed!";
       reject(std::make_exception_ptr(std::runtime_error(message)));
     }
   }

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -35,7 +35,7 @@ private:
 public:
   ~Promise() {
     if (isPending()) [[unlikely]] {
-      auto message = std::string("Timeouted: Promise<") + TypeInfo::getFriendlyTypeName<T>() + "> was destroyed!";
+      auto message = std::string("Timeouted: Promise<") + TypeInfo::getFriendlyTypename<T>() + "> was destroyed!";
       reject(std::make_exception_ptr(std::runtime_error(message)));
     }
   }

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -35,8 +35,8 @@ private:
 public:
   ~Promise() {
     if (isPending()) [[unlikely]] {
-      std::runtime_error error("Timeouted: Promise was destroyed!");
-      reject(std::make_exception_ptr(std::move(error)));
+      auto message = std::string("Timeouted: Promise<") + TypeInfo::getFriendlyTypeName<T>() + "> was destroyed!";
+      reject(std::make_exception_ptr(std::runtime_error(message)));
     }
   }
 
@@ -269,7 +269,7 @@ private:
 public:
   ~Promise() {
     if (isPending()) [[unlikely]] {
-      std::runtime_error error("Timeouted: Promise was destroyed!");
+      std::runtime_error error("Timeouted: Promise<void> was destroyed!");
       reject(std::make_exception_ptr(std::move(error)));
     }
   }

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -33,6 +33,14 @@ private:
   Promise() {}
 
 public:
+  ~Promise() {
+    if (isPending()) [[unlikely]] {
+      std::runtime_error error("Timeouted: Promise was destroyed!");
+      reject(std::make_exception_ptr(std::move(error)));
+    }
+  }
+
+public:
   /**
    * Creates a new pending Promise that has to be resolved
    * or rejected with `resolve(..)` or `reject(..)`.
@@ -257,6 +265,14 @@ public:
 
 private:
   Promise() {}
+
+public:
+  ~Promise() {
+    if (isPending()) [[unlikely]] {
+      std::runtime_error error("Timeouted: Promise was destroyed!");
+      reject(std::make_exception_ptr(std::move(error)));
+    }
+  }
 
 public:
   static std::shared_ptr<Promise> create() {

--- a/packages/react-native-nitro-modules/cpp/threading/Dispatcher.cpp
+++ b/packages/react-native-nitro-modules/cpp/threading/Dispatcher.cpp
@@ -1,3 +1,10 @@
+//
+//  Dispatcher.cpp
+//  react-native-nitro
+//
+//  Created by Marc Rousavy on 22.07.24.
+//
+
 #include "Dispatcher.hpp"
 #include "JSIHelpers.hpp"
 #include "NitroDefines.hpp"

--- a/packages/react-native-nitro-modules/ios/core/Promise.swift
+++ b/packages/react-native-nitro-modules/ios/core/Promise.swift
@@ -38,7 +38,7 @@ public final class Promise<T> {
   deinit {
     if state == nil {
       let message = "Timeouted: Promise<\(String(describing: T.self))> was destroyed!"
-      reject(RuntimeError.error(withMessage: message))
+      reject(withError: RuntimeError.error(withMessage: message))
     }
   }
 

--- a/packages/react-native-nitro-modules/ios/core/Promise.swift
+++ b/packages/react-native-nitro-modules/ios/core/Promise.swift
@@ -37,7 +37,8 @@ public final class Promise<T> {
 
   deinit {
     if state == nil {
-      print("⚠️ Promise<\(String(describing: T.self))> got destroyed, but was never resolved or rejected! It is probably left hanging in JS now.")
+      let message = "Timeouted: Promise<\(String(describing: T.self))> was destroyed!"
+      reject(RuntimeError.error(withMessage: message))
     }
   }
 


### PR DESCRIPTION
If a Promise gets destroyed without ever being resolved or rejected, it goes stale.

This PR fixes this and rejects a Promise with a timeout error if it gets destructed and is still pending