### PR TITLE
Updated the Math interface example in the Nitro Modules documentation.

### DIFF
--- a/docs/docs/using-nitro-in-a-library.md
+++ b/docs/docs/using-nitro-in-a-library.md
@@ -25,6 +25,8 @@ Each Hybrid Object you want to initialize from JS has to be registered in Nitro 
 Lastly, you can initialize and use the registered Hybrid Objects from JS. This is what this will ultimately look like:
 
 ```ts
+import type { HybridObject } from 'react-native-nitro-modules'
+
 interface Math extends HybridObject {
   add(a: number, b: number): number
 }


### PR DESCRIPTION
This PR updates the Math interface example in the Nitro Modules documentation by adding a missing HybridObject import. Without the explicit import, users copying the example could encounter errors, as HybridObject would not be recognized.

Error without import

![image](https://github.com/user-attachments/assets/b36ff21f-cefa-4249-8e2e-e8e5c63f775e)


