### PR TITLE
fix: Filter out duplicates for CMake extension

### DIFF
--- a/packages/nitrogen/src/autolinking/android/createCMakeExtension.ts
+++ b/packages/nitrogen/src/autolinking/android/createCMakeExtension.ts
@@ -5,6 +5,7 @@ import {
   getRelativeDirectory,
   getRelativeDirectoryGenerated,
   isCppFile,
+  isNotDuplicate,
 } from '../../syntax/helpers.js'
 import type { SourceFile } from '../../syntax/SourceFile.js'
 
@@ -18,10 +19,12 @@ export function createCMakeExtension(files: SourceFile[]): CMakeFile {
     .filter((f) => f.platform === 'shared' && isCppFile(f))
     .map((f) => getRelativeDirectory(f))
     .map((p) => toUnixPath(p))
+    .filter(isNotDuplicate)
   const androidFiles = files
     .filter((f) => f.platform === 'android' && isCppFile(f))
     .map((f) => getRelativeDirectory(f))
     .map((p) => toUnixPath(p))
+    .filter(isNotDuplicate)
   const autolinkingFilePath = getRelativeDirectoryGenerated(
     'android',
     `${name}OnLoad.cpp`


### PR DESCRIPTION
Apparently we sometimes have duplicates: https://github.com/jobpaardekooper/react-native-localize-date/blob/64226aa98a4bc5d6a1c04c28569133df48b20f0c/nitrogen/generated/android/NitroLocalizeDate%2Bautolinking.cmake#L24-L35