### PR TITLE
fix: Use UNIX paths for CMake file, even on Windows (`\` -> `/`)

### DIFF
--- a/.github/workflows/run-nitrogen.yml
+++ b/.github/workflows/run-nitrogen.yml
@@ -29,10 +29,7 @@ on:
 jobs:
   lint:
     name: Run Nitrogen for example module (react-native-nitro-image)
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/run-nitrogen.yml
+++ b/.github/workflows/run-nitrogen.yml
@@ -29,7 +29,10 @@ on:
 jobs:
   lint:
     name: Run Nitrogen for example module (react-native-nitro-image)
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro",
-  "packageManager": "bun@1.1.21",
+  "packageManager": "bun@1.1.42",
   "private": true,
   "version": "0.20.1",
   "repository": "https://github.com/mrousavy/nitro.git",

--- a/packages/nitrogen/src/autolinking/android/createCMakeExtension.ts
+++ b/packages/nitrogen/src/autolinking/android/createCMakeExtension.ts
@@ -1,5 +1,5 @@
 import { NitroConfig } from '../../config/NitroConfig.js'
-import { indent } from '../../utils.js'
+import { indent, toUnixPath } from '../../utils.js'
 import {
   createFileMetadataString,
   getRelativeDirectory,
@@ -17,13 +17,16 @@ export function createCMakeExtension(files: SourceFile[]): CMakeFile {
   const sharedFiles = files
     .filter((f) => f.platform === 'shared' && isCppFile(f))
     .map((f) => getRelativeDirectory(f))
+    .map((p) => toUnixPath(p))
   const androidFiles = files
     .filter((f) => f.platform === 'android' && isCppFile(f))
     .map((f) => getRelativeDirectory(f))
-  const autolinkingFile = getRelativeDirectoryGenerated(
+    .map((p) => toUnixPath(p))
+  const autolinkingFilePath = getRelativeDirectoryGenerated(
     'android',
     `${name}OnLoad.cpp`
   )
+  const autolinkingFile = toUnixPath(autolinkingFilePath)
 
   const code = `
 ${createFileMetadataString(`${name}+autolinking.cmake`, '#')}

--- a/packages/nitrogen/src/nitrogen.ts
+++ b/packages/nitrogen/src/nitrogen.ts
@@ -46,7 +46,7 @@ export async function runNitrogen({
   })
 
   const ignorePaths = NitroConfig.getIgnorePaths()
-  const globPattern = [path.join(baseDirectory, '/**/*.nitro.ts')]
+  const globPattern = [path.join(baseDirectory, '**', '*.nitro.ts')]
   ignorePaths.forEach((ignorePath) => {
     globPattern.push('!' + path.join(baseDirectory, ignorePath))
   })
@@ -69,7 +69,7 @@ export async function runNitrogen({
   // If no source files are found, we can exit
   if (project.getSourceFiles().length === 0) {
     const searchDir = prettifyDirectory(
-      path.join(path.resolve(baseDirectory), '**/*.nitro.ts')
+      path.join(path.resolve(baseDirectory), '**', '*.nitro.ts')
     )
     console.log(
       `❌  Nitrogen didn't find any spec files in ${chalk.underline(searchDir)}! ` +

--- a/packages/nitrogen/src/utils.ts
+++ b/packages/nitrogen/src/utils.ts
@@ -50,6 +50,12 @@ export function escapeComments(string: string): string {
     .replace(/\/\//g, '/ /') // Escape single-line comment
 }
 
+const HAS_UNIX_PATHS = path.join('a', 'b').includes('/')
+export function toUnixPath(p: string): string {
+  if (HAS_UNIX_PATHS) return p
+  return p.replaceAll('\\', '/')
+}
+
 function getFullPath(file: SourceFile): string {
   return path.join(
     file.platform,

--- a/packages/react-native-nitro-modules/package.json
+++ b/packages/react-native-nitro-modules/package.json
@@ -117,7 +117,6 @@
       [
         "typescript",
         {
-          "tsc": "../../node_modules/.bin/tsc",
           "project": "tsconfig.build.json"
         }
       ]

--- a/packages/react-native-nitro-modules/package.json
+++ b/packages/react-native-nitro-modules/package.json
@@ -117,6 +117,7 @@
       [
         "typescript",
         {
+          "tsc": "../../node_modules/.bin/tsc",
           "project": "tsconfig.build.json"
         }
       ]


### PR DESCRIPTION
Fixes Windows support for Android codegen