### PR TITLE
feat: Throw a better error message when using wrong imports

### DIFF
--- a/packages/nitrogen/src/syntax/createType.ts
+++ b/packages/nitrogen/src/syntax/createType.ts
@@ -336,9 +336,19 @@ export function createType(
         `String literal ${type.getText()} cannot be represented in C++ because it is ambiguous between a string and a discriminating union enum.`
       )
     } else {
-      throw new Error(
-        `The TypeScript type "${type.getText()}" cannot be represented in C++!`
-      )
+      if (type.getSymbol() == null) {
+        // There is no declaration for it!
+        // Could be an invalid import, e.g. an alias
+        throw new Error(
+          `The TypeScript type "${type.getText()}" cannot be resolved - is it imported properly? ` +
+            `Make sure to import it properly using fully specified relative or absolute imports, no aliases.`
+        )
+      } else {
+        // A different error
+        throw new Error(
+          `The TypeScript type "${type.getText()}" cannot be represented in C++!`
+        )
+      }
     }
   }
 


### PR DESCRIPTION
When doing this:

```ts
import { SomeType } from '@src/SomeType'
```

Nitrogen might not know where to import `SomeType` from because `@src` is a path alias created from the user's `tsconfig.json`.

Nitrogen does not use the user's `tsconfig.json` though, so it has to be imported like this instead:

```ts
import { SomeType } from '../SomeType'
```

This will work.

This PR now throws a better error message in these situations:

```diff
- The TypeScript type "SomeType" cannot be represented in C++!
+ The TypeScript type "SomeType" cannot be resolved - is it imported properly? Make sure to import it properly using fully specified relative or absolute imports, no aliases.
```

- Closes #457