### PR TITLE
test: Add test that rejects a Promise on JS side and rethrows on native

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -794,6 +794,23 @@ export function getTests(
         .didNotThrow()
         .equals(undefined)
     ),
+    createTest(
+      'JS Promise<void> that rejects will also reject on native',
+      async () =>
+        (
+          await it(() => {
+            return timeoutedPromise(async () => {
+              let reject = (_: Error) => {}
+              const promise = new Promise<void>((_, r) => {
+                reject = r
+              })
+              const nativePromise = testObject.awaitPromise(promise)
+              reject(new Error(`rejected from JS!`))
+              await nativePromise
+            })
+          })
+        ).didThrow()
+    ),
 
     // Callbacks
     createTest('callCallback(...)', async () =>

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -933,6 +933,19 @@ export function getTests(
           .didReturn('object')
           .toContain('byteLength')
     ),
+    createTest(
+      'Async callback that throws in JS will rethrow in native',
+      async () =>
+        (
+          await it(async () => {
+            return timeoutedPromise<ArrayBuffer>(async () => {
+              await testObject.callbackAsyncPromise(() => {
+                throw new Error(`throwing in JS!`)
+              })
+            })
+          })
+        ).didThrow()
+    ),
 
     // Objects
     createTest('getCar()', () =>


### PR DESCRIPTION
We create a Promise on JS side, await it on native and rethrow the error on native
