### PR TITLE
perf: Make JS callbacks lock-free

### DIFF
--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Function.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Function.hpp
@@ -95,9 +95,6 @@ struct JSIConverter<std::function<ReturnType(Args...)>> final {
 
 private:
   static inline ResultingType callJSFunction(jsi::Runtime& runtime, const OwningReference<jsi::Function>& function, const Args&... args) {
-    // Throw a lock on the OwningReference<T> so we can guarantee safe access (Hermes GC cannot delete it while `lock` is alive)
-    OwningLock<jsi::Function> lock = function.lock();
-
     if (!function) {
       if constexpr (std::is_void_v<ResultingType>) {
         // runtime has already been deleted. since this returns void, we can just ignore it being deleted.


### PR DESCRIPTION
No reason for a lock here since the assumption is that we are already on the JS Thread (otherwise calling it wouldn't be safe anyways), and we have `OwningReference` - so a _strong_ one.

It can never be deleted here by the GC, so no reason to hold an `OwningLock`.