### PR TITLE
feat: New Callback implementation that extends `() -> T` in Kotlin (faster!)

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1888,11 +1888,11 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   FBLazyVector: 1bf99bb46c6af9a2712592e707347315f23947aa
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: 06a9c6900587420b90accc394199527c64259db4
   NitroImage: b49db0212f1b50aa976b8cdd97072df904b29102
   NitroModules: ff8680342cb7008646d8160ff9b30ba74c681c11

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -960,6 +960,11 @@ export function getTests(
           })
         ).didThrow()
     ),
+    createTest('Getting complex callback from native returns a function', () =>
+      it(() => testObject.getComplexCallback())
+        .didNotThrow()
+        .didReturn('function')
+    ),
 
     // Objects
     createTest('getCar()', () =>

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -296,6 +296,20 @@ export function getTests(
         .didReturn(typeof OldEnum.SECOND)
         .equals(OldEnum.SECOND)
     ),
+    createTest('set optionalCallback, then undefined', () =>
+      it(() => {
+        testObject.optionalCallback = () => {}
+        testObject.optionalCallback = undefined
+      }).didNotThrow()
+    ),
+    createTest('get optionalCallback (== self)', () =>
+      it(() => {
+        testObject.optionalCallback = () => {}
+        return testObject.optionalCallback
+      })
+        .didNotThrow()
+        .didReturn('function')
+    ),
 
     // Test basic functions
     createTest('addNumbers(5, 13) = 18', () =>

--- a/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
@@ -255,13 +255,6 @@ static const auto method = _javaPart->getClass()->getMethod<${cxxSignature}>("${
 method(${paramsForward.join(', ')});
    `
   }
-  body = `
-try {
-  ${indent(body, '  ')}
-} catch (const jni::JniException& exc) {
-  throw std::runtime_error(exc.what());
-}
-  `.trim()
   const code = method.getCode(
     'c++',
     {

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -37,6 +37,9 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
 
   get needsSpecialHandling(): boolean {
     switch (this.type.kind) {
+      case 'function':
+        // Function needs to be converted from JFunc_... to Lambda
+        return true
       default:
         return false
     }

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -41,8 +41,20 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
         // Function needs to be converted from JFunc_... to Lambda
         return true
       default:
-        return false
+        break
     }
+    // check if any types this type references (e.g. underlying optional, array element, ...)
+    // needs special handling. if yes, we need it as well
+    const referencedTypes = getReferencedTypes(this.type)
+      .filter((t) => t !== this.type)
+      .map((t) => new KotlinCxxBridgedType(t))
+    for (const type of referencedTypes) {
+      if (type.needsSpecialHandling) {
+        return true
+      }
+    }
+    // no special handling needed
+    return false
   }
 
   getRequiredImports(): SourceImport[] {

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -219,9 +219,10 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
           return this.type.getCode(language)
         }
       case 'array':
+        const array = getTypeAs(this.type, ArrayType)
+        const bridgedItem = new KotlinCxxBridgedType(array.itemType)
         switch (language) {
           case 'c++':
-            const array = getTypeAs(this.type, ArrayType)
             switch (array.itemType.kind) {
               case 'number':
                 return 'jni::JArrayDouble'
@@ -230,9 +231,10 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
               case 'bigint':
                 return 'jni::JArrayLong'
               default:
-                const bridged = new KotlinCxxBridgedType(array.itemType)
-                return `jni::JArrayClass<${bridged.getTypeCode(language)}>`
+                return `jni::JArrayClass<${bridgedItem.getTypeCode(language)}>`
             }
+          case 'kotlin':
+            return `Array<${bridgedItem.getTypeCode(language)}>`
           default:
             return this.type.getCode(language)
         }
@@ -328,9 +330,12 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
             return this.type.getCode(language)
         }
       case 'optional': {
+        const optional = getTypeAs(this.type, OptionalType)
+        const bridgedWrappingType = new KotlinCxxBridgedType(
+          optional.wrappingType
+        )
         switch (language) {
           case 'c++':
-            const optional = getTypeAs(this.type, OptionalType)
             switch (optional.wrappingType.kind) {
               // primitives need to be boxed to make them nullable
               case 'number':
@@ -340,9 +345,10 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
                 return boxed
               default:
                 // all other types can be nullable as they are objects.
-                const bridge = new KotlinCxxBridgedType(optional.wrappingType)
-                return bridge.getTypeCode('c++')
+                return bridgedWrappingType.getTypeCode('c++')
             }
+          case 'kotlin':
+            return `${bridgedWrappingType.getTypeCode(language)}?`
           default:
             return this.type.getCode(language)
         }
@@ -457,6 +463,12 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
         switch (language) {
           case 'c++':
             return `${parameterName}.has_value() ? ${bridge.parseFromCppToKotlin(`${parameterName}.value()`, 'c++', true)} : nullptr`
+          case 'kotlin':
+            if (bridge.needsSpecialHandling) {
+              return `${parameterName}?.let { ${bridge.parseFromCppToKotlin('it', language, isBoxed)} }`
+            } else {
+              return parameterName
+            }
           default:
             return parameterName
         }
@@ -503,11 +515,11 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
         }
       }
       case 'array': {
+        const array = getTypeAs(this.type, ArrayType)
+        const arrayType = this.getTypeCode('c++')
+        const bridge = new KotlinCxxBridgedType(array.itemType)
         switch (language) {
           case 'c++': {
-            const array = getTypeAs(this.type, ArrayType)
-            const arrayType = this.getTypeCode('c++')
-            const bridge = new KotlinCxxBridgedType(array.itemType)
             switch (array.itemType.kind) {
               case 'number':
               case 'boolean':
@@ -531,7 +543,7 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
   jni::local_ref<${arrayType}> __array = ${arrayType}::newArray(__size);
   for (size_t __i = 0; __i < __size; __i++) {
     const auto& __element = ${parameterName}[__i];
-    __array->setElement(__i, *${bridge.parseFromCppToKotlin('__element', 'c++')});
+    __array->setElement(__i, *${indent(bridge.parseFromCppToKotlin('__element', 'c++'), '    ')});
   }
   return __array;
 }()
@@ -539,6 +551,12 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
               }
             }
           }
+          case 'kotlin':
+            if (bridge.needsSpecialHandling) {
+              return `${parameterName}.map { ${bridge.parseFromCppToKotlin('it', language, isBoxed)} }`
+            } else {
+              return parameterName
+            }
           default:
             return parameterName
         }

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -442,7 +442,7 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
             const func = getTypeAs(this.type, FunctionType)
             return `J${func.specializationName}_cxx::fromCpp(${parameterName})`
           case 'kotlin':
-            return `${parameterName} /* TODO: Does this work? */`
+            return parameterName
           default:
             return parameterName
         }

--- a/packages/nitrogen/src/syntax/kotlin/KotlinEnum.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinEnum.ts
@@ -60,6 +60,7 @@ namespace ${cxxNamespace} {
      * Convert this Java/Kotlin-based enum to the C++ enum ${enumType.enumName}.
      */
     [[maybe_unused]]
+    [[nodiscard]]
     ${enumType.enumName} toCpp() const {
       static const auto clazz = javaClassStatic();
       static const auto fieldOrdinal = clazz->getField<int>("_ordinal");

--- a/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
@@ -186,6 +186,9 @@ namespace ${cxxNamespace} {
     static auto constexpr kJavaDescriptor = "L${jniInterfaceDescriptor};";
 
   public:
+    /**
+     * Invokes the function this \`J${name}\` instance holds through JNI.
+     */
     ${functionType.returnType.getCode('c++')} invoke(${jniParams.join(', ')}) const {
       ${indent(jniCallBody, '      ')}
     }
@@ -201,6 +204,9 @@ namespace ${cxxNamespace} {
     }
 
   public:
+    /**
+     * Invokes the C++ \`std::function<...>\` this \`J${name}_cxx\` instance holds.
+     */
     ${bridgedReturn.asJniReferenceType('local')} invoke_cxx(${cppParams.join(', ')}) {
       ${indent(cppCallBody, '      ')}
     }

--- a/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
@@ -33,7 +33,7 @@ import dalvik.annotation.optimization.FastNative
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused")
+@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
 class ${name} {
   @DoNotStrip
   @Keep

--- a/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
@@ -196,7 +196,7 @@ namespace ${cxxNamespace} {
    */
   struct J${name}_cxx final: public jni::HybridClass<J${name}_cxx, J${name}> {
   public:
-    static jni::local_ref<J${name}_cxx::javaobject> fromCpp(const ${typename}& func) {
+    static jni::local_ref<J${name}::javaobject> fromCpp(const ${typename}& func) {
       return J${name}_cxx::newObjectCxxArgs(func);
     }
 

--- a/packages/nitrogen/src/syntax/kotlin/KotlinHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinHybridObject.ts
@@ -53,7 +53,7 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "RedundantSuppression", "RedundantUnitReturnType",
+  "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class ${name.HybridTSpec}: ${kotlinBase}() {

--- a/packages/nitrogen/src/syntax/kotlin/KotlinHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinHybridObject.ts
@@ -53,8 +53,8 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "LocalVariableName", "PropertyName", "FunctionName",
-  "RedundantSuppression", "RedundantUnitReturnType"
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class ${name.HybridTSpec}: ${kotlinBase}() {
   @DoNotStrip

--- a/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
@@ -61,9 +61,12 @@ import com.margelo.nitro.core.*
  */
 @DoNotStrip
 @Keep
-data class ${structType.structName}(
-  ${indent(values.join(',\n'), '  ')}
-) {
+data class ${structType.structName}
+  @DoNotStrip
+  @Keep
+  constructor(
+    ${indent(values.join(',\n'), '    ')}
+  ) {
   ${indent(secondaryConstructor, '  ')}
 }
   `.trim()

--- a/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
@@ -101,6 +101,7 @@ namespace ${cxxNamespace} {
      * Convert this Java/Kotlin-based struct to the C++ struct ${structType.structName} by copying all values to C++.
      */
     [[maybe_unused]]
+    [[nodiscard]]
     ${structType.structName} toCpp() const {
       ${indent(jniStructInitializerBody, '      ')}
     }

--- a/packages/nitrogen/src/syntax/types/FunctionType.ts
+++ b/packages/nitrogen/src/syntax/types/FunctionType.ts
@@ -113,7 +113,7 @@ export class FunctionType implements Type {
           })
           .join(', ')
         const returnType = this.returnType.getCode(language)
-        return `((${params}) -> ${returnType})`
+        return `(${params}) -> ${returnType}`
       }
       case 'kotlin': {
         const params = this.parameters

--- a/packages/nitrogen/src/syntax/types/OptionalType.ts
+++ b/packages/nitrogen/src/syntax/types/OptionalType.ts
@@ -16,6 +16,14 @@ export class OptionalType implements Type {
   get kind(): TypeKind {
     return 'optional'
   }
+  get needsBraces(): boolean {
+    switch (this.wrappingType.kind) {
+      case 'function':
+        return true
+      default:
+        return false
+    }
+  }
 
   getCode(language: Language): string {
     const wrapping = this.wrappingType.getCode(language)
@@ -23,9 +31,17 @@ export class OptionalType implements Type {
       case 'c++':
         return `std::optional<${wrapping}>`
       case 'swift':
-        return `${wrapping}?`
+        if (this.needsBraces) {
+          return `(${wrapping})?`
+        } else {
+          return `${wrapping}?`
+        }
       case 'kotlin':
-        return `${wrapping}?`
+        if (this.needsBraces) {
+          return `(${wrapping})?`
+        } else {
+          return `${wrapping}?`
+        }
       default:
         throw new Error(
           `Language ${language} is not yet supported for OptionalType!`

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -219,6 +219,12 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
     }
   }
 
+  override fun getComplexCallback(): (Double) -> Unit {
+    return { value
+        Log.i(TAG, "Callback called with $value.")
+    }
+  }
+
     override fun getCar(): Car {
         return Car(2018.0, "Lamborghini", "Huracán", 640.0, Powertrain.GAS, null, true)
     }

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -28,6 +28,7 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
     override var optionalArray: Array<String>? = null
     override var optionalEnum: Powertrain? = null
     override var optionalOldEnum: OldEnum? = null
+    override var optionalCallback: ((value: Double) -> Unit)? = null
 
     override fun simpleFunc() {
         // do nothing

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -220,7 +220,7 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
   }
 
   override fun getComplexCallback(): (Double) -> Unit {
-    return { value
+    return { value ->
         Log.i(TAG, "Callback called with $value.")
     }
   }

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -125,6 +125,14 @@ void HybridTestObjectCpp::setOptionalOldEnum(std::optional<OldEnum> optionalOldE
   _optionalOldEnum = optionalOldEnum;
 }
 
+std::optional<std::function<void(double)>> HybridTestObjectCpp::getOptionalCallback() {
+  return _optionalCallback;
+}
+
+void HybridTestObjectCpp::setOptionalCallback(const std::optional<std::function<void(double)>>& callback) {
+  _optionalCallback = callback;
+}
+
 // Methods
 double HybridTestObjectCpp::addNumbers(double a, double b) {
   return a + b;

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -318,6 +318,12 @@ std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> HybridTestObjectCpp::call
   });
 }
 
+std::function<void(double)> HybridTestObjectCpp::getComplexCallback() {
+  return [](double value) {
+    Logger::log(LogLevel::Info, TAG, "Callback called with %f", value);
+  };
+}
+
 std::shared_ptr<Promise<double>>
 HybridTestObjectCpp::getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) {
   return Promise<double>::async([=]() -> double {

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -319,9 +319,7 @@ std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> HybridTestObjectCpp::call
 }
 
 std::function<void(double)> HybridTestObjectCpp::getComplexCallback() {
-  return [](double value) {
-    Logger::log(LogLevel::Info, TAG, "Callback called with %f", value);
-  };
+  return [](double value) { Logger::log(LogLevel::Info, TAG, "Callback called with %f", value); };
 }
 
 std::shared_ptr<Promise<double>>

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -120,6 +120,8 @@ public:
   callbackAsyncPromise(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& callback) override;
   std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> callbackAsyncPromiseBuffer(
       const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& callback) override;
+  std::function<void(double)> getComplexCallback() override;
+  
   std::shared_ptr<Promise<void>>
   getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback,
                          const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) override;

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -30,6 +30,7 @@ private:
   std::optional<std::shared_ptr<HybridTestObjectCppSpec>> _optionalHybrid;
   std::optional<Powertrain> _optionalEnum;
   std::optional<OldEnum> _optionalOldEnum;
+  std::optional<std::function<void(double)>> _optionalCallback;
 
 private:
   static inline uint64_t calculateFibonacci(int count) noexcept {
@@ -70,6 +71,8 @@ public:
   void setOptionalEnum(std::optional<Powertrain> optionalEnum) override;
   std::optional<OldEnum> getOptionalOldEnum() override;
   void setOptionalOldEnum(std::optional<OldEnum> optionalOldEnum) override;
+  std::optional<std::function<void(double)>> getOptionalCallback() override;
+  void setOptionalCallback(const std::optional<std::function<void(double)>>& callback) override;
 
 public:
   // Methods

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -121,7 +121,7 @@ public:
   std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> callbackAsyncPromiseBuffer(
       const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& callback) override;
   std::function<void(double)> getComplexCallback() override;
-  
+
   std::shared_ptr<Promise<void>>
   getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback,
                          const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) override;

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -100,6 +100,9 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     }
   }
 
+  func getComplexCallback() throws -> (Double) -> Void {
+    return { value in print("Callback called with \(value).") }
+  }
 
   func bounceStrings(array: [String]) throws -> [String] {
     return array

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -33,6 +33,8 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
 
   var optionalOldEnum: OldEnum? = nil
 
+  var optionalCallback: ((Double) -> Void)? = nil
+
   func simpleFunc() throws {
     // do nothing
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -43,24 +43,24 @@ int initialize(JavaVM* vm) {
   return facebook::jni::initialize(vm, [] {
     // Register native JNI methods
     margelo::nitro::image::JHybridImageSpec::registerNatives();
-    margelo::nitro::image::JFunc_void_std__string::registerNatives();
+    margelo::nitro::image::JFunc_void_std__string_cxx::registerNatives();
     margelo::nitro::image::JHybridImageFactorySpec::registerNatives();
     margelo::nitro::image::JHybridTestObjectSwiftKotlinSpec::registerNatives();
-    margelo::nitro::image::JFunc_void_double::registerNatives();
-    margelo::nitro::image::JFunc_void_double::registerNatives();
-    margelo::nitro::image::JFunc_void_std__vector_Powertrain_::registerNatives();
-    margelo::nitro::image::JFunc_void::registerNatives();
-    margelo::nitro::image::JFunc_void::registerNatives();
-    margelo::nitro::image::JFunc_void::registerNatives();
-    margelo::nitro::image::JFunc_void::registerNatives();
-    margelo::nitro::image::JFunc_void_std__optional_double_::registerNatives();
-    margelo::nitro::image::JFunc_std__shared_ptr_Promise_double__::registerNatives();
-    margelo::nitro::image::JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::registerNatives();
-    margelo::nitro::image::JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::registerNatives();
-    margelo::nitro::image::JFunc_std__shared_ptr_Promise_double__::registerNatives();
-    margelo::nitro::image::JFunc_std__shared_ptr_Promise_std__string__::registerNatives();
-    margelo::nitro::image::JFunc_void_std__string::registerNatives();
-    margelo::nitro::image::JFunc_void_double::registerNatives();
+    margelo::nitro::image::JFunc_void_double_cxx::registerNatives();
+    margelo::nitro::image::JFunc_void_double_cxx::registerNatives();
+    margelo::nitro::image::JFunc_void_std__vector_Powertrain__cxx::registerNatives();
+    margelo::nitro::image::JFunc_void_cxx::registerNatives();
+    margelo::nitro::image::JFunc_void_cxx::registerNatives();
+    margelo::nitro::image::JFunc_void_cxx::registerNatives();
+    margelo::nitro::image::JFunc_void_cxx::registerNatives();
+    margelo::nitro::image::JFunc_void_std__optional_double__cxx::registerNatives();
+    margelo::nitro::image::JFunc_std__shared_ptr_Promise_double___cxx::registerNatives();
+    margelo::nitro::image::JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx::registerNatives();
+    margelo::nitro::image::JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx::registerNatives();
+    margelo::nitro::image::JFunc_std__shared_ptr_Promise_double___cxx::registerNatives();
+    margelo::nitro::image::JFunc_std__shared_ptr_Promise_std__string___cxx::registerNatives();
+    margelo::nitro::image::JFunc_void_std__string_cxx::registerNatives();
+    margelo::nitro::image::JFunc_void_double_cxx::registerNatives();
     margelo::nitro::image::JHybridBaseSpec::registerNatives();
     margelo::nitro::image::JHybridChildSpec::registerNatives();
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -47,6 +47,7 @@ int initialize(JavaVM* vm) {
     margelo::nitro::image::JHybridImageFactorySpec::registerNatives();
     margelo::nitro::image::JHybridTestObjectSwiftKotlinSpec::registerNatives();
     margelo::nitro::image::JFunc_void_double::registerNatives();
+    margelo::nitro::image::JFunc_void_double::registerNatives();
     margelo::nitro::image::JFunc_void_std__vector_Powertrain_::registerNatives();
     margelo::nitro::image::JFunc_void::registerNatives();
     margelo::nitro::image::JFunc_void::registerNatives();

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -19,6 +19,7 @@
 #include "JFunc_void_std__string.hpp"
 #include "JHybridImageFactorySpec.hpp"
 #include "JHybridTestObjectSwiftKotlinSpec.hpp"
+#include "JFunc_void_double.hpp"
 #include "JFunc_void_std__vector_Powertrain_.hpp"
 #include "JFunc_void.hpp"
 #include "JFunc_void_std__optional_double_.hpp"
@@ -26,7 +27,6 @@
 #include "JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.hpp"
 #include "JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.hpp"
 #include "JFunc_std__shared_ptr_Promise_std__string__.hpp"
-#include "JFunc_void_double.hpp"
 #include "JHybridBaseSpec.hpp"
 #include "JHybridChildSpec.hpp"
 #include <NitroModules/JNISharedPtr.hpp>
@@ -46,6 +46,7 @@ int initialize(JavaVM* vm) {
     margelo::nitro::image::JFunc_void_std__string::registerNatives();
     margelo::nitro::image::JHybridImageFactorySpec::registerNatives();
     margelo::nitro::image::JHybridTestObjectSwiftKotlinSpec::registerNatives();
+    margelo::nitro::image::JFunc_void_double::registerNatives();
     margelo::nitro::image::JFunc_void_std__vector_Powertrain_::registerNatives();
     margelo::nitro::image::JFunc_void::registerNatives();
     margelo::nitro::image::JFunc_void::registerNatives();

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JCar.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JCar.hpp
@@ -33,6 +33,7 @@ namespace margelo::nitro::image {
      * Convert this Java/Kotlin-based struct to the C++ struct Car by copying all values to C++.
      */
     [[maybe_unused]]
+    [[nodiscard]]
     Car toCpp() const {
       static const auto clazz = javaClassStatic();
       static const auto fieldYear = clazz->getField<double>("year");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_double__.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_double__.hpp
@@ -19,17 +19,43 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * C++ representation of the callback Func_std__shared_ptr_Promise_double__.
-   * This is a Kotlin `() -> Promise<Double>`, backed by a `std::function<...>`.
+   * Represents the Java/Kotlin callback `() -> Promise<Double>`.
+   * This can be passed around between C++ and Java/Kotlin.
    */
-  struct JFunc_std__shared_ptr_Promise_double__ final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_double__> {
+  struct JFunc_std__shared_ptr_Promise_double__: public jni::JavaClass<JFunc_std__shared_ptr_Promise_double__> {
   public:
-    static jni::local_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<double>>()>& func) {
-      return JFunc_std__shared_ptr_Promise_double__::newObjectCxxArgs(func);
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_double__;";
+
+  public:
+    std::shared_ptr<Promise<double>> invoke() const {
+      static const auto method = getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("invoke");
+      auto __result = method(self());
+      return [&]() {
+        auto __promise = Promise<double>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+          __promise->resolve(__result->value());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+    }
+  };
+
+  /**
+   * An implementation of Func_std__shared_ptr_Promise_double__ that is backed by a C++ implementation (using `std::function<...>`)
+   */
+  struct JFunc_std__shared_ptr_Promise_double___cxx final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_double___cxx, JFunc_std__shared_ptr_Promise_double__> {
+  public:
+    static jni::local_ref<JFunc_std__shared_ptr_Promise_double___cxx::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<double>>()>& func) {
+      return JFunc_std__shared_ptr_Promise_double___cxx::newObjectCxxArgs(func);
     }
 
   public:
-    jni::local_ref<JPromise::javaobject> call() {
+    jni::local_ref<JPromise::javaobject> invoke_cxx() {
       std::shared_ptr<Promise<double>> __result = _func();
       return [&]() {
         jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
@@ -46,18 +72,19 @@ namespace margelo::nitro::image {
     }
 
   public:
+    [[nodiscard]]
     inline const std::function<std::shared_ptr<Promise<double>>()>& getFunction() const {
       return _func;
     }
 
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_double__;";
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_double___cxx;";
     static void registerNatives() {
-      registerHybrid({makeNativeMethod("call", JFunc_std__shared_ptr_Promise_double__::call)});
+      registerHybrid({makeNativeMethod("invoke", JFunc_std__shared_ptr_Promise_double___cxx::invoke_cxx)});
     }
 
   private:
-    explicit JFunc_std__shared_ptr_Promise_double__(const std::function<std::shared_ptr<Promise<double>>()>& func): _func(func) { }
+    explicit JFunc_std__shared_ptr_Promise_double___cxx(const std::function<std::shared_ptr<Promise<double>>()>& func): _func(func) { }
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_double__.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_double__.hpp
@@ -50,7 +50,7 @@ namespace margelo::nitro::image {
    */
   struct JFunc_std__shared_ptr_Promise_double___cxx final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_double___cxx, JFunc_std__shared_ptr_Promise_double__> {
   public:
-    static jni::local_ref<JFunc_std__shared_ptr_Promise_double___cxx::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<double>>()>& func) {
+    static jni::local_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<double>>()>& func) {
       return JFunc_std__shared_ptr_Promise_double___cxx::newObjectCxxArgs(func);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_double__.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_double__.hpp
@@ -27,6 +27,9 @@ namespace margelo::nitro::image {
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_double__;";
 
   public:
+    /**
+     * Invokes the function this `JFunc_std__shared_ptr_Promise_double__` instance holds through JNI.
+     */
     std::shared_ptr<Promise<double>> invoke() const {
       static const auto method = getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("invoke");
       auto __result = method(self());
@@ -55,6 +58,9 @@ namespace margelo::nitro::image {
     }
 
   public:
+    /**
+     * Invokes the C++ `std::function<...>` this `JFunc_std__shared_ptr_Promise_double___cxx` instance holds.
+     */
     jni::local_ref<JPromise::javaobject> invoke_cxx() {
       std::shared_ptr<Promise<double>> __result = _func();
       return [&]() {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.hpp
@@ -19,17 +19,54 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * C++ representation of the callback Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.
-   * This is a Kotlin `() -> Promise<Promise<Double>>`, backed by a `std::function<...>`.
+   * Represents the Java/Kotlin callback `() -> Promise<Promise<Double>>`.
+   * This can be passed around between C++ and Java/Kotlin.
    */
-  struct JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____> {
+  struct JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____: public jni::JavaClass<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____> {
   public:
-    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& func) {
-      return JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::newObjectCxxArgs(func);
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____;";
+
+  public:
+    std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> invoke() const {
+      static const auto method = getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("invoke");
+      auto __result = method(self());
+      return [&]() {
+        auto __promise = Promise<std::shared_ptr<Promise<double>>>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<JPromise::javaobject>(__boxedResult);
+          __promise->resolve([&]() {
+            auto __promise = Promise<double>::create();
+            __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+              auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+              __promise->resolve(__result->value());
+            });
+            __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+              jni::JniException __jniError(__throwable);
+              __promise->reject(std::make_exception_ptr(__jniError));
+            });
+            return __promise;
+          }());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+    }
+  };
+
+  /**
+   * An implementation of Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ that is backed by a C++ implementation (using `std::function<...>`)
+   */
+  struct JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____> {
+  public:
+    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& func) {
+      return JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx::newObjectCxxArgs(func);
     }
 
   public:
-    jni::local_ref<JPromise::javaobject> call() {
+    jni::local_ref<JPromise::javaobject> invoke_cxx() {
       std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> __result = _func();
       return [&]() {
         jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
@@ -57,18 +94,19 @@ namespace margelo::nitro::image {
     }
 
   public:
+    [[nodiscard]]
     inline const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& getFunction() const {
       return _func;
     }
 
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____;";
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx;";
     static void registerNatives() {
-      registerHybrid({makeNativeMethod("call", JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::call)});
+      registerHybrid({makeNativeMethod("invoke", JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx::invoke_cxx)});
     }
 
   private:
-    explicit JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& func): _func(func) { }
+    explicit JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& func): _func(func) { }
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.hpp
@@ -61,7 +61,7 @@ namespace margelo::nitro::image {
    */
   struct JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____> {
   public:
-    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& func) {
+    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& func) {
       return JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx::newObjectCxxArgs(func);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.hpp
@@ -27,6 +27,9 @@ namespace margelo::nitro::image {
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____;";
 
   public:
+    /**
+     * Invokes the function this `JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____` instance holds through JNI.
+     */
     std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> invoke() const {
       static const auto method = getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("invoke");
       auto __result = method(self());
@@ -66,6 +69,9 @@ namespace margelo::nitro::image {
     }
 
   public:
+    /**
+     * Invokes the C++ `std::function<...>` this `JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx` instance holds.
+     */
     jni::local_ref<JPromise::javaobject> invoke_cxx() {
       std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> __result = _func();
       return [&]() {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.hpp
@@ -22,17 +22,54 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * C++ representation of the callback Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.
-   * This is a Kotlin `() -> Promise<Promise<ArrayBuffer>>`, backed by a `std::function<...>`.
+   * Represents the Java/Kotlin callback `() -> Promise<Promise<ArrayBuffer>>`.
+   * This can be passed around between C++ and Java/Kotlin.
    */
-  struct JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____> {
+  struct JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____: public jni::JavaClass<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____> {
   public:
-    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& func) {
-      return JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::newObjectCxxArgs(func);
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____;";
+
+  public:
+    std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> invoke() const {
+      static const auto method = getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("invoke");
+      auto __result = method(self());
+      return [&]() {
+        auto __promise = Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<JPromise::javaobject>(__boxedResult);
+          __promise->resolve([&]() {
+            auto __promise = Promise<std::shared_ptr<ArrayBuffer>>::create();
+            __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+              auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
+              __promise->resolve(__result->cthis()->getArrayBuffer());
+            });
+            __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+              jni::JniException __jniError(__throwable);
+              __promise->reject(std::make_exception_ptr(__jniError));
+            });
+            return __promise;
+          }());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+    }
+  };
+
+  /**
+   * An implementation of Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ that is backed by a C++ implementation (using `std::function<...>`)
+   */
+  struct JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____> {
+  public:
+    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& func) {
+      return JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx::newObjectCxxArgs(func);
     }
 
   public:
-    jni::local_ref<JPromise::javaobject> call() {
+    jni::local_ref<JPromise::javaobject> invoke_cxx() {
       std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> __result = _func();
       return [&]() {
         jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
@@ -60,18 +97,19 @@ namespace margelo::nitro::image {
     }
 
   public:
+    [[nodiscard]]
     inline const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& getFunction() const {
       return _func;
     }
 
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____;";
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx;";
     static void registerNatives() {
-      registerHybrid({makeNativeMethod("call", JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::call)});
+      registerHybrid({makeNativeMethod("invoke", JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx::invoke_cxx)});
     }
 
   private:
-    explicit JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& func): _func(func) { }
+    explicit JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& func): _func(func) { }
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.hpp
@@ -64,7 +64,7 @@ namespace margelo::nitro::image {
    */
   struct JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____> {
   public:
-    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& func) {
+    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& func) {
       return JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx::newObjectCxxArgs(func);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.hpp
@@ -30,6 +30,9 @@ namespace margelo::nitro::image {
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____;";
 
   public:
+    /**
+     * Invokes the function this `JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____` instance holds through JNI.
+     */
     std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> invoke() const {
       static const auto method = getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("invoke");
       auto __result = method(self());
@@ -69,6 +72,9 @@ namespace margelo::nitro::image {
     }
 
   public:
+    /**
+     * Invokes the C++ `std::function<...>` this `JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx` instance holds.
+     */
     jni::local_ref<JPromise::javaobject> invoke_cxx() {
       std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> __result = _func();
       return [&]() {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__string__.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__string__.hpp
@@ -51,7 +51,7 @@ namespace margelo::nitro::image {
    */
   struct JFunc_std__shared_ptr_Promise_std__string___cxx final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_std__string___cxx, JFunc_std__shared_ptr_Promise_std__string__> {
   public:
-    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__string___cxx::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::string>>()>& func) {
+    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__string__::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::string>>()>& func) {
       return JFunc_std__shared_ptr_Promise_std__string___cxx::newObjectCxxArgs(func);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__string__.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__string__.hpp
@@ -28,6 +28,9 @@ namespace margelo::nitro::image {
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__string__;";
 
   public:
+    /**
+     * Invokes the function this `JFunc_std__shared_ptr_Promise_std__string__` instance holds through JNI.
+     */
     std::shared_ptr<Promise<std::string>> invoke() const {
       static const auto method = getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("invoke");
       auto __result = method(self());
@@ -56,6 +59,9 @@ namespace margelo::nitro::image {
     }
 
   public:
+    /**
+     * Invokes the C++ `std::function<...>` this `JFunc_std__shared_ptr_Promise_std__string___cxx` instance holds.
+     */
     jni::local_ref<JPromise::javaobject> invoke_cxx() {
       std::shared_ptr<Promise<std::string>> __result = _func();
       return [&]() {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__string__.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_std__shared_ptr_Promise_std__string__.hpp
@@ -20,17 +20,43 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * C++ representation of the callback Func_std__shared_ptr_Promise_std__string__.
-   * This is a Kotlin `() -> Promise<String>`, backed by a `std::function<...>`.
+   * Represents the Java/Kotlin callback `() -> Promise<String>`.
+   * This can be passed around between C++ and Java/Kotlin.
    */
-  struct JFunc_std__shared_ptr_Promise_std__string__ final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_std__string__> {
+  struct JFunc_std__shared_ptr_Promise_std__string__: public jni::JavaClass<JFunc_std__shared_ptr_Promise_std__string__> {
   public:
-    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__string__::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::string>>()>& func) {
-      return JFunc_std__shared_ptr_Promise_std__string__::newObjectCxxArgs(func);
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__string__;";
+
+  public:
+    std::shared_ptr<Promise<std::string>> invoke() const {
+      static const auto method = getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("invoke");
+      auto __result = method(self());
+      return [&]() {
+        auto __promise = Promise<std::string>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<jni::JString>(__boxedResult);
+          __promise->resolve(__result->toStdString());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+    }
+  };
+
+  /**
+   * An implementation of Func_std__shared_ptr_Promise_std__string__ that is backed by a C++ implementation (using `std::function<...>`)
+   */
+  struct JFunc_std__shared_ptr_Promise_std__string___cxx final: public jni::HybridClass<JFunc_std__shared_ptr_Promise_std__string___cxx, JFunc_std__shared_ptr_Promise_std__string__> {
+  public:
+    static jni::local_ref<JFunc_std__shared_ptr_Promise_std__string___cxx::javaobject> fromCpp(const std::function<std::shared_ptr<Promise<std::string>>()>& func) {
+      return JFunc_std__shared_ptr_Promise_std__string___cxx::newObjectCxxArgs(func);
     }
 
   public:
-    jni::local_ref<JPromise::javaobject> call() {
+    jni::local_ref<JPromise::javaobject> invoke_cxx() {
       std::shared_ptr<Promise<std::string>> __result = _func();
       return [&]() {
         jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
@@ -47,18 +73,19 @@ namespace margelo::nitro::image {
     }
 
   public:
+    [[nodiscard]]
     inline const std::function<std::shared_ptr<Promise<std::string>>()>& getFunction() const {
       return _func;
     }
 
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__string__;";
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_std__shared_ptr_Promise_std__string___cxx;";
     static void registerNatives() {
-      registerHybrid({makeNativeMethod("call", JFunc_std__shared_ptr_Promise_std__string__::call)});
+      registerHybrid({makeNativeMethod("invoke", JFunc_std__shared_ptr_Promise_std__string___cxx::invoke_cxx)});
     }
 
   private:
-    explicit JFunc_std__shared_ptr_Promise_std__string__(const std::function<std::shared_ptr<Promise<std::string>>()>& func): _func(func) { }
+    explicit JFunc_std__shared_ptr_Promise_std__string___cxx(const std::function<std::shared_ptr<Promise<std::string>>()>& func): _func(func) { }
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void.hpp
@@ -17,33 +17,48 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * C++ representation of the callback Func_void.
-   * This is a Kotlin `() -> Unit`, backed by a `std::function<...>`.
+   * Represents the Java/Kotlin callback `() -> Unit`.
+   * This can be passed around between C++ and Java/Kotlin.
    */
-  struct JFunc_void final: public jni::HybridClass<JFunc_void> {
+  struct JFunc_void: public jni::JavaClass<JFunc_void> {
   public:
-    static jni::local_ref<JFunc_void::javaobject> fromCpp(const std::function<void()>& func) {
-      return JFunc_void::newObjectCxxArgs(func);
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void;";
+
+  public:
+    void invoke() const {
+      static const auto method = getClass()->getMethod<void()>("invoke");
+      method(self());
+    }
+  };
+
+  /**
+   * An implementation of Func_void that is backed by a C++ implementation (using `std::function<...>`)
+   */
+  struct JFunc_void_cxx final: public jni::HybridClass<JFunc_void_cxx, JFunc_void> {
+  public:
+    static jni::local_ref<JFunc_void_cxx::javaobject> fromCpp(const std::function<void()>& func) {
+      return JFunc_void_cxx::newObjectCxxArgs(func);
     }
 
   public:
-    void call() {
+    void invoke_cxx() {
       _func();
     }
 
   public:
+    [[nodiscard]]
     inline const std::function<void()>& getFunction() const {
       return _func;
     }
 
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void;";
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_cxx;";
     static void registerNatives() {
-      registerHybrid({makeNativeMethod("call", JFunc_void::call)});
+      registerHybrid({makeNativeMethod("invoke", JFunc_void_cxx::invoke_cxx)});
     }
 
   private:
-    explicit JFunc_void(const std::function<void()>& func): _func(func) { }
+    explicit JFunc_void_cxx(const std::function<void()>& func): _func(func) { }
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void.hpp
@@ -25,6 +25,9 @@ namespace margelo::nitro::image {
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void;";
 
   public:
+    /**
+     * Invokes the function this `JFunc_void` instance holds through JNI.
+     */
     void invoke() const {
       static const auto method = getClass()->getMethod<void()>("invoke");
       method(self());
@@ -41,6 +44,9 @@ namespace margelo::nitro::image {
     }
 
   public:
+    /**
+     * Invokes the C++ `std::function<...>` this `JFunc_void_cxx` instance holds.
+     */
     void invoke_cxx() {
       _func();
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void.hpp
@@ -36,7 +36,7 @@ namespace margelo::nitro::image {
    */
   struct JFunc_void_cxx final: public jni::HybridClass<JFunc_void_cxx, JFunc_void> {
   public:
-    static jni::local_ref<JFunc_void_cxx::javaobject> fromCpp(const std::function<void()>& func) {
+    static jni::local_ref<JFunc_void::javaobject> fromCpp(const std::function<void()>& func) {
       return JFunc_void_cxx::newObjectCxxArgs(func);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_double.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_double.hpp
@@ -17,33 +17,48 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * C++ representation of the callback Func_void_double.
-   * This is a Kotlin `(num: Double) -> Unit`, backed by a `std::function<...>`.
+   * Represents the Java/Kotlin callback `(num: Double) -> Unit`.
+   * This can be passed around between C++ and Java/Kotlin.
    */
-  struct JFunc_void_double final: public jni::HybridClass<JFunc_void_double> {
+  struct JFunc_void_double: public jni::JavaClass<JFunc_void_double> {
   public:
-    static jni::local_ref<JFunc_void_double::javaobject> fromCpp(const std::function<void(double /* num */)>& func) {
-      return JFunc_void_double::newObjectCxxArgs(func);
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_double;";
+
+  public:
+    void invoke(double num) const {
+      static const auto method = getClass()->getMethod<void(double /* num */)>("invoke");
+      method(self(), num);
+    }
+  };
+
+  /**
+   * An implementation of Func_void_double that is backed by a C++ implementation (using `std::function<...>`)
+   */
+  struct JFunc_void_double_cxx final: public jni::HybridClass<JFunc_void_double_cxx, JFunc_void_double> {
+  public:
+    static jni::local_ref<JFunc_void_double_cxx::javaobject> fromCpp(const std::function<void(double /* num */)>& func) {
+      return JFunc_void_double_cxx::newObjectCxxArgs(func);
     }
 
   public:
-    void call(double num) {
+    void invoke_cxx(double num) {
       _func(num);
     }
 
   public:
+    [[nodiscard]]
     inline const std::function<void(double /* num */)>& getFunction() const {
       return _func;
     }
 
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_double;";
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_double_cxx;";
     static void registerNatives() {
-      registerHybrid({makeNativeMethod("call", JFunc_void_double::call)});
+      registerHybrid({makeNativeMethod("invoke", JFunc_void_double_cxx::invoke_cxx)});
     }
 
   private:
-    explicit JFunc_void_double(const std::function<void(double /* num */)>& func): _func(func) { }
+    explicit JFunc_void_double_cxx(const std::function<void(double /* num */)>& func): _func(func) { }
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_double.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_double.hpp
@@ -25,6 +25,9 @@ namespace margelo::nitro::image {
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_double;";
 
   public:
+    /**
+     * Invokes the function this `JFunc_void_double` instance holds through JNI.
+     */
     void invoke(double num) const {
       static const auto method = getClass()->getMethod<void(double /* num */)>("invoke");
       method(self(), num);
@@ -41,6 +44,9 @@ namespace margelo::nitro::image {
     }
 
   public:
+    /**
+     * Invokes the C++ `std::function<...>` this `JFunc_void_double_cxx` instance holds.
+     */
     void invoke_cxx(double num) {
       _func(num);
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_double.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_double.hpp
@@ -36,7 +36,7 @@ namespace margelo::nitro::image {
    */
   struct JFunc_void_double_cxx final: public jni::HybridClass<JFunc_void_double_cxx, JFunc_void_double> {
   public:
-    static jni::local_ref<JFunc_void_double_cxx::javaobject> fromCpp(const std::function<void(double /* num */)>& func) {
+    static jni::local_ref<JFunc_void_double::javaobject> fromCpp(const std::function<void(double /* num */)>& func) {
       return JFunc_void_double_cxx::newObjectCxxArgs(func);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__optional_double_.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__optional_double_.hpp
@@ -37,7 +37,7 @@ namespace margelo::nitro::image {
    */
   struct JFunc_void_std__optional_double__cxx final: public jni::HybridClass<JFunc_void_std__optional_double__cxx, JFunc_void_std__optional_double_> {
   public:
-    static jni::local_ref<JFunc_void_std__optional_double__cxx::javaobject> fromCpp(const std::function<void(std::optional<double> /* maybe */)>& func) {
+    static jni::local_ref<JFunc_void_std__optional_double_::javaobject> fromCpp(const std::function<void(std::optional<double> /* maybe */)>& func) {
       return JFunc_void_std__optional_double__cxx::newObjectCxxArgs(func);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__optional_double_.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__optional_double_.hpp
@@ -18,33 +18,48 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * C++ representation of the callback Func_void_std__optional_double_.
-   * This is a Kotlin `(maybe: Double?) -> Unit`, backed by a `std::function<...>`.
+   * Represents the Java/Kotlin callback `(maybe: Double?) -> Unit`.
+   * This can be passed around between C++ and Java/Kotlin.
    */
-  struct JFunc_void_std__optional_double_ final: public jni::HybridClass<JFunc_void_std__optional_double_> {
+  struct JFunc_void_std__optional_double_: public jni::JavaClass<JFunc_void_std__optional_double_> {
   public:
-    static jni::local_ref<JFunc_void_std__optional_double_::javaobject> fromCpp(const std::function<void(std::optional<double> /* maybe */)>& func) {
-      return JFunc_void_std__optional_double_::newObjectCxxArgs(func);
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__optional_double_;";
+
+  public:
+    void invoke(std::optional<double> maybe) const {
+      static const auto method = getClass()->getMethod<void(jni::alias_ref<jni::JDouble> /* maybe */)>("invoke");
+      method(self(), maybe.has_value() ? jni::JDouble::valueOf(maybe.value()) : nullptr);
+    }
+  };
+
+  /**
+   * An implementation of Func_void_std__optional_double_ that is backed by a C++ implementation (using `std::function<...>`)
+   */
+  struct JFunc_void_std__optional_double__cxx final: public jni::HybridClass<JFunc_void_std__optional_double__cxx, JFunc_void_std__optional_double_> {
+  public:
+    static jni::local_ref<JFunc_void_std__optional_double__cxx::javaobject> fromCpp(const std::function<void(std::optional<double> /* maybe */)>& func) {
+      return JFunc_void_std__optional_double__cxx::newObjectCxxArgs(func);
     }
 
   public:
-    void call(jni::alias_ref<jni::JDouble> maybe) {
+    void invoke_cxx(jni::alias_ref<jni::JDouble> maybe) {
       _func(maybe != nullptr ? std::make_optional(maybe->value()) : std::nullopt);
     }
 
   public:
+    [[nodiscard]]
     inline const std::function<void(std::optional<double> /* maybe */)>& getFunction() const {
       return _func;
     }
 
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__optional_double_;";
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__optional_double__cxx;";
     static void registerNatives() {
-      registerHybrid({makeNativeMethod("call", JFunc_void_std__optional_double_::call)});
+      registerHybrid({makeNativeMethod("invoke", JFunc_void_std__optional_double__cxx::invoke_cxx)});
     }
 
   private:
-    explicit JFunc_void_std__optional_double_(const std::function<void(std::optional<double> /* maybe */)>& func): _func(func) { }
+    explicit JFunc_void_std__optional_double__cxx(const std::function<void(std::optional<double> /* maybe */)>& func): _func(func) { }
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__optional_double_.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__optional_double_.hpp
@@ -26,6 +26,9 @@ namespace margelo::nitro::image {
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__optional_double_;";
 
   public:
+    /**
+     * Invokes the function this `JFunc_void_std__optional_double_` instance holds through JNI.
+     */
     void invoke(std::optional<double> maybe) const {
       static const auto method = getClass()->getMethod<void(jni::alias_ref<jni::JDouble> /* maybe */)>("invoke");
       method(self(), maybe.has_value() ? jni::JDouble::valueOf(maybe.value()) : nullptr);
@@ -42,6 +45,9 @@ namespace margelo::nitro::image {
     }
 
   public:
+    /**
+     * Invokes the C++ `std::function<...>` this `JFunc_void_std__optional_double__cxx` instance holds.
+     */
     void invoke_cxx(jni::alias_ref<jni::JDouble> maybe) {
       _func(maybe != nullptr ? std::make_optional(maybe->value()) : std::nullopt);
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__string.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__string.hpp
@@ -18,33 +18,48 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * C++ representation of the callback Func_void_std__string.
-   * This is a Kotlin `(valueFromJs: String) -> Unit`, backed by a `std::function<...>`.
+   * Represents the Java/Kotlin callback `(valueFromJs: String) -> Unit`.
+   * This can be passed around between C++ and Java/Kotlin.
    */
-  struct JFunc_void_std__string final: public jni::HybridClass<JFunc_void_std__string> {
+  struct JFunc_void_std__string: public jni::JavaClass<JFunc_void_std__string> {
   public:
-    static jni::local_ref<JFunc_void_std__string::javaobject> fromCpp(const std::function<void(const std::string& /* valueFromJs */)>& func) {
-      return JFunc_void_std__string::newObjectCxxArgs(func);
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__string;";
+
+  public:
+    void invoke(const std::string& valueFromJs) const {
+      static const auto method = getClass()->getMethod<void(jni::alias_ref<jni::JString> /* valueFromJs */)>("invoke");
+      method(self(), jni::make_jstring(valueFromJs));
+    }
+  };
+
+  /**
+   * An implementation of Func_void_std__string that is backed by a C++ implementation (using `std::function<...>`)
+   */
+  struct JFunc_void_std__string_cxx final: public jni::HybridClass<JFunc_void_std__string_cxx, JFunc_void_std__string> {
+  public:
+    static jni::local_ref<JFunc_void_std__string_cxx::javaobject> fromCpp(const std::function<void(const std::string& /* valueFromJs */)>& func) {
+      return JFunc_void_std__string_cxx::newObjectCxxArgs(func);
     }
 
   public:
-    void call(jni::alias_ref<jni::JString> valueFromJs) {
+    void invoke_cxx(jni::alias_ref<jni::JString> valueFromJs) {
       _func(valueFromJs->toStdString());
     }
 
   public:
+    [[nodiscard]]
     inline const std::function<void(const std::string& /* valueFromJs */)>& getFunction() const {
       return _func;
     }
 
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__string;";
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__string_cxx;";
     static void registerNatives() {
-      registerHybrid({makeNativeMethod("call", JFunc_void_std__string::call)});
+      registerHybrid({makeNativeMethod("invoke", JFunc_void_std__string_cxx::invoke_cxx)});
     }
 
   private:
-    explicit JFunc_void_std__string(const std::function<void(const std::string& /* valueFromJs */)>& func): _func(func) { }
+    explicit JFunc_void_std__string_cxx(const std::function<void(const std::string& /* valueFromJs */)>& func): _func(func) { }
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__string.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__string.hpp
@@ -37,7 +37,7 @@ namespace margelo::nitro::image {
    */
   struct JFunc_void_std__string_cxx final: public jni::HybridClass<JFunc_void_std__string_cxx, JFunc_void_std__string> {
   public:
-    static jni::local_ref<JFunc_void_std__string_cxx::javaobject> fromCpp(const std::function<void(const std::string& /* valueFromJs */)>& func) {
+    static jni::local_ref<JFunc_void_std__string::javaobject> fromCpp(const std::function<void(const std::string& /* valueFromJs */)>& func) {
       return JFunc_void_std__string_cxx::newObjectCxxArgs(func);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__string.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__string.hpp
@@ -26,6 +26,9 @@ namespace margelo::nitro::image {
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__string;";
 
   public:
+    /**
+     * Invokes the function this `JFunc_void_std__string` instance holds through JNI.
+     */
     void invoke(const std::string& valueFromJs) const {
       static const auto method = getClass()->getMethod<void(jni::alias_ref<jni::JString> /* valueFromJs */)>("invoke");
       method(self(), jni::make_jstring(valueFromJs));
@@ -42,6 +45,9 @@ namespace margelo::nitro::image {
     }
 
   public:
+    /**
+     * Invokes the C++ `std::function<...>` this `JFunc_void_std__string_cxx` instance holds.
+     */
     void invoke_cxx(jni::alias_ref<jni::JString> valueFromJs) {
       _func(valueFromJs->toStdString());
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__vector_Powertrain_.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__vector_Powertrain_.hpp
@@ -20,17 +20,39 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * C++ representation of the callback Func_void_std__vector_Powertrain_.
-   * This is a Kotlin `(array: Array<Powertrain>) -> Unit`, backed by a `std::function<...>`.
+   * Represents the Java/Kotlin callback `(array: Array<Powertrain>) -> Unit`.
+   * This can be passed around between C++ and Java/Kotlin.
    */
-  struct JFunc_void_std__vector_Powertrain_ final: public jni::HybridClass<JFunc_void_std__vector_Powertrain_> {
+  struct JFunc_void_std__vector_Powertrain_: public jni::JavaClass<JFunc_void_std__vector_Powertrain_> {
   public:
-    static jni::local_ref<JFunc_void_std__vector_Powertrain_::javaobject> fromCpp(const std::function<void(const std::vector<Powertrain>& /* array */)>& func) {
-      return JFunc_void_std__vector_Powertrain_::newObjectCxxArgs(func);
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__vector_Powertrain_;";
+
+  public:
+    void invoke(const std::vector<Powertrain>& array) const {
+      static const auto method = getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<JPowertrain>> /* array */)>("invoke");
+      method(self(), [&]() {
+        size_t __size = array.size();
+        jni::local_ref<jni::JArrayClass<JPowertrain>> __array = jni::JArrayClass<JPowertrain>::newArray(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          const auto& __element = array[__i];
+          __array->setElement(__i, *JPowertrain::fromCpp(__element));
+        }
+        return __array;
+      }());
+    }
+  };
+
+  /**
+   * An implementation of Func_void_std__vector_Powertrain_ that is backed by a C++ implementation (using `std::function<...>`)
+   */
+  struct JFunc_void_std__vector_Powertrain__cxx final: public jni::HybridClass<JFunc_void_std__vector_Powertrain__cxx, JFunc_void_std__vector_Powertrain_> {
+  public:
+    static jni::local_ref<JFunc_void_std__vector_Powertrain__cxx::javaobject> fromCpp(const std::function<void(const std::vector<Powertrain>& /* array */)>& func) {
+      return JFunc_void_std__vector_Powertrain__cxx::newObjectCxxArgs(func);
     }
 
   public:
-    void call(jni::alias_ref<jni::JArrayClass<JPowertrain>> array) {
+    void invoke_cxx(jni::alias_ref<jni::JArrayClass<JPowertrain>> array) {
       _func([&]() {
               size_t __size = array->size();
               std::vector<Powertrain> __vector;
@@ -44,18 +66,19 @@ namespace margelo::nitro::image {
     }
 
   public:
+    [[nodiscard]]
     inline const std::function<void(const std::vector<Powertrain>& /* array */)>& getFunction() const {
       return _func;
     }
 
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__vector_Powertrain_;";
+    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__vector_Powertrain__cxx;";
     static void registerNatives() {
-      registerHybrid({makeNativeMethod("call", JFunc_void_std__vector_Powertrain_::call)});
+      registerHybrid({makeNativeMethod("invoke", JFunc_void_std__vector_Powertrain__cxx::invoke_cxx)});
     }
 
   private:
-    explicit JFunc_void_std__vector_Powertrain_(const std::function<void(const std::vector<Powertrain>& /* array */)>& func): _func(func) { }
+    explicit JFunc_void_std__vector_Powertrain__cxx(const std::function<void(const std::vector<Powertrain>& /* array */)>& func): _func(func) { }
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__vector_Powertrain_.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__vector_Powertrain_.hpp
@@ -28,6 +28,9 @@ namespace margelo::nitro::image {
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/image/Func_void_std__vector_Powertrain_;";
 
   public:
+    /**
+     * Invokes the function this `JFunc_void_std__vector_Powertrain_` instance holds through JNI.
+     */
     void invoke(const std::vector<Powertrain>& array) const {
       static const auto method = getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<JPowertrain>> /* array */)>("invoke");
       method(self(), [&]() {
@@ -52,6 +55,9 @@ namespace margelo::nitro::image {
     }
 
   public:
+    /**
+     * Invokes the C++ `std::function<...>` this `JFunc_void_std__vector_Powertrain__cxx` instance holds.
+     */
     void invoke_cxx(jni::alias_ref<jni::JArrayClass<JPowertrain>> array) {
       _func([&]() {
               size_t __size = array->size();

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__vector_Powertrain_.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JFunc_void_std__vector_Powertrain_.hpp
@@ -47,7 +47,7 @@ namespace margelo::nitro::image {
    */
   struct JFunc_void_std__vector_Powertrain__cxx final: public jni::HybridClass<JFunc_void_std__vector_Powertrain__cxx, JFunc_void_std__vector_Powertrain_> {
   public:
-    static jni::local_ref<JFunc_void_std__vector_Powertrain__cxx::javaobject> fromCpp(const std::function<void(const std::vector<Powertrain>& /* array */)>& func) {
+    static jni::local_ref<JFunc_void_std__vector_Powertrain_::javaobject> fromCpp(const std::function<void(const std::vector<Powertrain>& /* array */)>& func) {
       return JFunc_void_std__vector_Powertrain__cxx::newObjectCxxArgs(func);
     }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridBaseSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridBaseSpec.cpp
@@ -30,15 +30,9 @@ namespace margelo::nitro::image {
 
   // Properties
   double JHybridBaseSpec::getBaseValue() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<double()>("getBaseValue");
-      auto __result = method(_javaPart);
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<double()>("getBaseValue");
+    auto __result = method(_javaPart);
+    return __result;
   }
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridBaseSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridBaseSpec.cpp
@@ -30,9 +30,15 @@ namespace margelo::nitro::image {
 
   // Properties
   double JHybridBaseSpec::getBaseValue() {
-    static const auto method = _javaPart->getClass()->getMethod<double()>("getBaseValue");
-    auto __result = method(_javaPart);
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<double()>("getBaseValue");
+      auto __result = method(_javaPart);
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridChildSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridChildSpec.cpp
@@ -30,14 +30,26 @@ namespace margelo::nitro::image {
 
   // Properties
   double JHybridChildSpec::getChildValue() {
-    static const auto method = _javaPart->getClass()->getMethod<double()>("getChildValue");
-    auto __result = method(_javaPart);
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<double()>("getChildValue");
+      auto __result = method(_javaPart);
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   double JHybridChildSpec::getBaseValue() {
-    static const auto method = _javaPart->getClass()->getMethod<double()>("getBaseValue");
-    auto __result = method(_javaPart);
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<double()>("getBaseValue");
+      auto __result = method(_javaPart);
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridChildSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridChildSpec.cpp
@@ -30,26 +30,14 @@ namespace margelo::nitro::image {
 
   // Properties
   double JHybridChildSpec::getChildValue() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<double()>("getChildValue");
-      auto __result = method(_javaPart);
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<double()>("getChildValue");
+    auto __result = method(_javaPart);
+    return __result;
   }
   double JHybridChildSpec::getBaseValue() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<double()>("getBaseValue");
-      auto __result = method(_javaPart);
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<double()>("getBaseValue");
+    auto __result = method(_javaPart);
+    return __result;
   }
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageFactorySpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageFactorySpec.cpp
@@ -38,24 +38,48 @@ namespace margelo::nitro::image {
 
   // Methods
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::loadImageFromFile(const std::string& path) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromFile");
-    auto __result = method(_javaPart, jni::make_jstring(path));
-    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromFile");
+      auto __result = method(_javaPart, jni::make_jstring(path));
+      return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::loadImageFromURL(const std::string& path) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromURL");
-    auto __result = method(_javaPart, jni::make_jstring(path));
-    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromURL");
+      auto __result = method(_javaPart, jni::make_jstring(path));
+      return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::loadImageFromSystemName(const std::string& path) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromSystemName");
-    auto __result = method(_javaPart, jni::make_jstring(path));
-    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromSystemName");
+      auto __result = method(_javaPart, jni::make_jstring(path));
+      return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::bounceBack(const std::shared_ptr<margelo::nitro::image::HybridImageSpec>& image) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<JHybridImageSpec::javaobject> /* image */)>("bounceBack");
-    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridImageSpec>(image)->getJavaPart());
-    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<JHybridImageSpec::javaobject> /* image */)>("bounceBack");
+      auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridImageSpec>(image)->getJavaPart());
+      return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageFactorySpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageFactorySpec.cpp
@@ -38,48 +38,24 @@ namespace margelo::nitro::image {
 
   // Methods
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::loadImageFromFile(const std::string& path) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromFile");
-      auto __result = method(_javaPart, jni::make_jstring(path));
-      return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromFile");
+    auto __result = method(_javaPart, jni::make_jstring(path));
+    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::loadImageFromURL(const std::string& path) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromURL");
-      auto __result = method(_javaPart, jni::make_jstring(path));
-      return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromURL");
+    auto __result = method(_javaPart, jni::make_jstring(path));
+    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::loadImageFromSystemName(const std::string& path) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromSystemName");
-      auto __result = method(_javaPart, jni::make_jstring(path));
-      return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("loadImageFromSystemName");
+    auto __result = method(_javaPart, jni::make_jstring(path));
+    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridImageSpec> JHybridImageFactorySpec::bounceBack(const std::shared_ptr<margelo::nitro::image::HybridImageSpec>& image) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<JHybridImageSpec::javaobject> /* image */)>("bounceBack");
-      auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridImageSpec>(image)->getJavaPart());
-      return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridImageSpec::javaobject>(jni::alias_ref<JHybridImageSpec::javaobject> /* image */)>("bounceBack");
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridImageSpec>(image)->getJavaPart());
+    return JNISharedPtr::make_shared_from_jni<JHybridImageSpec>(jni::make_global(__result));
   }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.cpp
@@ -102,7 +102,7 @@ namespace margelo::nitro::image {
     try {
       
       static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* path */, jni::alias_ref<JFunc_void_std__string::javaobject> /* onFinished */)>("saveToFile_cxx");
-      method(_javaPart, jni::make_jstring(path), JFunc_void_std__string::fromCpp(onFinished));
+      method(_javaPart, jni::make_jstring(path), JFunc_void_std__string_cxx::fromCpp(onFinished));
          
     } catch (const jni::JniException& exc) {
       throw std::runtime_error(exc.what());

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.cpp
@@ -43,70 +43,34 @@ namespace margelo::nitro::image {
 
   // Properties
   ImageSize JHybridImageSpec::getSize() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JImageSize>()>("getSize");
-      auto __result = method(_javaPart);
-      return __result->toCpp();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JImageSize>()>("getSize");
+    auto __result = method(_javaPart);
+    return __result->toCpp();
   }
   PixelFormat JHybridImageSpec::getPixelFormat() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPixelFormat>()>("getPixelFormat");
-      auto __result = method(_javaPart);
-      return __result->toCpp();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPixelFormat>()>("getPixelFormat");
+    auto __result = method(_javaPart);
+    return __result->toCpp();
   }
   double JHybridImageSpec::getSomeSettableProp() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<double()>("getSomeSettableProp");
-      auto __result = method(_javaPart);
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<double()>("getSomeSettableProp");
+    auto __result = method(_javaPart);
+    return __result;
   }
   void JHybridImageSpec::setSomeSettableProp(double someSettableProp) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(double /* someSettableProp */)>("setSomeSettableProp");
-      method(_javaPart, someSettableProp);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(double /* someSettableProp */)>("setSomeSettableProp");
+    method(_javaPart, someSettableProp);
   }
 
   // Methods
   double JHybridImageSpec::toArrayBuffer(ImageFormat format) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<double(jni::alias_ref<JImageFormat> /* format */)>("toArrayBuffer");
-      auto __result = method(_javaPart, JImageFormat::fromCpp(format));
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<double(jni::alias_ref<JImageFormat> /* format */)>("toArrayBuffer");
+    auto __result = method(_javaPart, JImageFormat::fromCpp(format));
+    return __result;
   }
   void JHybridImageSpec::saveToFile(const std::string& path, const std::function<void(const std::string& /* path */)>& onFinished) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* path */, jni::alias_ref<JFunc_void_std__string::javaobject> /* onFinished */)>("saveToFile_cxx");
-      method(_javaPart, jni::make_jstring(path), JFunc_void_std__string_cxx::fromCpp(onFinished));
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* path */, jni::alias_ref<JFunc_void_std__string::javaobject> /* onFinished */)>("saveToFile_cxx");
+    method(_javaPart, jni::make_jstring(path), JFunc_void_std__string_cxx::fromCpp(onFinished));
   }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridImageSpec.cpp
@@ -43,34 +43,70 @@ namespace margelo::nitro::image {
 
   // Properties
   ImageSize JHybridImageSpec::getSize() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JImageSize>()>("getSize");
-    auto __result = method(_javaPart);
-    return __result->toCpp();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JImageSize>()>("getSize");
+      auto __result = method(_javaPart);
+      return __result->toCpp();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   PixelFormat JHybridImageSpec::getPixelFormat() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPixelFormat>()>("getPixelFormat");
-    auto __result = method(_javaPart);
-    return __result->toCpp();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPixelFormat>()>("getPixelFormat");
+      auto __result = method(_javaPart);
+      return __result->toCpp();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   double JHybridImageSpec::getSomeSettableProp() {
-    static const auto method = _javaPart->getClass()->getMethod<double()>("getSomeSettableProp");
-    auto __result = method(_javaPart);
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<double()>("getSomeSettableProp");
+      auto __result = method(_javaPart);
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridImageSpec::setSomeSettableProp(double someSettableProp) {
-    static const auto method = _javaPart->getClass()->getMethod<void(double /* someSettableProp */)>("setSomeSettableProp");
-    method(_javaPart, someSettableProp);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(double /* someSettableProp */)>("setSomeSettableProp");
+      method(_javaPart, someSettableProp);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
 
   // Methods
   double JHybridImageSpec::toArrayBuffer(ImageFormat format) {
-    static const auto method = _javaPart->getClass()->getMethod<double(jni::alias_ref<JImageFormat> /* format */)>("toArrayBuffer");
-    auto __result = method(_javaPart, JImageFormat::fromCpp(format));
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<double(jni::alias_ref<JImageFormat> /* format */)>("toArrayBuffer");
+      auto __result = method(_javaPart, JImageFormat::fromCpp(format));
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridImageSpec::saveToFile(const std::string& path, const std::function<void(const std::string& /* path */)>& onFinished) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* path */, jni::alias_ref<JFunc_void_std__string::javaobject> /* onFinished */)>("saveToFile");
-    method(_javaPart, jni::make_jstring(path), JFunc_void_std__string::fromCpp(onFinished));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* path */, jni::alias_ref<JFunc_void_std__string::javaobject> /* onFinished */)>("saveToFile_cxx");
+      method(_javaPart, jni::make_jstring(path), JFunc_void_std__string::fromCpp(onFinished));
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -352,7 +352,16 @@ namespace margelo::nitro::image {
       
       static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getOptionalCallback_cxx");
       auto __result = method(_javaPart);
-      return __result != nullptr ? std::make_optional(__result->cthis()->getFunction()) : std::nullopt;
+      return __result != nullptr ? std::make_optional([&]() -> std::function<void(double /* value */)> {
+        if (__result->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
+          auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(__result);
+          return downcast->cthis()->getFunction();
+        } else {
+          return [__result](double value) -> void {
+            return __result->invoke(value);
+          };
+        }
+      }()) : std::nullopt;
           
     } catch (const jni::JniException& exc) {
       throw std::runtime_error(exc.what());
@@ -362,7 +371,7 @@ namespace margelo::nitro::image {
     try {
       
       static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void_double::javaobject> /* optionalCallback */)>("setOptionalCallback_cxx");
-      method(_javaPart, optionalCallback.has_value() ? JFunc_void_double::fromCpp(optionalCallback.value()) : nullptr);
+      method(_javaPart, optionalCallback.has_value() ? JFunc_void_double_cxx::fromCpp(optionalCallback.value()) : nullptr);
          
     } catch (const jni::JniException& exc) {
       throw std::runtime_error(exc.what());
@@ -561,7 +570,7 @@ namespace margelo::nitro::image {
           __array->setElement(__i, *JPowertrain::fromCpp(__element));
         }
         return __array;
-      }(), JFunc_void_std__vector_Powertrain_::fromCpp(callback));
+      }(), JFunc_void_std__vector_Powertrain__cxx::fromCpp(callback));
          
     } catch (const jni::JniException& exc) {
       throw std::runtime_error(exc.what());
@@ -841,7 +850,7 @@ namespace margelo::nitro::image {
     try {
       
       static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* callback */)>("callCallback_cxx");
-      method(_javaPart, JFunc_void::fromCpp(callback));
+      method(_javaPart, JFunc_void_cxx::fromCpp(callback));
          
     } catch (const jni::JniException& exc) {
       throw std::runtime_error(exc.what());
@@ -851,7 +860,7 @@ namespace margelo::nitro::image {
     try {
       
       static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* first */, jni::alias_ref<JFunc_void::javaobject> /* second */, jni::alias_ref<JFunc_void::javaobject> /* third */)>("callAll_cxx");
-      method(_javaPart, JFunc_void::fromCpp(first), JFunc_void::fromCpp(second), JFunc_void::fromCpp(third));
+      method(_javaPart, JFunc_void_cxx::fromCpp(first), JFunc_void_cxx::fromCpp(second), JFunc_void_cxx::fromCpp(third));
          
     } catch (const jni::JniException& exc) {
       throw std::runtime_error(exc.what());
@@ -861,7 +870,7 @@ namespace margelo::nitro::image {
     try {
       
       static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JDouble> /* value */, jni::alias_ref<JFunc_void_std__optional_double_::javaobject> /* callback */)>("callWithOptional_cxx");
-      method(_javaPart, value.has_value() ? jni::JDouble::valueOf(value.value()) : nullptr, JFunc_void_std__optional_double_::fromCpp(callback));
+      method(_javaPart, value.has_value() ? jni::JDouble::valueOf(value.value()) : nullptr, JFunc_void_std__optional_double__cxx::fromCpp(callback));
          
     } catch (const jni::JniException& exc) {
       throw std::runtime_error(exc.what());
@@ -871,7 +880,7 @@ namespace margelo::nitro::image {
     try {
       
       static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* callback */, double /* n */)>("callSumUpNTimes_cxx");
-      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double__::fromCpp(callback), n);
+      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double___cxx::fromCpp(callback), n);
       return [&]() {
         auto __promise = Promise<double>::create();
         __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
@@ -893,7 +902,7 @@ namespace margelo::nitro::image {
     try {
       
       static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::javaobject> /* callback */)>("callbackAsyncPromise_cxx");
-      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::fromCpp(callback));
+      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx::fromCpp(callback));
       return [&]() {
         auto __promise = Promise<double>::create();
         __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
@@ -915,7 +924,7 @@ namespace margelo::nitro::image {
     try {
       
       static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::javaobject> /* callback */)>("callbackAsyncPromiseBuffer_cxx");
-      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::fromCpp(callback));
+      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx::fromCpp(callback));
       return [&]() {
         auto __promise = Promise<std::shared_ptr<ArrayBuffer>>::create();
         __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
@@ -938,7 +947,16 @@ namespace margelo::nitro::image {
       
       static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getComplexCallback_cxx");
       auto __result = method(_javaPart);
-      return __result->cthis()->getFunction();
+      return [&]() -> std::function<void(double /* value */)> {
+        if (__result->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
+          auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(__result);
+          return downcast->cthis()->getFunction();
+        } else {
+          return [__result](double value) -> void {
+            return __result->invoke(value);
+          };
+        }
+      }();
           
     } catch (const jni::JniException& exc) {
       throw std::runtime_error(exc.what());
@@ -948,7 +966,7 @@ namespace margelo::nitro::image {
     try {
       
       static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* getValue */)>("getValueFromJSCallbackAndWait_cxx");
-      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double__::fromCpp(getValue));
+      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double___cxx::fromCpp(getValue));
       return [&]() {
         auto __promise = Promise<double>::create();
         __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
@@ -970,7 +988,7 @@ namespace margelo::nitro::image {
     try {
       
       static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__string__::javaobject> /* callback */, jni::alias_ref<JFunc_void_std__string::javaobject> /* andThenCall */)>("getValueFromJsCallback_cxx");
-      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__string__::fromCpp(callback), JFunc_void_std__string::fromCpp(andThenCall));
+      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__string___cxx::fromCpp(callback), JFunc_void_std__string_cxx::fromCpp(andThenCall));
       return [&]() {
         auto __promise = Promise<void>::create();
         __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -89,1095 +89,639 @@ namespace margelo::nitro::image {
 
   // Properties
   std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> JHybridTestObjectSwiftKotlinSpec::getThisObject() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("getThisObject");
-      auto __result = method(_javaPart);
-      return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("getThisObject");
+    auto __result = method(_javaPart);
+    return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result));
   }
   std::optional<std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec>> JHybridTestObjectSwiftKotlinSpec::getOptionalHybrid() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("getOptionalHybrid");
-      auto __result = method(_javaPart);
-      return __result != nullptr ? std::make_optional(JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result))) : std::nullopt;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("getOptionalHybrid");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result))) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalHybrid(const std::optional<std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec>>& optionalHybrid) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JHybridTestObjectSwiftKotlinSpec::javaobject> /* optionalHybrid */)>("setOptionalHybrid");
-      method(_javaPart, optionalHybrid.has_value() ? std::dynamic_pointer_cast<JHybridTestObjectSwiftKotlinSpec>(optionalHybrid.value())->getJavaPart() : nullptr);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JHybridTestObjectSwiftKotlinSpec::javaobject> /* optionalHybrid */)>("setOptionalHybrid");
+    method(_javaPart, optionalHybrid.has_value() ? std::dynamic_pointer_cast<JHybridTestObjectSwiftKotlinSpec>(optionalHybrid.value())->getJavaPart() : nullptr);
   }
   double JHybridTestObjectSwiftKotlinSpec::getNumberValue() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<double()>("getNumberValue");
-      auto __result = method(_javaPart);
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<double()>("getNumberValue");
+    auto __result = method(_javaPart);
+    return __result;
   }
   void JHybridTestObjectSwiftKotlinSpec::setNumberValue(double numberValue) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(double /* numberValue */)>("setNumberValue");
-      method(_javaPart, numberValue);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(double /* numberValue */)>("setNumberValue");
+    method(_javaPart, numberValue);
   }
   bool JHybridTestObjectSwiftKotlinSpec::getBoolValue() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jboolean()>("getBoolValue");
-      auto __result = method(_javaPart);
-      return static_cast<bool>(__result);
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jboolean()>("getBoolValue");
+    auto __result = method(_javaPart);
+    return static_cast<bool>(__result);
   }
   void JHybridTestObjectSwiftKotlinSpec::setBoolValue(bool boolValue) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jboolean /* boolValue */)>("setBoolValue");
-      method(_javaPart, boolValue);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jboolean /* boolValue */)>("setBoolValue");
+    method(_javaPart, boolValue);
   }
   std::string JHybridTestObjectSwiftKotlinSpec::getStringValue() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringValue");
-      auto __result = method(_javaPart);
-      return __result->toStdString();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringValue");
+    auto __result = method(_javaPart);
+    return __result->toStdString();
   }
   void JHybridTestObjectSwiftKotlinSpec::setStringValue(const std::string& stringValue) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringValue */)>("setStringValue");
-      method(_javaPart, jni::make_jstring(stringValue));
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringValue */)>("setStringValue");
+    method(_javaPart, jni::make_jstring(stringValue));
   }
   int64_t JHybridTestObjectSwiftKotlinSpec::getBigintValue() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<int64_t()>("getBigintValue");
-      auto __result = method(_javaPart);
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<int64_t()>("getBigintValue");
+    auto __result = method(_javaPart);
+    return __result;
   }
   void JHybridTestObjectSwiftKotlinSpec::setBigintValue(int64_t bigintValue) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(int64_t /* bigintValue */)>("setBigintValue");
-      method(_javaPart, bigintValue);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(int64_t /* bigintValue */)>("setBigintValue");
+    method(_javaPart, bigintValue);
   }
   std::optional<std::string> JHybridTestObjectSwiftKotlinSpec::getStringOrUndefined() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringOrUndefined");
-      auto __result = method(_javaPart);
-      return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringOrUndefined");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setStringOrUndefined(const std::optional<std::string>& stringOrUndefined) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringOrUndefined */)>("setStringOrUndefined");
-      method(_javaPart, stringOrUndefined.has_value() ? jni::make_jstring(stringOrUndefined.value()) : nullptr);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringOrUndefined */)>("setStringOrUndefined");
+    method(_javaPart, stringOrUndefined.has_value() ? jni::make_jstring(stringOrUndefined.value()) : nullptr);
   }
   std::optional<std::string> JHybridTestObjectSwiftKotlinSpec::getStringOrNull() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringOrNull");
-      auto __result = method(_javaPart);
-      return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringOrNull");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setStringOrNull(const std::optional<std::string>& stringOrNull) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringOrNull */)>("setStringOrNull");
-      method(_javaPart, stringOrNull.has_value() ? jni::make_jstring(stringOrNull.value()) : nullptr);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringOrNull */)>("setStringOrNull");
+    method(_javaPart, stringOrNull.has_value() ? jni::make_jstring(stringOrNull.value()) : nullptr);
   }
   std::optional<std::string> JHybridTestObjectSwiftKotlinSpec::getOptionalString() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getOptionalString");
-      auto __result = method(_javaPart);
-      return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getOptionalString");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalString(const std::optional<std::string>& optionalString) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* optionalString */)>("setOptionalString");
-      method(_javaPart, optionalString.has_value() ? jni::make_jstring(optionalString.value()) : nullptr);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* optionalString */)>("setOptionalString");
+    method(_javaPart, optionalString.has_value() ? jni::make_jstring(optionalString.value()) : nullptr);
   }
   std::optional<std::vector<std::string>> JHybridTestObjectSwiftKotlinSpec::getOptionalArray() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>()>("getOptionalArray");
-      auto __result = method(_javaPart);
-      return __result != nullptr ? std::make_optional([&]() {
-        size_t __size = __result->size();
-        std::vector<std::string> __vector;
-        __vector.reserve(__size);
-        for (size_t __i = 0; __i < __size; __i++) {
-          auto __element = __result->getElement(__i);
-          __vector.push_back(__element->toStdString());
-        }
-        return __vector;
-      }()) : std::nullopt;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>()>("getOptionalArray");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional([&]() {
+      size_t __size = __result->size();
+      std::vector<std::string> __vector;
+      __vector.reserve(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        auto __element = __result->getElement(__i);
+        __vector.push_back(__element->toStdString());
+      }
+      return __vector;
+    }()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalArray(const std::optional<std::vector<std::string>>& optionalArray) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<jni::JString>> /* optionalArray */)>("setOptionalArray");
-      method(_javaPart, optionalArray.has_value() ? [&]() {
-        size_t __size = optionalArray.value().size();
-        jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
-        for (size_t __i = 0; __i < __size; __i++) {
-          const auto& __element = optionalArray.value()[__i];
-          __array->setElement(__i, *jni::make_jstring(__element));
-        }
-        return __array;
-      }() : nullptr);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<jni::JString>> /* optionalArray */)>("setOptionalArray");
+    method(_javaPart, optionalArray.has_value() ? [&]() {
+      size_t __size = optionalArray.value().size();
+      jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        const auto& __element = optionalArray.value()[__i];
+        __array->setElement(__i, *jni::make_jstring(__element));
+      }
+      return __array;
+    }() : nullptr);
   }
   std::optional<Powertrain> JHybridTestObjectSwiftKotlinSpec::getOptionalEnum() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPowertrain>()>("getOptionalEnum");
-      auto __result = method(_javaPart);
-      return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPowertrain>()>("getOptionalEnum");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalEnum(std::optional<Powertrain> optionalEnum) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JPowertrain> /* optionalEnum */)>("setOptionalEnum");
-      method(_javaPart, optionalEnum.has_value() ? JPowertrain::fromCpp(optionalEnum.value()) : nullptr);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JPowertrain> /* optionalEnum */)>("setOptionalEnum");
+    method(_javaPart, optionalEnum.has_value() ? JPowertrain::fromCpp(optionalEnum.value()) : nullptr);
   }
   std::optional<OldEnum> JHybridTestObjectSwiftKotlinSpec::getOptionalOldEnum() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JOldEnum>()>("getOptionalOldEnum");
-      auto __result = method(_javaPart);
-      return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JOldEnum>()>("getOptionalOldEnum");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalOldEnum(std::optional<OldEnum> optionalOldEnum) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JOldEnum> /* optionalOldEnum */)>("setOptionalOldEnum");
-      method(_javaPart, optionalOldEnum.has_value() ? JOldEnum::fromCpp(optionalOldEnum.value()) : nullptr);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JOldEnum> /* optionalOldEnum */)>("setOptionalOldEnum");
+    method(_javaPart, optionalOldEnum.has_value() ? JOldEnum::fromCpp(optionalOldEnum.value()) : nullptr);
   }
   std::optional<std::function<void(double /* value */)>> JHybridTestObjectSwiftKotlinSpec::getOptionalCallback() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getOptionalCallback_cxx");
-      auto __result = method(_javaPart);
-      return __result != nullptr ? std::make_optional([&]() -> std::function<void(double /* value */)> {
-        if (__result->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
-          auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(__result);
-          return downcast->cthis()->getFunction();
-        } else {
-          return [__result](double value) -> void {
-            return __result->invoke(value);
-          };
-        }
-      }()) : std::nullopt;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getOptionalCallback_cxx");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional([&]() -> std::function<void(double /* value */)> {
+      if (__result->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
+        auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(__result);
+        return downcast->cthis()->getFunction();
+      } else {
+        return [__result](double value) -> void {
+          return __result->invoke(value);
+        };
+      }
+    }()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalCallback(const std::optional<std::function<void(double /* value */)>>& optionalCallback) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void_double::javaobject> /* optionalCallback */)>("setOptionalCallback_cxx");
-      method(_javaPart, optionalCallback.has_value() ? JFunc_void_double_cxx::fromCpp(optionalCallback.value()) : nullptr);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void_double::javaobject> /* optionalCallback */)>("setOptionalCallback_cxx");
+    method(_javaPart, optionalCallback.has_value() ? JFunc_void_double_cxx::fromCpp(optionalCallback.value()) : nullptr);
   }
   std::variant<std::string, double> JHybridTestObjectSwiftKotlinSpec::getSomeVariant() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JVariant_String_Double>()>("getSomeVariant");
-      auto __result = method(_javaPart);
-      return __result->toCpp();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JVariant_String_Double>()>("getSomeVariant");
+    auto __result = method(_javaPart);
+    return __result->toCpp();
   }
   void JHybridTestObjectSwiftKotlinSpec::setSomeVariant(const std::variant<std::string, double>& someVariant) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JVariant_String_Double> /* someVariant */)>("setSomeVariant");
-      method(_javaPart, JVariant_String_Double::fromCpp(someVariant));
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JVariant_String_Double> /* someVariant */)>("setSomeVariant");
+    method(_javaPart, JVariant_String_Double::fromCpp(someVariant));
   }
 
   // Methods
   std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> JHybridTestObjectSwiftKotlinSpec::newTestObject() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("newTestObject");
-      auto __result = method(_javaPart);
-      return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("newTestObject");
+    auto __result = method(_javaPart);
+    return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result));
   }
   void JHybridTestObjectSwiftKotlinSpec::simpleFunc() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void()>("simpleFunc");
-      method(_javaPart);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void()>("simpleFunc");
+    method(_javaPart);
   }
   double JHybridTestObjectSwiftKotlinSpec::addNumbers(double a, double b) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<double(double /* a */, double /* b */)>("addNumbers");
-      auto __result = method(_javaPart, a, b);
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<double(double /* a */, double /* b */)>("addNumbers");
+    auto __result = method(_javaPart, a, b);
+    return __result;
   }
   std::string JHybridTestObjectSwiftKotlinSpec::addStrings(const std::string& a, const std::string& b) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(jni::alias_ref<jni::JString> /* a */, jni::alias_ref<jni::JString> /* b */)>("addStrings");
-      auto __result = method(_javaPart, jni::make_jstring(a), jni::make_jstring(b));
-      return __result->toStdString();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(jni::alias_ref<jni::JString> /* a */, jni::alias_ref<jni::JString> /* b */)>("addStrings");
+    auto __result = method(_javaPart, jni::make_jstring(a), jni::make_jstring(b));
+    return __result->toStdString();
   }
   void JHybridTestObjectSwiftKotlinSpec::multipleArguments(double num, const std::string& str, bool boo) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(double /* num */, jni::alias_ref<jni::JString> /* str */, jboolean /* boo */)>("multipleArguments");
-      method(_javaPart, num, jni::make_jstring(str), boo);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(double /* num */, jni::alias_ref<jni::JString> /* str */, jboolean /* boo */)>("multipleArguments");
+    method(_javaPart, num, jni::make_jstring(str), boo);
   }
   std::vector<std::string> JHybridTestObjectSwiftKotlinSpec::bounceStrings(const std::vector<std::string>& array) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>(jni::alias_ref<jni::JArrayClass<jni::JString>> /* array */)>("bounceStrings");
-      auto __result = method(_javaPart, [&]() {
-        size_t __size = array.size();
-        jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
-        for (size_t __i = 0; __i < __size; __i++) {
-          const auto& __element = array[__i];
-          __array->setElement(__i, *jni::make_jstring(__element));
-        }
-        return __array;
-      }());
-      return [&]() {
-        size_t __size = __result->size();
-        std::vector<std::string> __vector;
-        __vector.reserve(__size);
-        for (size_t __i = 0; __i < __size; __i++) {
-          auto __element = __result->getElement(__i);
-          __vector.push_back(__element->toStdString());
-        }
-        return __vector;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>(jni::alias_ref<jni::JArrayClass<jni::JString>> /* array */)>("bounceStrings");
+    auto __result = method(_javaPart, [&]() {
+      size_t __size = array.size();
+      jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        const auto& __element = array[__i];
+        __array->setElement(__i, *jni::make_jstring(__element));
+      }
+      return __array;
+    }());
+    return [&]() {
+      size_t __size = __result->size();
+      std::vector<std::string> __vector;
+      __vector.reserve(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        auto __element = __result->getElement(__i);
+        __vector.push_back(__element->toStdString());
+      }
+      return __vector;
+    }();
   }
   std::vector<double> JHybridTestObjectSwiftKotlinSpec::bounceNumbers(const std::vector<double>& array) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayDouble>(jni::alias_ref<jni::JArrayDouble> /* array */)>("bounceNumbers");
-      auto __result = method(_javaPart, [&]() {
-        size_t __size = array.size();
-        jni::local_ref<jni::JArrayDouble> __array = jni::JArrayDouble::newArray(__size);
-        __array->setRegion(0, __size, array.data());
-        return __array;
-      }());
-      return [&]() {
-        size_t __size = __result->size();
-        std::vector<double> __vector(__size);
-        __result->getRegion(0, __size, __vector.data());
-        return __vector;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayDouble>(jni::alias_ref<jni::JArrayDouble> /* array */)>("bounceNumbers");
+    auto __result = method(_javaPart, [&]() {
+      size_t __size = array.size();
+      jni::local_ref<jni::JArrayDouble> __array = jni::JArrayDouble::newArray(__size);
+      __array->setRegion(0, __size, array.data());
+      return __array;
+    }());
+    return [&]() {
+      size_t __size = __result->size();
+      std::vector<double> __vector(__size);
+      __result->getRegion(0, __size, __vector.data());
+      return __vector;
+    }();
   }
   std::vector<Person> JHybridTestObjectSwiftKotlinSpec::bounceStructs(const std::vector<Person>& array) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<JPerson>>(jni::alias_ref<jni::JArrayClass<JPerson>> /* array */)>("bounceStructs");
-      auto __result = method(_javaPart, [&]() {
-        size_t __size = array.size();
-        jni::local_ref<jni::JArrayClass<JPerson>> __array = jni::JArrayClass<JPerson>::newArray(__size);
-        for (size_t __i = 0; __i < __size; __i++) {
-          const auto& __element = array[__i];
-          __array->setElement(__i, *JPerson::fromCpp(__element));
-        }
-        return __array;
-      }());
-      return [&]() {
-        size_t __size = __result->size();
-        std::vector<Person> __vector;
-        __vector.reserve(__size);
-        for (size_t __i = 0; __i < __size; __i++) {
-          auto __element = __result->getElement(__i);
-          __vector.push_back(__element->toCpp());
-        }
-        return __vector;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<JPerson>>(jni::alias_ref<jni::JArrayClass<JPerson>> /* array */)>("bounceStructs");
+    auto __result = method(_javaPart, [&]() {
+      size_t __size = array.size();
+      jni::local_ref<jni::JArrayClass<JPerson>> __array = jni::JArrayClass<JPerson>::newArray(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        const auto& __element = array[__i];
+        __array->setElement(__i, *JPerson::fromCpp(__element));
+      }
+      return __array;
+    }());
+    return [&]() {
+      size_t __size = __result->size();
+      std::vector<Person> __vector;
+      __vector.reserve(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        auto __element = __result->getElement(__i);
+        __vector.push_back(__element->toCpp());
+      }
+      return __vector;
+    }();
   }
   std::vector<Powertrain> JHybridTestObjectSwiftKotlinSpec::bounceEnums(const std::vector<Powertrain>& array) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<JPowertrain>>(jni::alias_ref<jni::JArrayClass<JPowertrain>> /* array */)>("bounceEnums");
-      auto __result = method(_javaPart, [&]() {
-        size_t __size = array.size();
-        jni::local_ref<jni::JArrayClass<JPowertrain>> __array = jni::JArrayClass<JPowertrain>::newArray(__size);
-        for (size_t __i = 0; __i < __size; __i++) {
-          const auto& __element = array[__i];
-          __array->setElement(__i, *JPowertrain::fromCpp(__element));
-        }
-        return __array;
-      }());
-      return [&]() {
-        size_t __size = __result->size();
-        std::vector<Powertrain> __vector;
-        __vector.reserve(__size);
-        for (size_t __i = 0; __i < __size; __i++) {
-          auto __element = __result->getElement(__i);
-          __vector.push_back(__element->toCpp());
-        }
-        return __vector;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<JPowertrain>>(jni::alias_ref<jni::JArrayClass<JPowertrain>> /* array */)>("bounceEnums");
+    auto __result = method(_javaPart, [&]() {
+      size_t __size = array.size();
+      jni::local_ref<jni::JArrayClass<JPowertrain>> __array = jni::JArrayClass<JPowertrain>::newArray(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        const auto& __element = array[__i];
+        __array->setElement(__i, *JPowertrain::fromCpp(__element));
+      }
+      return __array;
+    }());
+    return [&]() {
+      size_t __size = __result->size();
+      std::vector<Powertrain> __vector;
+      __vector.reserve(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        auto __element = __result->getElement(__i);
+        __vector.push_back(__element->toCpp());
+      }
+      return __vector;
+    }();
   }
   void JHybridTestObjectSwiftKotlinSpec::complexEnumCallback(const std::vector<Powertrain>& array, const std::function<void(const std::vector<Powertrain>& /* array */)>& callback) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<JPowertrain>> /* array */, jni::alias_ref<JFunc_void_std__vector_Powertrain_::javaobject> /* callback */)>("complexEnumCallback_cxx");
-      method(_javaPart, [&]() {
-        size_t __size = array.size();
-        jni::local_ref<jni::JArrayClass<JPowertrain>> __array = jni::JArrayClass<JPowertrain>::newArray(__size);
-        for (size_t __i = 0; __i < __size; __i++) {
-          const auto& __element = array[__i];
-          __array->setElement(__i, *JPowertrain::fromCpp(__element));
-        }
-        return __array;
-      }(), JFunc_void_std__vector_Powertrain__cxx::fromCpp(callback));
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<JPowertrain>> /* array */, jni::alias_ref<JFunc_void_std__vector_Powertrain_::javaobject> /* callback */)>("complexEnumCallback_cxx");
+    method(_javaPart, [&]() {
+      size_t __size = array.size();
+      jni::local_ref<jni::JArrayClass<JPowertrain>> __array = jni::JArrayClass<JPowertrain>::newArray(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        const auto& __element = array[__i];
+        __array->setElement(__i, *JPowertrain::fromCpp(__element));
+      }
+      return __array;
+    }(), JFunc_void_std__vector_Powertrain__cxx::fromCpp(callback));
   }
   std::shared_ptr<AnyMap> JHybridTestObjectSwiftKotlinSpec::createMap() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JAnyMap::javaobject>()>("createMap");
-      auto __result = method(_javaPart);
-      return __result->cthis()->getMap();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JAnyMap::javaobject>()>("createMap");
+    auto __result = method(_javaPart);
+    return __result->cthis()->getMap();
   }
   std::shared_ptr<AnyMap> JHybridTestObjectSwiftKotlinSpec::mapRoundtrip(const std::shared_ptr<AnyMap>& map) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JAnyMap::javaobject>(jni::alias_ref<JAnyMap::javaobject> /* map */)>("mapRoundtrip");
-      auto __result = method(_javaPart, JAnyMap::create(map));
-      return __result->cthis()->getMap();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JAnyMap::javaobject>(jni::alias_ref<JAnyMap::javaobject> /* map */)>("mapRoundtrip");
+    auto __result = method(_javaPart, JAnyMap::create(map));
+    return __result->cthis()->getMap();
   }
   double JHybridTestObjectSwiftKotlinSpec::funcThatThrows() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<double()>("funcThatThrows");
-      auto __result = method(_javaPart);
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<double()>("funcThatThrows");
+    auto __result = method(_javaPart);
+    return __result;
   }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::funcThatThrowsBeforePromise() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("funcThatThrowsBeforePromise");
-      auto __result = method(_javaPart);
-      return [&]() {
-        auto __promise = Promise<void>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
-          __promise->resolve();
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("funcThatThrowsBeforePromise");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   void JHybridTestObjectSwiftKotlinSpec::throwError(const std::exception_ptr& error) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JThrowable> /* error */)>("throwError");
-      method(_javaPart, jni::getJavaExceptionForCppException(error));
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JThrowable> /* error */)>("throwError");
+    method(_javaPart, jni::getJavaExceptionForCppException(error));
   }
   std::string JHybridTestObjectSwiftKotlinSpec::tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jboolean /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryOptionalParams");
-      auto __result = method(_javaPart, num, boo, str.has_value() ? jni::make_jstring(str.value()) : nullptr);
-      return __result->toStdString();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jboolean /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryOptionalParams");
+    auto __result = method(_javaPart, num, boo, str.has_value() ? jni::make_jstring(str.value()) : nullptr);
+    return __result->toStdString();
   }
   std::string JHybridTestObjectSwiftKotlinSpec::tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jni::alias_ref<jni::JBoolean> /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryMiddleParam");
-      auto __result = method(_javaPart, num, boo.has_value() ? jni::JBoolean::valueOf(boo.value()) : nullptr, jni::make_jstring(str));
-      return __result->toStdString();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jni::alias_ref<jni::JBoolean> /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryMiddleParam");
+    auto __result = method(_javaPart, num, boo.has_value() ? jni::JBoolean::valueOf(boo.value()) : nullptr, jni::make_jstring(str));
+    return __result->toStdString();
   }
   std::optional<Powertrain> JHybridTestObjectSwiftKotlinSpec::tryOptionalEnum(std::optional<Powertrain> value) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPowertrain>(jni::alias_ref<JPowertrain> /* value */)>("tryOptionalEnum");
-      auto __result = method(_javaPart, value.has_value() ? JPowertrain::fromCpp(value.value()) : nullptr);
-      return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPowertrain>(jni::alias_ref<JPowertrain> /* value */)>("tryOptionalEnum");
+    auto __result = method(_javaPart, value.has_value() ? JPowertrain::fromCpp(value.value()) : nullptr);
+    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   int64_t JHybridTestObjectSwiftKotlinSpec::calculateFibonacciSync(double value) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<int64_t(double /* value */)>("calculateFibonacciSync");
-      auto __result = method(_javaPart, value);
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<int64_t(double /* value */)>("calculateFibonacciSync");
+    auto __result = method(_javaPart, value);
+    return __result;
   }
   std::shared_ptr<Promise<int64_t>> JHybridTestObjectSwiftKotlinSpec::calculateFibonacciAsync(double value) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* value */)>("calculateFibonacciAsync");
-      auto __result = method(_javaPart, value);
-      return [&]() {
-        auto __promise = Promise<int64_t>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-          auto __result = jni::static_ref_cast<jni::JLong>(__boxedResult);
-          __promise->resolve(__result->value());
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* value */)>("calculateFibonacciAsync");
+    auto __result = method(_javaPart, value);
+    return [&]() {
+      auto __promise = Promise<int64_t>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JLong>(__boxedResult);
+        __promise->resolve(__result->value());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::wait(double seconds) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* seconds */)>("wait");
-      auto __result = method(_javaPart, seconds);
-      return [&]() {
-        auto __promise = Promise<void>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
-          __promise->resolve();
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* seconds */)>("wait");
+    auto __result = method(_javaPart, seconds);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::promiseThrows() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("promiseThrows");
-      auto __result = method(_javaPart);
-      return [&]() {
-        auto __promise = Promise<void>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
-          __promise->resolve();
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("promiseThrows");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetPromise");
-      auto __result = method(_javaPart, [&]() {
-        jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
-        jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
-        promise->addOnResolvedListener([=](const double& __result) {
-          __promise->cthis()->resolve(jni::JDouble::valueOf(__result));
-        });
-        promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
-          auto __jniError = jni::getJavaExceptionForCppException(__error);
-          __promise->cthis()->reject(__jniError);
-        });
-        return __localPromise;
-      }());
-      return [&]() {
-        auto __promise = Promise<double>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-          auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
-          __promise->resolve(__result->value());
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetPromise");
+    auto __result = method(_javaPart, [&]() {
+      jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
+      jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
+      promise->addOnResolvedListener([=](const double& __result) {
+        __promise->cthis()->resolve(jni::JDouble::valueOf(__result));
+      });
+      promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
+        auto __jniError = jni::getJavaExceptionForCppException(__error);
+        __promise->cthis()->reject(__jniError);
+      });
+      return __localPromise;
+    }());
+    return [&]() {
+      auto __promise = Promise<double>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+        __promise->resolve(__result->value());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::shared_ptr<Promise<Car>> JHybridTestObjectSwiftKotlinSpec::awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetComplexPromise");
-      auto __result = method(_javaPart, [&]() {
-        jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
-        jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
-        promise->addOnResolvedListener([=](const Car& __result) {
-          __promise->cthis()->resolve(JCar::fromCpp(__result));
-        });
-        promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
-          auto __jniError = jni::getJavaExceptionForCppException(__error);
-          __promise->cthis()->reject(__jniError);
-        });
-        return __localPromise;
-      }());
-      return [&]() {
-        auto __promise = Promise<Car>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-          auto __result = jni::static_ref_cast<JCar>(__boxedResult);
-          __promise->resolve(__result->toCpp());
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetComplexPromise");
+    auto __result = method(_javaPart, [&]() {
+      jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
+      jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
+      promise->addOnResolvedListener([=](const Car& __result) {
+        __promise->cthis()->resolve(JCar::fromCpp(__result));
+      });
+      promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
+        auto __jniError = jni::getJavaExceptionForCppException(__error);
+        __promise->cthis()->reject(__jniError);
+      });
+      return __localPromise;
+    }());
+    return [&]() {
+      auto __promise = Promise<Car>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<JCar>(__boxedResult);
+        __promise->resolve(__result->toCpp());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::awaitPromise(const std::shared_ptr<Promise<void>>& promise) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitPromise");
-      auto __result = method(_javaPart, [&]() {
-        jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
-        jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
-        promise->addOnResolvedListener([=]() {
-          __promise->cthis()->resolve(JUnit::instance());
-        });
-        promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
-          auto __jniError = jni::getJavaExceptionForCppException(__error);
-          __promise->cthis()->reject(__jniError);
-        });
-        return __localPromise;
-      }());
-      return [&]() {
-        auto __promise = Promise<void>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
-          __promise->resolve();
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitPromise");
+    auto __result = method(_javaPart, [&]() {
+      jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
+      jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
+      promise->addOnResolvedListener([=]() {
+        __promise->cthis()->resolve(JUnit::instance());
+      });
+      promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
+        auto __jniError = jni::getJavaExceptionForCppException(__error);
+        __promise->cthis()->reject(__jniError);
+      });
+      return __localPromise;
+    }());
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   void JHybridTestObjectSwiftKotlinSpec::callCallback(const std::function<void()>& callback) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* callback */)>("callCallback_cxx");
-      method(_javaPart, JFunc_void_cxx::fromCpp(callback));
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* callback */)>("callCallback_cxx");
+    method(_javaPart, JFunc_void_cxx::fromCpp(callback));
   }
   void JHybridTestObjectSwiftKotlinSpec::callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* first */, jni::alias_ref<JFunc_void::javaobject> /* second */, jni::alias_ref<JFunc_void::javaobject> /* third */)>("callAll_cxx");
-      method(_javaPart, JFunc_void_cxx::fromCpp(first), JFunc_void_cxx::fromCpp(second), JFunc_void_cxx::fromCpp(third));
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* first */, jni::alias_ref<JFunc_void::javaobject> /* second */, jni::alias_ref<JFunc_void::javaobject> /* third */)>("callAll_cxx");
+    method(_javaPart, JFunc_void_cxx::fromCpp(first), JFunc_void_cxx::fromCpp(second), JFunc_void_cxx::fromCpp(third));
   }
   void JHybridTestObjectSwiftKotlinSpec::callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JDouble> /* value */, jni::alias_ref<JFunc_void_std__optional_double_::javaobject> /* callback */)>("callWithOptional_cxx");
-      method(_javaPart, value.has_value() ? jni::JDouble::valueOf(value.value()) : nullptr, JFunc_void_std__optional_double__cxx::fromCpp(callback));
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JDouble> /* value */, jni::alias_ref<JFunc_void_std__optional_double_::javaobject> /* callback */)>("callWithOptional_cxx");
+    method(_javaPart, value.has_value() ? jni::JDouble::valueOf(value.value()) : nullptr, JFunc_void_std__optional_double__cxx::fromCpp(callback));
   }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* callback */, double /* n */)>("callSumUpNTimes_cxx");
-      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double___cxx::fromCpp(callback), n);
-      return [&]() {
-        auto __promise = Promise<double>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-          auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
-          __promise->resolve(__result->value());
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* callback */, double /* n */)>("callSumUpNTimes_cxx");
+    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double___cxx::fromCpp(callback), n);
+    return [&]() {
+      auto __promise = Promise<double>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+        __promise->resolve(__result->value());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::callbackAsyncPromise(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& callback) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::javaobject> /* callback */)>("callbackAsyncPromise_cxx");
-      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx::fromCpp(callback));
-      return [&]() {
-        auto __promise = Promise<double>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-          auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
-          __promise->resolve(__result->value());
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::javaobject> /* callback */)>("callbackAsyncPromise_cxx");
+    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx::fromCpp(callback));
+    return [&]() {
+      auto __promise = Promise<double>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+        __promise->resolve(__result->value());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> JHybridTestObjectSwiftKotlinSpec::callbackAsyncPromiseBuffer(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& callback) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::javaobject> /* callback */)>("callbackAsyncPromiseBuffer_cxx");
-      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx::fromCpp(callback));
-      return [&]() {
-        auto __promise = Promise<std::shared_ptr<ArrayBuffer>>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-          auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
-          __promise->resolve(__result->cthis()->getArrayBuffer());
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::javaobject> /* callback */)>("callbackAsyncPromiseBuffer_cxx");
+    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx::fromCpp(callback));
+    return [&]() {
+      auto __promise = Promise<std::shared_ptr<ArrayBuffer>>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
+        __promise->resolve(__result->cthis()->getArrayBuffer());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::function<void(double /* value */)> JHybridTestObjectSwiftKotlinSpec::getComplexCallback() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getComplexCallback_cxx");
-      auto __result = method(_javaPart);
-      return [&]() -> std::function<void(double /* value */)> {
-        if (__result->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
-          auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(__result);
-          return downcast->cthis()->getFunction();
-        } else {
-          return [__result](double value) -> void {
-            return __result->invoke(value);
-          };
-        }
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getComplexCallback_cxx");
+    auto __result = method(_javaPart);
+    return [&]() -> std::function<void(double /* value */)> {
+      if (__result->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
+        auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(__result);
+        return downcast->cthis()->getFunction();
+      } else {
+        return [__result](double value) -> void {
+          return __result->invoke(value);
+        };
+      }
+    }();
   }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* getValue */)>("getValueFromJSCallbackAndWait_cxx");
-      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double___cxx::fromCpp(getValue));
-      return [&]() {
-        auto __promise = Promise<double>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-          auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
-          __promise->resolve(__result->value());
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* getValue */)>("getValueFromJSCallbackAndWait_cxx");
+    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double___cxx::fromCpp(getValue));
+    return [&]() {
+      auto __promise = Promise<double>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+        __promise->resolve(__result->value());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__string__::javaobject> /* callback */, jni::alias_ref<JFunc_void_std__string::javaobject> /* andThenCall */)>("getValueFromJsCallback_cxx");
-      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__string___cxx::fromCpp(callback), JFunc_void_std__string_cxx::fromCpp(andThenCall));
-      return [&]() {
-        auto __promise = Promise<void>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
-          __promise->resolve();
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__string__::javaobject> /* callback */, jni::alias_ref<JFunc_void_std__string::javaobject> /* andThenCall */)>("getValueFromJsCallback_cxx");
+    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__string___cxx::fromCpp(callback), JFunc_void_std__string_cxx::fromCpp(andThenCall));
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   Car JHybridTestObjectSwiftKotlinSpec::getCar() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JCar>()>("getCar");
-      auto __result = method(_javaPart);
-      return __result->toCpp();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JCar>()>("getCar");
+    auto __result = method(_javaPart);
+    return __result->toCpp();
   }
   bool JHybridTestObjectSwiftKotlinSpec::isCarElectric(const Car& car) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jboolean(jni::alias_ref<JCar> /* car */)>("isCarElectric");
-      auto __result = method(_javaPart, JCar::fromCpp(car));
-      return static_cast<bool>(__result);
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jboolean(jni::alias_ref<JCar> /* car */)>("isCarElectric");
+    auto __result = method(_javaPart, JCar::fromCpp(car));
+    return static_cast<bool>(__result);
   }
   std::optional<Person> JHybridTestObjectSwiftKotlinSpec::getDriver(const Car& car) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPerson>(jni::alias_ref<JCar> /* car */)>("getDriver");
-      auto __result = method(_javaPart, JCar::fromCpp(car));
-      return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPerson>(jni::alias_ref<JCar> /* car */)>("getDriver");
+    auto __result = method(_javaPart, JCar::fromCpp(car));
+    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::jsStyleObjectAsParameters(const JsStyleStruct& params) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JJsStyleStruct> /* params */)>("jsStyleObjectAsParameters_cxx");
-      method(_javaPart, JJsStyleStruct::fromCpp(params));
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JJsStyleStruct> /* params */)>("jsStyleObjectAsParameters_cxx");
+    method(_javaPart, JJsStyleStruct::fromCpp(params));
   }
   std::shared_ptr<ArrayBuffer> JHybridTestObjectSwiftKotlinSpec::createArrayBuffer() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JArrayBuffer::javaobject>()>("createArrayBuffer");
-      auto __result = method(_javaPart);
-      return __result->cthis()->getArrayBuffer();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JArrayBuffer::javaobject>()>("createArrayBuffer");
+    auto __result = method(_javaPart);
+    return __result->cthis()->getArrayBuffer();
   }
   double JHybridTestObjectSwiftKotlinSpec::getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<double(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */)>("getBufferLastItem");
-      auto __result = method(_javaPart, JArrayBuffer::wrap(buffer));
-      return __result;
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<double(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */)>("getBufferLastItem");
+    auto __result = method(_javaPart, JArrayBuffer::wrap(buffer));
+    return __result;
   }
   void JHybridTestObjectSwiftKotlinSpec::setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */, double /* value */)>("setAllValuesTo");
-      method(_javaPart, JArrayBuffer::wrap(buffer), value);
-         
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */, double /* value */)>("setAllValuesTo");
+    method(_javaPart, JArrayBuffer::wrap(buffer), value);
   }
   std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> JHybridTestObjectSwiftKotlinSpec::createArrayBufferAsync() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("createArrayBufferAsync");
-      auto __result = method(_javaPart);
-      return [&]() {
-        auto __promise = Promise<std::shared_ptr<ArrayBuffer>>::create();
-        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-          auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
-          __promise->resolve(__result->cthis()->getArrayBuffer());
-        });
-        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-          jni::JniException __jniError(__throwable);
-          __promise->reject(std::make_exception_ptr(__jniError));
-        });
-        return __promise;
-      }();
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("createArrayBufferAsync");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = Promise<std::shared_ptr<ArrayBuffer>>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
+        __promise->resolve(__result->cthis()->getArrayBuffer());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> JHybridTestObjectSwiftKotlinSpec::createChild() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>()>("createChild");
-      auto __result = method(_javaPart);
-      return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>()>("createChild");
+    auto __result = method(_javaPart);
+    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::createBase() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>()>("createBase");
-      auto __result = method(_javaPart);
-      return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>()>("createBase");
+    auto __result = method(_javaPart);
+    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::createBaseActualChild() {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>()>("createBaseActualChild");
-      auto __result = method(_javaPart);
-      return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>()>("createBaseActualChild");
+    auto __result = method(_javaPart);
+    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> JHybridTestObjectSwiftKotlinSpec::bounceChild(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridChildSpec::javaobject> /* child */)>("bounceChild");
-      auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
-      return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridChildSpec::javaobject> /* child */)>("bounceChild");
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
+    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("bounceBase");
-      auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
-      return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("bounceBase");
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
+    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>(jni::alias_ref<JHybridChildSpec::javaobject> /* child */)>("bounceChildBase");
-      auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
-      return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>(jni::alias_ref<JHybridChildSpec::javaobject> /* child */)>("bounceChildBase");
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
+    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
   }
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> JHybridTestObjectSwiftKotlinSpec::castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) {
-    try {
-      
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("castBase");
-      auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
-      return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
-          
-    } catch (const jni::JniException& exc) {
-      throw std::runtime_error(exc.what());
-    }
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("castBase");
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
+    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
   }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -350,7 +350,7 @@ namespace margelo::nitro::image {
   std::optional<std::function<void(double /* value */)>> JHybridTestObjectSwiftKotlinSpec::getOptionalCallback() {
     try {
       
-      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getOptionalCallback");
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getOptionalCallback_cxx");
       auto __result = method(_javaPart);
       return __result != nullptr ? std::make_optional(__result->cthis()->getFunction()) : std::nullopt;
           
@@ -361,7 +361,7 @@ namespace margelo::nitro::image {
   void JHybridTestObjectSwiftKotlinSpec::setOptionalCallback(const std::optional<std::function<void(double /* value */)>>& optionalCallback) {
     try {
       
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void_double::javaobject> /* optionalCallback */)>("setOptionalCallback");
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void_double::javaobject> /* optionalCallback */)>("setOptionalCallback_cxx");
       method(_javaPart, optionalCallback.has_value() ? JFunc_void_double::fromCpp(optionalCallback.value()) : nullptr);
          
     } catch (const jni::JniException& exc) {
@@ -1023,7 +1023,7 @@ namespace margelo::nitro::image {
   void JHybridTestObjectSwiftKotlinSpec::jsStyleObjectAsParameters(const JsStyleStruct& params) {
     try {
       
-      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JJsStyleStruct> /* params */)>("jsStyleObjectAsParameters");
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JJsStyleStruct> /* params */)>("jsStyleObjectAsParameters_cxx");
       method(_javaPart, JJsStyleStruct::fromCpp(params));
          
     } catch (const jni::JniException& exc) {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -585,6 +585,11 @@ namespace margelo::nitro::image {
       return __promise;
     }();
   }
+  std::function<void(double /* value */)> JHybridTestObjectSwiftKotlinSpec::getComplexCallback() {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getComplexCallback");
+    auto __result = method(_javaPart);
+    return __result->cthis()->getFunction();
+  }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* getValue */)>("getValueFromJSCallbackAndWait");
     auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double__::fromCpp(getValue));

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -39,6 +39,8 @@ namespace margelo::nitro::image { struct JsStyleStruct; }
 #include "JPowertrain.hpp"
 #include "OldEnum.hpp"
 #include "JOldEnum.hpp"
+#include <functional>
+#include "JFunc_void_double.hpp"
 #include <variant>
 #include "JVariant_String_Double.hpp"
 #include "Person.hpp"
@@ -56,7 +58,6 @@ namespace margelo::nitro::image { struct JsStyleStruct; }
 #include "JHybridChildSpec.hpp"
 #include "HybridBaseSpec.hpp"
 #include "JHybridBaseSpec.hpp"
-#include <functional>
 #include "JFunc_void_std__vector_Powertrain_.hpp"
 #include <exception>
 #include "JFunc_void.hpp"
@@ -68,7 +69,6 @@ namespace margelo::nitro::image { struct JsStyleStruct; }
 #include "JFunc_void_std__string.hpp"
 #include "JsStyleStruct.hpp"
 #include "JJsStyleStruct.hpp"
-#include "JFunc_void_double.hpp"
 
 namespace margelo::nitro::image {
 
@@ -208,6 +208,15 @@ namespace margelo::nitro::image {
   void JHybridTestObjectSwiftKotlinSpec::setOptionalOldEnum(std::optional<OldEnum> optionalOldEnum) {
     static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JOldEnum> /* optionalOldEnum */)>("setOptionalOldEnum");
     method(_javaPart, optionalOldEnum.has_value() ? JOldEnum::fromCpp(optionalOldEnum.value()) : nullptr);
+  }
+  std::optional<std::function<void(double /* value */)>> JHybridTestObjectSwiftKotlinSpec::getOptionalCallback() {
+    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getOptionalCallback");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->cthis()->getFunction()) : std::nullopt;
+  }
+  void JHybridTestObjectSwiftKotlinSpec::setOptionalCallback(const std::optional<std::function<void(double /* value */)>>& optionalCallback) {
+    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void_double::javaobject> /* optionalCallback */)>("setOptionalCallback");
+    method(_javaPart, optionalCallback.has_value() ? JFunc_void_double::fromCpp(optionalCallback.value()) : nullptr);
   }
   std::variant<std::string, double> JHybridTestObjectSwiftKotlinSpec::getSomeVariant() {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JVariant_String_Double>()>("getSomeVariant");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -89,621 +89,1077 @@ namespace margelo::nitro::image {
 
   // Properties
   std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> JHybridTestObjectSwiftKotlinSpec::getThisObject() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("getThisObject");
-    auto __result = method(_javaPart);
-    return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("getThisObject");
+      auto __result = method(_javaPart);
+      return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::optional<std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec>> JHybridTestObjectSwiftKotlinSpec::getOptionalHybrid() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("getOptionalHybrid");
-    auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result))) : std::nullopt;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("getOptionalHybrid");
+      auto __result = method(_javaPart);
+      return __result != nullptr ? std::make_optional(JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result))) : std::nullopt;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalHybrid(const std::optional<std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec>>& optionalHybrid) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JHybridTestObjectSwiftKotlinSpec::javaobject> /* optionalHybrid */)>("setOptionalHybrid");
-    method(_javaPart, optionalHybrid.has_value() ? std::dynamic_pointer_cast<JHybridTestObjectSwiftKotlinSpec>(optionalHybrid.value())->getJavaPart() : nullptr);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JHybridTestObjectSwiftKotlinSpec::javaobject> /* optionalHybrid */)>("setOptionalHybrid");
+      method(_javaPart, optionalHybrid.has_value() ? std::dynamic_pointer_cast<JHybridTestObjectSwiftKotlinSpec>(optionalHybrid.value())->getJavaPart() : nullptr);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   double JHybridTestObjectSwiftKotlinSpec::getNumberValue() {
-    static const auto method = _javaPart->getClass()->getMethod<double()>("getNumberValue");
-    auto __result = method(_javaPart);
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<double()>("getNumberValue");
+      auto __result = method(_javaPart);
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setNumberValue(double numberValue) {
-    static const auto method = _javaPart->getClass()->getMethod<void(double /* numberValue */)>("setNumberValue");
-    method(_javaPart, numberValue);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(double /* numberValue */)>("setNumberValue");
+      method(_javaPart, numberValue);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   bool JHybridTestObjectSwiftKotlinSpec::getBoolValue() {
-    static const auto method = _javaPart->getClass()->getMethod<jboolean()>("getBoolValue");
-    auto __result = method(_javaPart);
-    return static_cast<bool>(__result);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jboolean()>("getBoolValue");
+      auto __result = method(_javaPart);
+      return static_cast<bool>(__result);
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setBoolValue(bool boolValue) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jboolean /* boolValue */)>("setBoolValue");
-    method(_javaPart, boolValue);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jboolean /* boolValue */)>("setBoolValue");
+      method(_javaPart, boolValue);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::string JHybridTestObjectSwiftKotlinSpec::getStringValue() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringValue");
-    auto __result = method(_javaPart);
-    return __result->toStdString();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringValue");
+      auto __result = method(_javaPart);
+      return __result->toStdString();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setStringValue(const std::string& stringValue) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringValue */)>("setStringValue");
-    method(_javaPart, jni::make_jstring(stringValue));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringValue */)>("setStringValue");
+      method(_javaPart, jni::make_jstring(stringValue));
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   int64_t JHybridTestObjectSwiftKotlinSpec::getBigintValue() {
-    static const auto method = _javaPart->getClass()->getMethod<int64_t()>("getBigintValue");
-    auto __result = method(_javaPart);
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<int64_t()>("getBigintValue");
+      auto __result = method(_javaPart);
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setBigintValue(int64_t bigintValue) {
-    static const auto method = _javaPart->getClass()->getMethod<void(int64_t /* bigintValue */)>("setBigintValue");
-    method(_javaPart, bigintValue);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(int64_t /* bigintValue */)>("setBigintValue");
+      method(_javaPart, bigintValue);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::optional<std::string> JHybridTestObjectSwiftKotlinSpec::getStringOrUndefined() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringOrUndefined");
-    auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringOrUndefined");
+      auto __result = method(_javaPart);
+      return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setStringOrUndefined(const std::optional<std::string>& stringOrUndefined) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringOrUndefined */)>("setStringOrUndefined");
-    method(_javaPart, stringOrUndefined.has_value() ? jni::make_jstring(stringOrUndefined.value()) : nullptr);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringOrUndefined */)>("setStringOrUndefined");
+      method(_javaPart, stringOrUndefined.has_value() ? jni::make_jstring(stringOrUndefined.value()) : nullptr);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::optional<std::string> JHybridTestObjectSwiftKotlinSpec::getStringOrNull() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringOrNull");
-    auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getStringOrNull");
+      auto __result = method(_javaPart);
+      return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setStringOrNull(const std::optional<std::string>& stringOrNull) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringOrNull */)>("setStringOrNull");
-    method(_javaPart, stringOrNull.has_value() ? jni::make_jstring(stringOrNull.value()) : nullptr);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* stringOrNull */)>("setStringOrNull");
+      method(_javaPart, stringOrNull.has_value() ? jni::make_jstring(stringOrNull.value()) : nullptr);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::optional<std::string> JHybridTestObjectSwiftKotlinSpec::getOptionalString() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getOptionalString");
-    auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>()>("getOptionalString");
+      auto __result = method(_javaPart);
+      return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalString(const std::optional<std::string>& optionalString) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* optionalString */)>("setOptionalString");
-    method(_javaPart, optionalString.has_value() ? jni::make_jstring(optionalString.value()) : nullptr);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* optionalString */)>("setOptionalString");
+      method(_javaPart, optionalString.has_value() ? jni::make_jstring(optionalString.value()) : nullptr);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::optional<std::vector<std::string>> JHybridTestObjectSwiftKotlinSpec::getOptionalArray() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>()>("getOptionalArray");
-    auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional([&]() {
-      size_t __size = __result->size();
-      std::vector<std::string> __vector;
-      __vector.reserve(__size);
-      for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
-        __vector.push_back(__element->toStdString());
-      }
-      return __vector;
-    }()) : std::nullopt;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>()>("getOptionalArray");
+      auto __result = method(_javaPart);
+      return __result != nullptr ? std::make_optional([&]() {
+        size_t __size = __result->size();
+        std::vector<std::string> __vector;
+        __vector.reserve(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          auto __element = __result->getElement(__i);
+          __vector.push_back(__element->toStdString());
+        }
+        return __vector;
+      }()) : std::nullopt;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalArray(const std::optional<std::vector<std::string>>& optionalArray) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<jni::JString>> /* optionalArray */)>("setOptionalArray");
-    method(_javaPart, optionalArray.has_value() ? [&]() {
-      size_t __size = optionalArray.value().size();
-      jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
-      for (size_t __i = 0; __i < __size; __i++) {
-        const auto& __element = optionalArray.value()[__i];
-        __array->setElement(__i, *jni::make_jstring(__element));
-      }
-      return __array;
-    }() : nullptr);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<jni::JString>> /* optionalArray */)>("setOptionalArray");
+      method(_javaPart, optionalArray.has_value() ? [&]() {
+        size_t __size = optionalArray.value().size();
+        jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          const auto& __element = optionalArray.value()[__i];
+          __array->setElement(__i, *jni::make_jstring(__element));
+        }
+        return __array;
+      }() : nullptr);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::optional<Powertrain> JHybridTestObjectSwiftKotlinSpec::getOptionalEnum() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPowertrain>()>("getOptionalEnum");
-    auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPowertrain>()>("getOptionalEnum");
+      auto __result = method(_javaPart);
+      return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalEnum(std::optional<Powertrain> optionalEnum) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JPowertrain> /* optionalEnum */)>("setOptionalEnum");
-    method(_javaPart, optionalEnum.has_value() ? JPowertrain::fromCpp(optionalEnum.value()) : nullptr);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JPowertrain> /* optionalEnum */)>("setOptionalEnum");
+      method(_javaPart, optionalEnum.has_value() ? JPowertrain::fromCpp(optionalEnum.value()) : nullptr);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::optional<OldEnum> JHybridTestObjectSwiftKotlinSpec::getOptionalOldEnum() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JOldEnum>()>("getOptionalOldEnum");
-    auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JOldEnum>()>("getOptionalOldEnum");
+      auto __result = method(_javaPart);
+      return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalOldEnum(std::optional<OldEnum> optionalOldEnum) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JOldEnum> /* optionalOldEnum */)>("setOptionalOldEnum");
-    method(_javaPart, optionalOldEnum.has_value() ? JOldEnum::fromCpp(optionalOldEnum.value()) : nullptr);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JOldEnum> /* optionalOldEnum */)>("setOptionalOldEnum");
+      method(_javaPart, optionalOldEnum.has_value() ? JOldEnum::fromCpp(optionalOldEnum.value()) : nullptr);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::optional<std::function<void(double /* value */)>> JHybridTestObjectSwiftKotlinSpec::getOptionalCallback() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getOptionalCallback");
-    auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(__result->cthis()->getFunction()) : std::nullopt;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getOptionalCallback");
+      auto __result = method(_javaPart);
+      return __result != nullptr ? std::make_optional(__result->cthis()->getFunction()) : std::nullopt;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalCallback(const std::optional<std::function<void(double /* value */)>>& optionalCallback) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void_double::javaobject> /* optionalCallback */)>("setOptionalCallback");
-    method(_javaPart, optionalCallback.has_value() ? JFunc_void_double::fromCpp(optionalCallback.value()) : nullptr);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void_double::javaobject> /* optionalCallback */)>("setOptionalCallback");
+      method(_javaPart, optionalCallback.has_value() ? JFunc_void_double::fromCpp(optionalCallback.value()) : nullptr);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::variant<std::string, double> JHybridTestObjectSwiftKotlinSpec::getSomeVariant() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JVariant_String_Double>()>("getSomeVariant");
-    auto __result = method(_javaPart);
-    return __result->toCpp();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JVariant_String_Double>()>("getSomeVariant");
+      auto __result = method(_javaPart);
+      return __result->toCpp();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setSomeVariant(const std::variant<std::string, double>& someVariant) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JVariant_String_Double> /* someVariant */)>("setSomeVariant");
-    method(_javaPart, JVariant_String_Double::fromCpp(someVariant));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JVariant_String_Double> /* someVariant */)>("setSomeVariant");
+      method(_javaPart, JVariant_String_Double::fromCpp(someVariant));
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
 
   // Methods
   std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec> JHybridTestObjectSwiftKotlinSpec::newTestObject() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("newTestObject");
-    auto __result = method(_javaPart);
-    return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridTestObjectSwiftKotlinSpec::javaobject>()>("newTestObject");
+      auto __result = method(_javaPart);
+      return JNISharedPtr::make_shared_from_jni<JHybridTestObjectSwiftKotlinSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::simpleFunc() {
-    static const auto method = _javaPart->getClass()->getMethod<void()>("simpleFunc");
-    method(_javaPart);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void()>("simpleFunc");
+      method(_javaPart);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   double JHybridTestObjectSwiftKotlinSpec::addNumbers(double a, double b) {
-    static const auto method = _javaPart->getClass()->getMethod<double(double /* a */, double /* b */)>("addNumbers");
-    auto __result = method(_javaPart, a, b);
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<double(double /* a */, double /* b */)>("addNumbers");
+      auto __result = method(_javaPart, a, b);
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::string JHybridTestObjectSwiftKotlinSpec::addStrings(const std::string& a, const std::string& b) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(jni::alias_ref<jni::JString> /* a */, jni::alias_ref<jni::JString> /* b */)>("addStrings");
-    auto __result = method(_javaPart, jni::make_jstring(a), jni::make_jstring(b));
-    return __result->toStdString();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(jni::alias_ref<jni::JString> /* a */, jni::alias_ref<jni::JString> /* b */)>("addStrings");
+      auto __result = method(_javaPart, jni::make_jstring(a), jni::make_jstring(b));
+      return __result->toStdString();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::multipleArguments(double num, const std::string& str, bool boo) {
-    static const auto method = _javaPart->getClass()->getMethod<void(double /* num */, jni::alias_ref<jni::JString> /* str */, jboolean /* boo */)>("multipleArguments");
-    method(_javaPart, num, jni::make_jstring(str), boo);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(double /* num */, jni::alias_ref<jni::JString> /* str */, jboolean /* boo */)>("multipleArguments");
+      method(_javaPart, num, jni::make_jstring(str), boo);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::vector<std::string> JHybridTestObjectSwiftKotlinSpec::bounceStrings(const std::vector<std::string>& array) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>(jni::alias_ref<jni::JArrayClass<jni::JString>> /* array */)>("bounceStrings");
-    auto __result = method(_javaPart, [&]() {
-      size_t __size = array.size();
-      jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
-      for (size_t __i = 0; __i < __size; __i++) {
-        const auto& __element = array[__i];
-        __array->setElement(__i, *jni::make_jstring(__element));
-      }
-      return __array;
-    }());
-    return [&]() {
-      size_t __size = __result->size();
-      std::vector<std::string> __vector;
-      __vector.reserve(__size);
-      for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
-        __vector.push_back(__element->toStdString());
-      }
-      return __vector;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>(jni::alias_ref<jni::JArrayClass<jni::JString>> /* array */)>("bounceStrings");
+      auto __result = method(_javaPart, [&]() {
+        size_t __size = array.size();
+        jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          const auto& __element = array[__i];
+          __array->setElement(__i, *jni::make_jstring(__element));
+        }
+        return __array;
+      }());
+      return [&]() {
+        size_t __size = __result->size();
+        std::vector<std::string> __vector;
+        __vector.reserve(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          auto __element = __result->getElement(__i);
+          __vector.push_back(__element->toStdString());
+        }
+        return __vector;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::vector<double> JHybridTestObjectSwiftKotlinSpec::bounceNumbers(const std::vector<double>& array) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayDouble>(jni::alias_ref<jni::JArrayDouble> /* array */)>("bounceNumbers");
-    auto __result = method(_javaPart, [&]() {
-      size_t __size = array.size();
-      jni::local_ref<jni::JArrayDouble> __array = jni::JArrayDouble::newArray(__size);
-      __array->setRegion(0, __size, array.data());
-      return __array;
-    }());
-    return [&]() {
-      size_t __size = __result->size();
-      std::vector<double> __vector(__size);
-      __result->getRegion(0, __size, __vector.data());
-      return __vector;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayDouble>(jni::alias_ref<jni::JArrayDouble> /* array */)>("bounceNumbers");
+      auto __result = method(_javaPart, [&]() {
+        size_t __size = array.size();
+        jni::local_ref<jni::JArrayDouble> __array = jni::JArrayDouble::newArray(__size);
+        __array->setRegion(0, __size, array.data());
+        return __array;
+      }());
+      return [&]() {
+        size_t __size = __result->size();
+        std::vector<double> __vector(__size);
+        __result->getRegion(0, __size, __vector.data());
+        return __vector;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::vector<Person> JHybridTestObjectSwiftKotlinSpec::bounceStructs(const std::vector<Person>& array) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<JPerson>>(jni::alias_ref<jni::JArrayClass<JPerson>> /* array */)>("bounceStructs");
-    auto __result = method(_javaPart, [&]() {
-      size_t __size = array.size();
-      jni::local_ref<jni::JArrayClass<JPerson>> __array = jni::JArrayClass<JPerson>::newArray(__size);
-      for (size_t __i = 0; __i < __size; __i++) {
-        const auto& __element = array[__i];
-        __array->setElement(__i, *JPerson::fromCpp(__element));
-      }
-      return __array;
-    }());
-    return [&]() {
-      size_t __size = __result->size();
-      std::vector<Person> __vector;
-      __vector.reserve(__size);
-      for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
-        __vector.push_back(__element->toCpp());
-      }
-      return __vector;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<JPerson>>(jni::alias_ref<jni::JArrayClass<JPerson>> /* array */)>("bounceStructs");
+      auto __result = method(_javaPart, [&]() {
+        size_t __size = array.size();
+        jni::local_ref<jni::JArrayClass<JPerson>> __array = jni::JArrayClass<JPerson>::newArray(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          const auto& __element = array[__i];
+          __array->setElement(__i, *JPerson::fromCpp(__element));
+        }
+        return __array;
+      }());
+      return [&]() {
+        size_t __size = __result->size();
+        std::vector<Person> __vector;
+        __vector.reserve(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          auto __element = __result->getElement(__i);
+          __vector.push_back(__element->toCpp());
+        }
+        return __vector;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::vector<Powertrain> JHybridTestObjectSwiftKotlinSpec::bounceEnums(const std::vector<Powertrain>& array) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<JPowertrain>>(jni::alias_ref<jni::JArrayClass<JPowertrain>> /* array */)>("bounceEnums");
-    auto __result = method(_javaPart, [&]() {
-      size_t __size = array.size();
-      jni::local_ref<jni::JArrayClass<JPowertrain>> __array = jni::JArrayClass<JPowertrain>::newArray(__size);
-      for (size_t __i = 0; __i < __size; __i++) {
-        const auto& __element = array[__i];
-        __array->setElement(__i, *JPowertrain::fromCpp(__element));
-      }
-      return __array;
-    }());
-    return [&]() {
-      size_t __size = __result->size();
-      std::vector<Powertrain> __vector;
-      __vector.reserve(__size);
-      for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
-        __vector.push_back(__element->toCpp());
-      }
-      return __vector;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JArrayClass<JPowertrain>>(jni::alias_ref<jni::JArrayClass<JPowertrain>> /* array */)>("bounceEnums");
+      auto __result = method(_javaPart, [&]() {
+        size_t __size = array.size();
+        jni::local_ref<jni::JArrayClass<JPowertrain>> __array = jni::JArrayClass<JPowertrain>::newArray(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          const auto& __element = array[__i];
+          __array->setElement(__i, *JPowertrain::fromCpp(__element));
+        }
+        return __array;
+      }());
+      return [&]() {
+        size_t __size = __result->size();
+        std::vector<Powertrain> __vector;
+        __vector.reserve(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          auto __element = __result->getElement(__i);
+          __vector.push_back(__element->toCpp());
+        }
+        return __vector;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::complexEnumCallback(const std::vector<Powertrain>& array, const std::function<void(const std::vector<Powertrain>& /* array */)>& callback) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<JPowertrain>> /* array */, jni::alias_ref<JFunc_void_std__vector_Powertrain_::javaobject> /* callback */)>("complexEnumCallback");
-    method(_javaPart, [&]() {
-      size_t __size = array.size();
-      jni::local_ref<jni::JArrayClass<JPowertrain>> __array = jni::JArrayClass<JPowertrain>::newArray(__size);
-      for (size_t __i = 0; __i < __size; __i++) {
-        const auto& __element = array[__i];
-        __array->setElement(__i, *JPowertrain::fromCpp(__element));
-      }
-      return __array;
-    }(), JFunc_void_std__vector_Powertrain_::fromCpp(callback));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<JPowertrain>> /* array */, jni::alias_ref<JFunc_void_std__vector_Powertrain_::javaobject> /* callback */)>("complexEnumCallback_cxx");
+      method(_javaPart, [&]() {
+        size_t __size = array.size();
+        jni::local_ref<jni::JArrayClass<JPowertrain>> __array = jni::JArrayClass<JPowertrain>::newArray(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          const auto& __element = array[__i];
+          __array->setElement(__i, *JPowertrain::fromCpp(__element));
+        }
+        return __array;
+      }(), JFunc_void_std__vector_Powertrain_::fromCpp(callback));
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<AnyMap> JHybridTestObjectSwiftKotlinSpec::createMap() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JAnyMap::javaobject>()>("createMap");
-    auto __result = method(_javaPart);
-    return __result->cthis()->getMap();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JAnyMap::javaobject>()>("createMap");
+      auto __result = method(_javaPart);
+      return __result->cthis()->getMap();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<AnyMap> JHybridTestObjectSwiftKotlinSpec::mapRoundtrip(const std::shared_ptr<AnyMap>& map) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JAnyMap::javaobject>(jni::alias_ref<JAnyMap::javaobject> /* map */)>("mapRoundtrip");
-    auto __result = method(_javaPart, JAnyMap::create(map));
-    return __result->cthis()->getMap();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JAnyMap::javaobject>(jni::alias_ref<JAnyMap::javaobject> /* map */)>("mapRoundtrip");
+      auto __result = method(_javaPart, JAnyMap::create(map));
+      return __result->cthis()->getMap();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   double JHybridTestObjectSwiftKotlinSpec::funcThatThrows() {
-    static const auto method = _javaPart->getClass()->getMethod<double()>("funcThatThrows");
-    auto __result = method(_javaPart);
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<double()>("funcThatThrows");
+      auto __result = method(_javaPart);
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::funcThatThrowsBeforePromise() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("funcThatThrowsBeforePromise");
-    auto __result = method(_javaPart);
-    return [&]() {
-      auto __promise = Promise<void>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
-        __promise->resolve();
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("funcThatThrowsBeforePromise");
+      auto __result = method(_javaPart);
+      return [&]() {
+        auto __promise = Promise<void>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+          __promise->resolve();
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::throwError(const std::exception_ptr& error) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JThrowable> /* error */)>("throwError");
-    method(_javaPart, jni::getJavaExceptionForCppException(error));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JThrowable> /* error */)>("throwError");
+      method(_javaPart, jni::getJavaExceptionForCppException(error));
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::string JHybridTestObjectSwiftKotlinSpec::tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jboolean /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryOptionalParams");
-    auto __result = method(_javaPart, num, boo, str.has_value() ? jni::make_jstring(str.value()) : nullptr);
-    return __result->toStdString();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jboolean /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryOptionalParams");
+      auto __result = method(_javaPart, num, boo, str.has_value() ? jni::make_jstring(str.value()) : nullptr);
+      return __result->toStdString();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::string JHybridTestObjectSwiftKotlinSpec::tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jni::alias_ref<jni::JBoolean> /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryMiddleParam");
-    auto __result = method(_javaPart, num, boo.has_value() ? jni::JBoolean::valueOf(boo.value()) : nullptr, jni::make_jstring(str));
-    return __result->toStdString();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<jni::JString>(double /* num */, jni::alias_ref<jni::JBoolean> /* boo */, jni::alias_ref<jni::JString> /* str */)>("tryMiddleParam");
+      auto __result = method(_javaPart, num, boo.has_value() ? jni::JBoolean::valueOf(boo.value()) : nullptr, jni::make_jstring(str));
+      return __result->toStdString();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::optional<Powertrain> JHybridTestObjectSwiftKotlinSpec::tryOptionalEnum(std::optional<Powertrain> value) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPowertrain>(jni::alias_ref<JPowertrain> /* value */)>("tryOptionalEnum");
-    auto __result = method(_javaPart, value.has_value() ? JPowertrain::fromCpp(value.value()) : nullptr);
-    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPowertrain>(jni::alias_ref<JPowertrain> /* value */)>("tryOptionalEnum");
+      auto __result = method(_javaPart, value.has_value() ? JPowertrain::fromCpp(value.value()) : nullptr);
+      return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   int64_t JHybridTestObjectSwiftKotlinSpec::calculateFibonacciSync(double value) {
-    static const auto method = _javaPart->getClass()->getMethod<int64_t(double /* value */)>("calculateFibonacciSync");
-    auto __result = method(_javaPart, value);
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<int64_t(double /* value */)>("calculateFibonacciSync");
+      auto __result = method(_javaPart, value);
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<int64_t>> JHybridTestObjectSwiftKotlinSpec::calculateFibonacciAsync(double value) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* value */)>("calculateFibonacciAsync");
-    auto __result = method(_javaPart, value);
-    return [&]() {
-      auto __promise = Promise<int64_t>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<jni::JLong>(__boxedResult);
-        __promise->resolve(__result->value());
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* value */)>("calculateFibonacciAsync");
+      auto __result = method(_javaPart, value);
+      return [&]() {
+        auto __promise = Promise<int64_t>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<jni::JLong>(__boxedResult);
+          __promise->resolve(__result->value());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::wait(double seconds) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* seconds */)>("wait");
-    auto __result = method(_javaPart, seconds);
-    return [&]() {
-      auto __promise = Promise<void>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
-        __promise->resolve();
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(double /* seconds */)>("wait");
+      auto __result = method(_javaPart, seconds);
+      return [&]() {
+        auto __promise = Promise<void>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+          __promise->resolve();
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::promiseThrows() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("promiseThrows");
-    auto __result = method(_javaPart);
-    return [&]() {
-      auto __promise = Promise<void>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
-        __promise->resolve();
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("promiseThrows");
+      auto __result = method(_javaPart);
+      return [&]() {
+        auto __promise = Promise<void>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+          __promise->resolve();
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetPromise");
-    auto __result = method(_javaPart, [&]() {
-      jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
-      jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
-      promise->addOnResolvedListener([=](const double& __result) {
-        __promise->cthis()->resolve(jni::JDouble::valueOf(__result));
-      });
-      promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
-        auto __jniError = jni::getJavaExceptionForCppException(__error);
-        __promise->cthis()->reject(__jniError);
-      });
-      return __localPromise;
-    }());
-    return [&]() {
-      auto __promise = Promise<double>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
-        __promise->resolve(__result->value());
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetPromise");
+      auto __result = method(_javaPart, [&]() {
+        jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
+        jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
+        promise->addOnResolvedListener([=](const double& __result) {
+          __promise->cthis()->resolve(jni::JDouble::valueOf(__result));
+        });
+        promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
+          auto __jniError = jni::getJavaExceptionForCppException(__error);
+          __promise->cthis()->reject(__jniError);
+        });
+        return __localPromise;
+      }());
+      return [&]() {
+        auto __promise = Promise<double>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+          __promise->resolve(__result->value());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<Car>> JHybridTestObjectSwiftKotlinSpec::awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetComplexPromise");
-    auto __result = method(_javaPart, [&]() {
-      jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
-      jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
-      promise->addOnResolvedListener([=](const Car& __result) {
-        __promise->cthis()->resolve(JCar::fromCpp(__result));
-      });
-      promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
-        auto __jniError = jni::getJavaExceptionForCppException(__error);
-        __promise->cthis()->reject(__jniError);
-      });
-      return __localPromise;
-    }());
-    return [&]() {
-      auto __promise = Promise<Car>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<JCar>(__boxedResult);
-        __promise->resolve(__result->toCpp());
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetComplexPromise");
+      auto __result = method(_javaPart, [&]() {
+        jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
+        jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
+        promise->addOnResolvedListener([=](const Car& __result) {
+          __promise->cthis()->resolve(JCar::fromCpp(__result));
+        });
+        promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
+          auto __jniError = jni::getJavaExceptionForCppException(__error);
+          __promise->cthis()->reject(__jniError);
+        });
+        return __localPromise;
+      }());
+      return [&]() {
+        auto __promise = Promise<Car>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<JCar>(__boxedResult);
+          __promise->resolve(__result->toCpp());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::awaitPromise(const std::shared_ptr<Promise<void>>& promise) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitPromise");
-    auto __result = method(_javaPart, [&]() {
-      jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
-      jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
-      promise->addOnResolvedListener([=]() {
-        __promise->cthis()->resolve(JUnit::instance());
-      });
-      promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
-        auto __jniError = jni::getJavaExceptionForCppException(__error);
-        __promise->cthis()->reject(__jniError);
-      });
-      return __localPromise;
-    }());
-    return [&]() {
-      auto __promise = Promise<void>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
-        __promise->resolve();
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitPromise");
+      auto __result = method(_javaPart, [&]() {
+        jni::local_ref<JPromise::javaobject> __localPromise = JPromise::create();
+        jni::global_ref<JPromise::javaobject> __promise = jni::make_global(__localPromise);
+        promise->addOnResolvedListener([=]() {
+          __promise->cthis()->resolve(JUnit::instance());
+        });
+        promise->addOnRejectedListener([=](const std::exception_ptr& __error) {
+          auto __jniError = jni::getJavaExceptionForCppException(__error);
+          __promise->cthis()->reject(__jniError);
+        });
+        return __localPromise;
+      }());
+      return [&]() {
+        auto __promise = Promise<void>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+          __promise->resolve();
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::callCallback(const std::function<void()>& callback) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* callback */)>("callCallback");
-    method(_javaPart, JFunc_void::fromCpp(callback));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* callback */)>("callCallback_cxx");
+      method(_javaPart, JFunc_void::fromCpp(callback));
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::callAll(const std::function<void()>& first, const std::function<void()>& second, const std::function<void()>& third) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* first */, jni::alias_ref<JFunc_void::javaobject> /* second */, jni::alias_ref<JFunc_void::javaobject> /* third */)>("callAll");
-    method(_javaPart, JFunc_void::fromCpp(first), JFunc_void::fromCpp(second), JFunc_void::fromCpp(third));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* first */, jni::alias_ref<JFunc_void::javaobject> /* second */, jni::alias_ref<JFunc_void::javaobject> /* third */)>("callAll_cxx");
+      method(_javaPart, JFunc_void::fromCpp(first), JFunc_void::fromCpp(second), JFunc_void::fromCpp(third));
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::callWithOptional(std::optional<double> value, const std::function<void(std::optional<double> /* maybe */)>& callback) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JDouble> /* value */, jni::alias_ref<JFunc_void_std__optional_double_::javaobject> /* callback */)>("callWithOptional");
-    method(_javaPart, value.has_value() ? jni::JDouble::valueOf(value.value()) : nullptr, JFunc_void_std__optional_double_::fromCpp(callback));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JDouble> /* value */, jni::alias_ref<JFunc_void_std__optional_double_::javaobject> /* callback */)>("callWithOptional_cxx");
+      method(_javaPart, value.has_value() ? jni::JDouble::valueOf(value.value()) : nullptr, JFunc_void_std__optional_double_::fromCpp(callback));
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* callback */, double /* n */)>("callSumUpNTimes");
-    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double__::fromCpp(callback), n);
-    return [&]() {
-      auto __promise = Promise<double>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
-        __promise->resolve(__result->value());
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* callback */, double /* n */)>("callSumUpNTimes_cxx");
+      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double__::fromCpp(callback), n);
+      return [&]() {
+        auto __promise = Promise<double>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+          __promise->resolve(__result->value());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::callbackAsyncPromise(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& callback) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::javaobject> /* callback */)>("callbackAsyncPromise");
-    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::fromCpp(callback));
-    return [&]() {
-      auto __promise = Promise<double>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
-        __promise->resolve(__result->value());
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::javaobject> /* callback */)>("callbackAsyncPromise_cxx");
+      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::fromCpp(callback));
+      return [&]() {
+        auto __promise = Promise<double>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+          __promise->resolve(__result->value());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> JHybridTestObjectSwiftKotlinSpec::callbackAsyncPromiseBuffer(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& callback) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::javaobject> /* callback */)>("callbackAsyncPromiseBuffer");
-    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::fromCpp(callback));
-    return [&]() {
-      auto __promise = Promise<std::shared_ptr<ArrayBuffer>>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
-        __promise->resolve(__result->cthis()->getArrayBuffer());
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::javaobject> /* callback */)>("callbackAsyncPromiseBuffer_cxx");
+      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::fromCpp(callback));
+      return [&]() {
+        auto __promise = Promise<std::shared_ptr<ArrayBuffer>>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
+          __promise->resolve(__result->cthis()->getArrayBuffer());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::function<void(double /* value */)> JHybridTestObjectSwiftKotlinSpec::getComplexCallback() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getComplexCallback");
-    auto __result = method(_javaPart);
-    return __result->cthis()->getFunction();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JFunc_void_double::javaobject>()>("getComplexCallback_cxx");
+      auto __result = method(_javaPart);
+      return __result->cthis()->getFunction();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* getValue */)>("getValueFromJSCallbackAndWait");
-    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double__::fromCpp(getValue));
-    return [&]() {
-      auto __promise = Promise<double>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
-        __promise->resolve(__result->value());
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_double__::javaobject> /* getValue */)>("getValueFromJSCallbackAndWait_cxx");
+      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_double__::fromCpp(getValue));
+      return [&]() {
+        auto __promise = Promise<double>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+          __promise->resolve(__result->value());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__string__::javaobject> /* callback */, jni::alias_ref<JFunc_void_std__string::javaobject> /* andThenCall */)>("getValueFromJsCallback");
-    auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__string__::fromCpp(callback), JFunc_void_std__string::fromCpp(andThenCall));
-    return [&]() {
-      auto __promise = Promise<void>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
-        __promise->resolve();
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_std__shared_ptr_Promise_std__string__::javaobject> /* callback */, jni::alias_ref<JFunc_void_std__string::javaobject> /* andThenCall */)>("getValueFromJsCallback_cxx");
+      auto __result = method(_javaPart, JFunc_std__shared_ptr_Promise_std__string__::fromCpp(callback), JFunc_void_std__string::fromCpp(andThenCall));
+      return [&]() {
+        auto __promise = Promise<void>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+          __promise->resolve();
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   Car JHybridTestObjectSwiftKotlinSpec::getCar() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JCar>()>("getCar");
-    auto __result = method(_javaPart);
-    return __result->toCpp();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JCar>()>("getCar");
+      auto __result = method(_javaPart);
+      return __result->toCpp();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   bool JHybridTestObjectSwiftKotlinSpec::isCarElectric(const Car& car) {
-    static const auto method = _javaPart->getClass()->getMethod<jboolean(jni::alias_ref<JCar> /* car */)>("isCarElectric");
-    auto __result = method(_javaPart, JCar::fromCpp(car));
-    return static_cast<bool>(__result);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jboolean(jni::alias_ref<JCar> /* car */)>("isCarElectric");
+      auto __result = method(_javaPart, JCar::fromCpp(car));
+      return static_cast<bool>(__result);
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::optional<Person> JHybridTestObjectSwiftKotlinSpec::getDriver(const Car& car) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPerson>(jni::alias_ref<JCar> /* car */)>("getDriver");
-    auto __result = method(_javaPart, JCar::fromCpp(car));
-    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPerson>(jni::alias_ref<JCar> /* car */)>("getDriver");
+      auto __result = method(_javaPart, JCar::fromCpp(car));
+      return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::jsStyleObjectAsParameters(const JsStyleStruct& params) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JJsStyleStruct> /* params */)>("jsStyleObjectAsParameters");
-    method(_javaPart, JJsStyleStruct::fromCpp(params));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JJsStyleStruct> /* params */)>("jsStyleObjectAsParameters");
+      method(_javaPart, JJsStyleStruct::fromCpp(params));
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<ArrayBuffer> JHybridTestObjectSwiftKotlinSpec::createArrayBuffer() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JArrayBuffer::javaobject>()>("createArrayBuffer");
-    auto __result = method(_javaPart);
-    return __result->cthis()->getArrayBuffer();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JArrayBuffer::javaobject>()>("createArrayBuffer");
+      auto __result = method(_javaPart);
+      return __result->cthis()->getArrayBuffer();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   double JHybridTestObjectSwiftKotlinSpec::getBufferLastItem(const std::shared_ptr<ArrayBuffer>& buffer) {
-    static const auto method = _javaPart->getClass()->getMethod<double(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */)>("getBufferLastItem");
-    auto __result = method(_javaPart, JArrayBuffer::wrap(buffer));
-    return __result;
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<double(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */)>("getBufferLastItem");
+      auto __result = method(_javaPart, JArrayBuffer::wrap(buffer));
+      return __result;
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   void JHybridTestObjectSwiftKotlinSpec::setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */, double /* value */)>("setAllValuesTo");
-    method(_javaPart, JArrayBuffer::wrap(buffer), value);
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JArrayBuffer::javaobject> /* buffer */, double /* value */)>("setAllValuesTo");
+      method(_javaPart, JArrayBuffer::wrap(buffer), value);
+         
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> JHybridTestObjectSwiftKotlinSpec::createArrayBufferAsync() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("createArrayBufferAsync");
-    auto __result = method(_javaPart);
-    return [&]() {
-      auto __promise = Promise<std::shared_ptr<ArrayBuffer>>::create();
-      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
-        __promise->resolve(__result->cthis()->getArrayBuffer());
-      });
-      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
-        jni::JniException __jniError(__throwable);
-        __promise->reject(std::make_exception_ptr(__jniError));
-      });
-      return __promise;
-    }();
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JPromise::javaobject>()>("createArrayBufferAsync");
+      auto __result = method(_javaPart);
+      return [&]() {
+        auto __promise = Promise<std::shared_ptr<ArrayBuffer>>::create();
+        __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+          auto __result = jni::static_ref_cast<JArrayBuffer::javaobject>(__boxedResult);
+          __promise->resolve(__result->cthis()->getArrayBuffer());
+        });
+        __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+          jni::JniException __jniError(__throwable);
+          __promise->reject(std::make_exception_ptr(__jniError));
+        });
+        return __promise;
+      }();
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> JHybridTestObjectSwiftKotlinSpec::createChild() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>()>("createChild");
-    auto __result = method(_javaPart);
-    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>()>("createChild");
+      auto __result = method(_javaPart);
+      return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::createBase() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>()>("createBase");
-    auto __result = method(_javaPart);
-    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>()>("createBase");
+      auto __result = method(_javaPart);
+      return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::createBaseActualChild() {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>()>("createBaseActualChild");
-    auto __result = method(_javaPart);
-    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>()>("createBaseActualChild");
+      auto __result = method(_javaPart);
+      return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> JHybridTestObjectSwiftKotlinSpec::bounceChild(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridChildSpec::javaobject> /* child */)>("bounceChild");
-    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
-    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridChildSpec::javaobject> /* child */)>("bounceChild");
+      auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
+      return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("bounceBase");
-    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
-    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("bounceBase");
+      auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
+      return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<margelo::nitro::image::HybridBaseSpec> JHybridTestObjectSwiftKotlinSpec::bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>(jni::alias_ref<JHybridChildSpec::javaobject> /* child */)>("bounceChildBase");
-    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
-    return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridBaseSpec::javaobject>(jni::alias_ref<JHybridChildSpec::javaobject> /* child */)>("bounceChildBase");
+      auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridChildSpec>(child)->getJavaPart());
+      return JNISharedPtr::make_shared_from_jni<JHybridBaseSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
   std::shared_ptr<margelo::nitro::image::HybridChildSpec> JHybridTestObjectSwiftKotlinSpec::castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) {
-    static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("castBase");
-    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
-    return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
+    try {
+      
+      static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("castBase");
+      auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
+      return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
+          
+    } catch (const jni::JniException& exc) {
+      throw std::runtime_error(exc.what());
+    }
   }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -70,6 +70,8 @@ namespace margelo::nitro::image {
     void setOptionalEnum(std::optional<Powertrain> optionalEnum) override;
     std::optional<OldEnum> getOptionalOldEnum() override;
     void setOptionalOldEnum(std::optional<OldEnum> optionalOldEnum) override;
+    std::optional<std::function<void(double /* value */)>> getOptionalCallback() override;
+    void setOptionalCallback(const std::optional<std::function<void(double /* value */)>>& optionalCallback) override;
     std::variant<std::string, double> getSomeVariant() override;
     void setSomeVariant(const std::variant<std::string, double>& someVariant) override;
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -108,6 +108,7 @@ namespace margelo::nitro::image {
     std::shared_ptr<Promise<double>> callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) override;
     std::shared_ptr<Promise<double>> callbackAsyncPromise(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& callback) override;
     std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> callbackAsyncPromiseBuffer(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& callback) override;
+    std::function<void(double /* value */)> getComplexCallback() override;
     std::shared_ptr<Promise<double>> getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) override;
     std::shared_ptr<Promise<void>> getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) override;
     Car getCar() override;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JImageFormat.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JImageFormat.hpp
@@ -26,6 +26,7 @@ namespace margelo::nitro::image {
      * Convert this Java/Kotlin-based enum to the C++ enum ImageFormat.
      */
     [[maybe_unused]]
+    [[nodiscard]]
     ImageFormat toCpp() const {
       static const auto clazz = javaClassStatic();
       static const auto fieldOrdinal = clazz->getField<int>("_ordinal");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JImageSize.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JImageSize.hpp
@@ -28,6 +28,7 @@ namespace margelo::nitro::image {
      * Convert this Java/Kotlin-based struct to the C++ struct ImageSize by copying all values to C++.
      */
     [[maybe_unused]]
+    [[nodiscard]]
     ImageSize toCpp() const {
       static const auto clazz = javaClassStatic();
       static const auto fieldWidth = clazz->getField<double>("width");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JOldEnum.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JOldEnum.hpp
@@ -26,6 +26,7 @@ namespace margelo::nitro::image {
      * Convert this Java/Kotlin-based enum to the C++ enum OldEnum.
      */
     [[maybe_unused]]
+    [[nodiscard]]
     OldEnum toCpp() const {
       static const auto clazz = javaClassStatic();
       static const auto fieldOrdinal = clazz->getField<int>("_ordinal");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPerson.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPerson.hpp
@@ -28,6 +28,7 @@ namespace margelo::nitro::image {
      * Convert this Java/Kotlin-based struct to the C++ struct Person by copying all values to C++.
      */
     [[maybe_unused]]
+    [[nodiscard]]
     Person toCpp() const {
       static const auto clazz = javaClassStatic();
       static const auto fieldName = clazz->getField<jni::JString>("name");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPixelFormat.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPixelFormat.hpp
@@ -26,6 +26,7 @@ namespace margelo::nitro::image {
      * Convert this Java/Kotlin-based enum to the C++ enum PixelFormat.
      */
     [[maybe_unused]]
+    [[nodiscard]]
     PixelFormat toCpp() const {
       static const auto clazz = javaClassStatic();
       static const auto fieldOrdinal = clazz->getField<int>("_ordinal");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPowertrain.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPowertrain.hpp
@@ -26,6 +26,7 @@ namespace margelo::nitro::image {
      * Convert this Java/Kotlin-based enum to the C++ enum Powertrain.
      */
     [[maybe_unused]]
+    [[nodiscard]]
     Powertrain toCpp() const {
       static const auto clazz = javaClassStatic();
       static const auto fieldOrdinal = clazz->getField<int>("_ordinal");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Car.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Car.kt
@@ -24,4 +24,6 @@ data class Car(
   val powertrain: Powertrain,
   val driver: Person?,
   val isFast: Boolean?
-)
+) {
+  /* main constructor */
+}

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Car.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Car.kt
@@ -16,14 +16,17 @@ import com.margelo.nitro.core.*
  */
 @DoNotStrip
 @Keep
-data class Car(
-  val year: Double,
-  val make: String,
-  val model: String,
-  val power: Double,
-  val powertrain: Powertrain,
-  val driver: Person?,
-  val isFast: Boolean?
-) {
+data class Car
+  @DoNotStrip
+  @Keep
+  constructor(
+    val year: Double,
+    val make: String,
+    val model: String,
+    val power: Double,
+    val powertrain: Powertrain,
+    val driver: Person?,
+    val isFast: Boolean?
+  ) {
   /* main constructor */
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_double__.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_double__.kt
@@ -15,12 +15,35 @@ import dalvik.annotation.optimization.FastNative
 
 /**
  * Represents the JavaScript callback `() => std::shared_ptr<Promise<double>>`.
- * This is implemented in C++, via a `std::function<...>`.
+ * This can be either implemented in C++ (in which case it might be a callback coming from JS),
+ * or in Kotlin/Java (in which case it is a native callback).
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
-class Func_std__shared_ptr_Promise_double__ {
+@Suppress("ClassName", "RedundantUnitReturnType")
+fun interface Func_std__shared_ptr_Promise_double__: () -> Promise<Double> {
+  /**
+   * Call the given JS callback.
+   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
+   */
+  @DoNotStrip
+  @Keep
+  override fun invoke(): Promise<Double>
+}
+
+/**
+ * Represents the JavaScript callback `() => std::shared_ptr<Promise<double>>`.
+ * This is implemented in C++, via a `std::function<...>`.
+ * The callback might be coming from JS.
+ */
+@DoNotStrip
+@Keep
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "ConvertSecondaryConstructorToPrimary", "ClassName", "LocalVariableName",
+)
+class Func_std__shared_ptr_Promise_double___cxx: Func_std__shared_ptr_Promise_double__ {
   @DoNotStrip
   @Keep
   private val mHybridData: HybridData
@@ -31,16 +54,22 @@ class Func_std__shared_ptr_Promise_double__ {
     mHybridData = hybridData
   }
 
-  /**
-   * Converts this function to a Kotlin Lambda.
-   * This exists purely as syntactic sugar, and has minimal runtime overhead.
-   */
-  fun toLambda(): () -> Promise<Double> = this::call
-
-  /**
-   * Call the given JS callback.
-   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
-   */
   @FastNative
-  external fun call(): Promise<Double>
+  external override fun invoke(): Promise<Double>
+}
+
+/**
+ * Represents the JavaScript callback `() => std::shared_ptr<Promise<double>>`.
+ * This is implemented in Java/Kotlin, via a `() -> Promise<Double>`.
+ * The callback is always coming from native.
+ */
+@DoNotStrip
+@Keep
+@Suppress("ClassName", "RedundantUnitReturnType", "unused")
+class Func_std__shared_ptr_Promise_double___java(private val function: () -> Promise<Double>): Func_std__shared_ptr_Promise_double__ {
+  @DoNotStrip
+  @Keep
+  override fun invoke(): Promise<Double> {
+    return this.function()
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_double__.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_double__.kt
@@ -19,7 +19,7 @@ import dalvik.annotation.optimization.FastNative
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused")
+@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
 class Func_std__shared_ptr_Promise_double__ {
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.kt
@@ -19,7 +19,7 @@ import dalvik.annotation.optimization.FastNative
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused")
+@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
 class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ {
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.kt
@@ -15,12 +15,35 @@ import dalvik.annotation.optimization.FastNative
 
 /**
  * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>`.
- * This is implemented in C++, via a `std::function<...>`.
+ * This can be either implemented in C++ (in which case it might be a callback coming from JS),
+ * or in Kotlin/Java (in which case it is a native callback).
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
-class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ {
+@Suppress("ClassName", "RedundantUnitReturnType")
+fun interface Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____: () -> Promise<Promise<Double>> {
+  /**
+   * Call the given JS callback.
+   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
+   */
+  @DoNotStrip
+  @Keep
+  override fun invoke(): Promise<Promise<Double>>
+}
+
+/**
+ * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>`.
+ * This is implemented in C++, via a `std::function<...>`.
+ * The callback might be coming from JS.
+ */
+@DoNotStrip
+@Keep
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "ConvertSecondaryConstructorToPrimary", "ClassName", "LocalVariableName",
+)
+class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ {
   @DoNotStrip
   @Keep
   private val mHybridData: HybridData
@@ -31,16 +54,22 @@ class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ {
     mHybridData = hybridData
   }
 
-  /**
-   * Converts this function to a Kotlin Lambda.
-   * This exists purely as syntactic sugar, and has minimal runtime overhead.
-   */
-  fun toLambda(): () -> Promise<Promise<Double>> = this::call
-
-  /**
-   * Call the given JS callback.
-   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
-   */
   @FastNative
-  external fun call(): Promise<Promise<Double>>
+  external override fun invoke(): Promise<Promise<Double>>
+}
+
+/**
+ * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>`.
+ * This is implemented in Java/Kotlin, via a `() -> Promise<Promise<Double>>`.
+ * The callback is always coming from native.
+ */
+@DoNotStrip
+@Keep
+@Suppress("ClassName", "RedundantUnitReturnType", "unused")
+class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____java(private val function: () -> Promise<Promise<Double>>): Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ {
+  @DoNotStrip
+  @Keep
+  override fun invoke(): Promise<Promise<Double>> {
+    return this.function()
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.kt
@@ -15,12 +15,35 @@ import dalvik.annotation.optimization.FastNative
 
 /**
  * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>`.
- * This is implemented in C++, via a `std::function<...>`.
+ * This can be either implemented in C++ (in which case it might be a callback coming from JS),
+ * or in Kotlin/Java (in which case it is a native callback).
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
-class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ {
+@Suppress("ClassName", "RedundantUnitReturnType")
+fun interface Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____: () -> Promise<Promise<ArrayBuffer>> {
+  /**
+   * Call the given JS callback.
+   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
+   */
+  @DoNotStrip
+  @Keep
+  override fun invoke(): Promise<Promise<ArrayBuffer>>
+}
+
+/**
+ * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>`.
+ * This is implemented in C++, via a `std::function<...>`.
+ * The callback might be coming from JS.
+ */
+@DoNotStrip
+@Keep
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "ConvertSecondaryConstructorToPrimary", "ClassName", "LocalVariableName",
+)
+class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______cxx: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ {
   @DoNotStrip
   @Keep
   private val mHybridData: HybridData
@@ -31,16 +54,22 @@ class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_Array
     mHybridData = hybridData
   }
 
-  /**
-   * Converts this function to a Kotlin Lambda.
-   * This exists purely as syntactic sugar, and has minimal runtime overhead.
-   */
-  fun toLambda(): () -> Promise<Promise<ArrayBuffer>> = this::call
-
-  /**
-   * Call the given JS callback.
-   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
-   */
   @FastNative
-  external fun call(): Promise<Promise<ArrayBuffer>>
+  external override fun invoke(): Promise<Promise<ArrayBuffer>>
+}
+
+/**
+ * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>`.
+ * This is implemented in Java/Kotlin, via a `() -> Promise<Promise<ArrayBuffer>>`.
+ * The callback is always coming from native.
+ */
+@DoNotStrip
+@Keep
+@Suppress("ClassName", "RedundantUnitReturnType", "unused")
+class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______java(private val function: () -> Promise<Promise<ArrayBuffer>>): Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ {
+  @DoNotStrip
+  @Keep
+  override fun invoke(): Promise<Promise<ArrayBuffer>> {
+    return this.function()
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.kt
@@ -19,7 +19,7 @@ import dalvik.annotation.optimization.FastNative
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused")
+@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
 class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ {
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__string__.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__string__.kt
@@ -15,12 +15,35 @@ import dalvik.annotation.optimization.FastNative
 
 /**
  * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::string>>`.
- * This is implemented in C++, via a `std::function<...>`.
+ * This can be either implemented in C++ (in which case it might be a callback coming from JS),
+ * or in Kotlin/Java (in which case it is a native callback).
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
-class Func_std__shared_ptr_Promise_std__string__ {
+@Suppress("ClassName", "RedundantUnitReturnType")
+fun interface Func_std__shared_ptr_Promise_std__string__: () -> Promise<String> {
+  /**
+   * Call the given JS callback.
+   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
+   */
+  @DoNotStrip
+  @Keep
+  override fun invoke(): Promise<String>
+}
+
+/**
+ * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::string>>`.
+ * This is implemented in C++, via a `std::function<...>`.
+ * The callback might be coming from JS.
+ */
+@DoNotStrip
+@Keep
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "ConvertSecondaryConstructorToPrimary", "ClassName", "LocalVariableName",
+)
+class Func_std__shared_ptr_Promise_std__string___cxx: Func_std__shared_ptr_Promise_std__string__ {
   @DoNotStrip
   @Keep
   private val mHybridData: HybridData
@@ -31,16 +54,22 @@ class Func_std__shared_ptr_Promise_std__string__ {
     mHybridData = hybridData
   }
 
-  /**
-   * Converts this function to a Kotlin Lambda.
-   * This exists purely as syntactic sugar, and has minimal runtime overhead.
-   */
-  fun toLambda(): () -> Promise<String> = this::call
-
-  /**
-   * Call the given JS callback.
-   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
-   */
   @FastNative
-  external fun call(): Promise<String>
+  external override fun invoke(): Promise<String>
+}
+
+/**
+ * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::string>>`.
+ * This is implemented in Java/Kotlin, via a `() -> Promise<String>`.
+ * The callback is always coming from native.
+ */
+@DoNotStrip
+@Keep
+@Suppress("ClassName", "RedundantUnitReturnType", "unused")
+class Func_std__shared_ptr_Promise_std__string___java(private val function: () -> Promise<String>): Func_std__shared_ptr_Promise_std__string__ {
+  @DoNotStrip
+  @Keep
+  override fun invoke(): Promise<String> {
+    return this.function()
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__string__.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_std__shared_ptr_Promise_std__string__.kt
@@ -19,7 +19,7 @@ import dalvik.annotation.optimization.FastNative
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused")
+@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
 class Func_std__shared_ptr_Promise_std__string__ {
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void.kt
@@ -15,12 +15,35 @@ import dalvik.annotation.optimization.FastNative
 
 /**
  * Represents the JavaScript callback `() => void`.
- * This is implemented in C++, via a `std::function<...>`.
+ * This can be either implemented in C++ (in which case it might be a callback coming from JS),
+ * or in Kotlin/Java (in which case it is a native callback).
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
-class Func_void {
+@Suppress("ClassName", "RedundantUnitReturnType")
+fun interface Func_void: () -> Unit {
+  /**
+   * Call the given JS callback.
+   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
+   */
+  @DoNotStrip
+  @Keep
+  override fun invoke(): Unit
+}
+
+/**
+ * Represents the JavaScript callback `() => void`.
+ * This is implemented in C++, via a `std::function<...>`.
+ * The callback might be coming from JS.
+ */
+@DoNotStrip
+@Keep
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "ConvertSecondaryConstructorToPrimary", "ClassName", "LocalVariableName",
+)
+class Func_void_cxx: Func_void {
   @DoNotStrip
   @Keep
   private val mHybridData: HybridData
@@ -31,16 +54,22 @@ class Func_void {
     mHybridData = hybridData
   }
 
-  /**
-   * Converts this function to a Kotlin Lambda.
-   * This exists purely as syntactic sugar, and has minimal runtime overhead.
-   */
-  fun toLambda(): () -> Unit = this::call
-
-  /**
-   * Call the given JS callback.
-   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
-   */
   @FastNative
-  external fun call(): Unit
+  external override fun invoke(): Unit
+}
+
+/**
+ * Represents the JavaScript callback `() => void`.
+ * This is implemented in Java/Kotlin, via a `() -> Unit`.
+ * The callback is always coming from native.
+ */
+@DoNotStrip
+@Keep
+@Suppress("ClassName", "RedundantUnitReturnType", "unused")
+class Func_void_java(private val function: () -> Unit): Func_void {
+  @DoNotStrip
+  @Keep
+  override fun invoke(): Unit {
+    return this.function()
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void.kt
@@ -19,7 +19,7 @@ import dalvik.annotation.optimization.FastNative
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused")
+@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
 class Func_void {
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_double.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_double.kt
@@ -19,7 +19,7 @@ import dalvik.annotation.optimization.FastNative
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused")
+@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
 class Func_void_double {
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_double.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_double.kt
@@ -15,12 +15,35 @@ import dalvik.annotation.optimization.FastNative
 
 /**
  * Represents the JavaScript callback `(num: number) => void`.
- * This is implemented in C++, via a `std::function<...>`.
+ * This can be either implemented in C++ (in which case it might be a callback coming from JS),
+ * or in Kotlin/Java (in which case it is a native callback).
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
-class Func_void_double {
+@Suppress("ClassName", "RedundantUnitReturnType")
+fun interface Func_void_double: (Double) -> Unit {
+  /**
+   * Call the given JS callback.
+   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
+   */
+  @DoNotStrip
+  @Keep
+  override fun invoke(num: Double): Unit
+}
+
+/**
+ * Represents the JavaScript callback `(num: number) => void`.
+ * This is implemented in C++, via a `std::function<...>`.
+ * The callback might be coming from JS.
+ */
+@DoNotStrip
+@Keep
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "ConvertSecondaryConstructorToPrimary", "ClassName", "LocalVariableName",
+)
+class Func_void_double_cxx: Func_void_double {
   @DoNotStrip
   @Keep
   private val mHybridData: HybridData
@@ -31,16 +54,22 @@ class Func_void_double {
     mHybridData = hybridData
   }
 
-  /**
-   * Converts this function to a Kotlin Lambda.
-   * This exists purely as syntactic sugar, and has minimal runtime overhead.
-   */
-  fun toLambda(): (num: Double) -> Unit = this::call
-
-  /**
-   * Call the given JS callback.
-   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
-   */
   @FastNative
-  external fun call(num: Double): Unit
+  external override fun invoke(num: Double): Unit
+}
+
+/**
+ * Represents the JavaScript callback `(num: number) => void`.
+ * This is implemented in Java/Kotlin, via a `(Double) -> Unit`.
+ * The callback is always coming from native.
+ */
+@DoNotStrip
+@Keep
+@Suppress("ClassName", "RedundantUnitReturnType", "unused")
+class Func_void_double_java(private val function: (Double) -> Unit): Func_void_double {
+  @DoNotStrip
+  @Keep
+  override fun invoke(num: Double): Unit {
+    return this.function(num)
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__optional_double_.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__optional_double_.kt
@@ -19,7 +19,7 @@ import dalvik.annotation.optimization.FastNative
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused")
+@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
 class Func_void_std__optional_double_ {
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__optional_double_.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__optional_double_.kt
@@ -15,12 +15,35 @@ import dalvik.annotation.optimization.FastNative
 
 /**
  * Represents the JavaScript callback `(maybe: optional) => void`.
- * This is implemented in C++, via a `std::function<...>`.
+ * This can be either implemented in C++ (in which case it might be a callback coming from JS),
+ * or in Kotlin/Java (in which case it is a native callback).
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
-class Func_void_std__optional_double_ {
+@Suppress("ClassName", "RedundantUnitReturnType")
+fun interface Func_void_std__optional_double_: (Double?) -> Unit {
+  /**
+   * Call the given JS callback.
+   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
+   */
+  @DoNotStrip
+  @Keep
+  override fun invoke(maybe: Double?): Unit
+}
+
+/**
+ * Represents the JavaScript callback `(maybe: optional) => void`.
+ * This is implemented in C++, via a `std::function<...>`.
+ * The callback might be coming from JS.
+ */
+@DoNotStrip
+@Keep
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "ConvertSecondaryConstructorToPrimary", "ClassName", "LocalVariableName",
+)
+class Func_void_std__optional_double__cxx: Func_void_std__optional_double_ {
   @DoNotStrip
   @Keep
   private val mHybridData: HybridData
@@ -31,16 +54,22 @@ class Func_void_std__optional_double_ {
     mHybridData = hybridData
   }
 
-  /**
-   * Converts this function to a Kotlin Lambda.
-   * This exists purely as syntactic sugar, and has minimal runtime overhead.
-   */
-  fun toLambda(): (maybe: Double?) -> Unit = this::call
-
-  /**
-   * Call the given JS callback.
-   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
-   */
   @FastNative
-  external fun call(maybe: Double?): Unit
+  external override fun invoke(maybe: Double?): Unit
+}
+
+/**
+ * Represents the JavaScript callback `(maybe: optional) => void`.
+ * This is implemented in Java/Kotlin, via a `(Double?) -> Unit`.
+ * The callback is always coming from native.
+ */
+@DoNotStrip
+@Keep
+@Suppress("ClassName", "RedundantUnitReturnType", "unused")
+class Func_void_std__optional_double__java(private val function: (Double?) -> Unit): Func_void_std__optional_double_ {
+  @DoNotStrip
+  @Keep
+  override fun invoke(maybe: Double?): Unit {
+    return this.function(maybe)
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__string.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__string.kt
@@ -19,7 +19,7 @@ import dalvik.annotation.optimization.FastNative
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused")
+@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
 class Func_void_std__string {
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__string.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__string.kt
@@ -15,12 +15,35 @@ import dalvik.annotation.optimization.FastNative
 
 /**
  * Represents the JavaScript callback `(valueFromJs: string) => void`.
- * This is implemented in C++, via a `std::function<...>`.
+ * This can be either implemented in C++ (in which case it might be a callback coming from JS),
+ * or in Kotlin/Java (in which case it is a native callback).
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
-class Func_void_std__string {
+@Suppress("ClassName", "RedundantUnitReturnType")
+fun interface Func_void_std__string: (String) -> Unit {
+  /**
+   * Call the given JS callback.
+   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
+   */
+  @DoNotStrip
+  @Keep
+  override fun invoke(valueFromJs: String): Unit
+}
+
+/**
+ * Represents the JavaScript callback `(valueFromJs: string) => void`.
+ * This is implemented in C++, via a `std::function<...>`.
+ * The callback might be coming from JS.
+ */
+@DoNotStrip
+@Keep
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "ConvertSecondaryConstructorToPrimary", "ClassName", "LocalVariableName",
+)
+class Func_void_std__string_cxx: Func_void_std__string {
   @DoNotStrip
   @Keep
   private val mHybridData: HybridData
@@ -31,16 +54,22 @@ class Func_void_std__string {
     mHybridData = hybridData
   }
 
-  /**
-   * Converts this function to a Kotlin Lambda.
-   * This exists purely as syntactic sugar, and has minimal runtime overhead.
-   */
-  fun toLambda(): (valueFromJs: String) -> Unit = this::call
-
-  /**
-   * Call the given JS callback.
-   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
-   */
   @FastNative
-  external fun call(valueFromJs: String): Unit
+  external override fun invoke(valueFromJs: String): Unit
+}
+
+/**
+ * Represents the JavaScript callback `(valueFromJs: string) => void`.
+ * This is implemented in Java/Kotlin, via a `(String) -> Unit`.
+ * The callback is always coming from native.
+ */
+@DoNotStrip
+@Keep
+@Suppress("ClassName", "RedundantUnitReturnType", "unused")
+class Func_void_std__string_java(private val function: (String) -> Unit): Func_void_std__string {
+  @DoNotStrip
+  @Keep
+  override fun invoke(valueFromJs: String): Unit {
+    return this.function(valueFromJs)
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__vector_Powertrain_.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__vector_Powertrain_.kt
@@ -15,12 +15,35 @@ import dalvik.annotation.optimization.FastNative
 
 /**
  * Represents the JavaScript callback `(array: array) => void`.
- * This is implemented in C++, via a `std::function<...>`.
+ * This can be either implemented in C++ (in which case it might be a callback coming from JS),
+ * or in Kotlin/Java (in which case it is a native callback).
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
-class Func_void_std__vector_Powertrain_ {
+@Suppress("ClassName", "RedundantUnitReturnType")
+fun interface Func_void_std__vector_Powertrain_: (Array<Powertrain>) -> Unit {
+  /**
+   * Call the given JS callback.
+   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
+   */
+  @DoNotStrip
+  @Keep
+  override fun invoke(array: Array<Powertrain>): Unit
+}
+
+/**
+ * Represents the JavaScript callback `(array: array) => void`.
+ * This is implemented in C++, via a `std::function<...>`.
+ * The callback might be coming from JS.
+ */
+@DoNotStrip
+@Keep
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "ConvertSecondaryConstructorToPrimary", "ClassName", "LocalVariableName",
+)
+class Func_void_std__vector_Powertrain__cxx: Func_void_std__vector_Powertrain_ {
   @DoNotStrip
   @Keep
   private val mHybridData: HybridData
@@ -31,16 +54,22 @@ class Func_void_std__vector_Powertrain_ {
     mHybridData = hybridData
   }
 
-  /**
-   * Converts this function to a Kotlin Lambda.
-   * This exists purely as syntactic sugar, and has minimal runtime overhead.
-   */
-  fun toLambda(): (array: Array<Powertrain>) -> Unit = this::call
-
-  /**
-   * Call the given JS callback.
-   * @throws Throwable if the JS function itself throws an error, or if the JS function/runtime has already been deleted.
-   */
   @FastNative
-  external fun call(array: Array<Powertrain>): Unit
+  external override fun invoke(array: Array<Powertrain>): Unit
+}
+
+/**
+ * Represents the JavaScript callback `(array: array) => void`.
+ * This is implemented in Java/Kotlin, via a `(Array<Powertrain>) -> Unit`.
+ * The callback is always coming from native.
+ */
+@DoNotStrip
+@Keep
+@Suppress("ClassName", "RedundantUnitReturnType", "unused")
+class Func_void_std__vector_Powertrain__java(private val function: (Array<Powertrain>) -> Unit): Func_void_std__vector_Powertrain_ {
+  @DoNotStrip
+  @Keep
+  override fun invoke(array: Array<Powertrain>): Unit {
+    return this.function(array)
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__vector_Powertrain_.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Func_void_std__vector_Powertrain_.kt
@@ -19,7 +19,7 @@ import dalvik.annotation.optimization.FastNative
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused")
+@Suppress("RedundantSuppression", "ConvertSecondaryConstructorToPrimary", "RedundantUnitReturnType", "KotlinJniMissingFunction", "ClassName", "unused", "LocalVariableName")
 class Func_void_std__vector_Powertrain_ {
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridBaseSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridBaseSpec.kt
@@ -19,7 +19,11 @@ import com.margelo.nitro.core.*
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "KotlinJniMissingFunction", "PropertyName", "RedundantUnitReturnType", "unused")
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "LocalVariableName", "PropertyName", "FunctionName",
+  "RedundantSuppression", "RedundantUnitReturnType"
+)
 abstract class HybridBaseSpec: HybridObject() {
   @DoNotStrip
   private var mHybridData: HybridData = initHybrid()

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridBaseSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridBaseSpec.kt
@@ -21,8 +21,8 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "LocalVariableName", "PropertyName", "FunctionName",
-  "RedundantSuppression", "RedundantUnitReturnType"
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridBaseSpec: HybridObject() {
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridBaseSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridBaseSpec.kt
@@ -21,7 +21,7 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "RedundantSuppression", "RedundantUnitReturnType",
+  "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridBaseSpec: HybridObject() {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridChildSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridChildSpec.kt
@@ -21,7 +21,7 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "RedundantSuppression", "RedundantUnitReturnType",
+  "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridChildSpec: HybridBaseSpec() {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridChildSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridChildSpec.kt
@@ -21,8 +21,8 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "LocalVariableName", "PropertyName", "FunctionName",
-  "RedundantSuppression", "RedundantUnitReturnType"
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridChildSpec: HybridBaseSpec() {
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridChildSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridChildSpec.kt
@@ -19,7 +19,11 @@ import com.margelo.nitro.core.*
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "KotlinJniMissingFunction", "PropertyName", "RedundantUnitReturnType", "unused")
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "LocalVariableName", "PropertyName", "FunctionName",
+  "RedundantSuppression", "RedundantUnitReturnType"
+)
 abstract class HybridChildSpec: HybridBaseSpec() {
   @DoNotStrip
   private var mHybridData: HybridData = initHybrid()

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
@@ -19,7 +19,11 @@ import com.margelo.nitro.core.*
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "KotlinJniMissingFunction", "PropertyName", "RedundantUnitReturnType", "unused")
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "LocalVariableName", "PropertyName", "FunctionName",
+  "RedundantSuppression", "RedundantUnitReturnType"
+)
 abstract class HybridImageFactorySpec: HybridObject() {
   @DoNotStrip
   private var mHybridData: HybridData = initHybrid()

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
@@ -21,8 +21,8 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "LocalVariableName", "PropertyName", "FunctionName",
-  "RedundantSuppression", "RedundantUnitReturnType"
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridImageFactorySpec: HybridObject() {
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
@@ -21,7 +21,7 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "RedundantSuppression", "RedundantUnitReturnType",
+  "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridImageFactorySpec: HybridObject() {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -19,7 +19,11 @@ import com.margelo.nitro.core.*
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "KotlinJniMissingFunction", "PropertyName", "RedundantUnitReturnType", "unused")
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "LocalVariableName", "PropertyName", "FunctionName",
+  "RedundantSuppression", "RedundantUnitReturnType"
+)
 abstract class HybridImageSpec: HybridObject() {
   @DoNotStrip
   private var mHybridData: HybridData = initHybrid()
@@ -63,7 +67,7 @@ abstract class HybridImageSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  private fun saveToFile(path: String, onFinished: Func_void_std__string): Unit {
+  private fun saveToFile_cxx(path: String, onFinished: Func_void_std__string): Unit {
     val __result = saveToFile(path, onFinished.toLambda())
     return __result
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -21,7 +21,7 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "RedundantSuppression", "RedundantUnitReturnType",
+  "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridImageSpec: HybridObject() {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -21,8 +21,8 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "LocalVariableName", "PropertyName", "FunctionName",
-  "RedundantSuppression", "RedundantUnitReturnType"
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridImageSpec: HybridObject() {
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -66,7 +66,7 @@ abstract class HybridImageSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun saveToFile_cxx(path: String, onFinished: Func_void_std__string): Unit {
-    val __result = saveToFile(path, onFinished.toLambda())
+    val __result = saveToFile(path, onFinished /* TODO: Does this work? */)
     return __result
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -66,7 +66,7 @@ abstract class HybridImageSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun saveToFile_cxx(path: String, onFinished: Func_void_std__string): Unit {
-    val __result = saveToFile(path, onFinished /* TODO: Does this work? */)
+    val __result = saveToFile(path, onFinished)
     return __result
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -61,8 +61,6 @@ abstract class HybridImageSpec: HybridObject() {
   @Keep
   abstract fun toArrayBuffer(format: ImageFormat): Double
   
-  @DoNotStrip
-  @Keep
   abstract fun saveToFile(path: String, onFinished: (path: String) -> Unit): Unit
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -296,6 +296,17 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun getComplexCallback(): (value: Double) -> Unit
+  
+  @DoNotStrip
+  @Keep
+  private fun getComplexCallback(): Func_void_double {
+    val __result = getComplexCallback()
+    return __result
+  }
+  
+  @DoNotStrip
+  @Keep
   abstract fun getValueFromJSCallbackAndWait(getValue: () -> Promise<Double>): Promise<Double>
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -123,7 +123,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     @Keep
     @DoNotStrip
     set(value) {
-      optionalCallback = value?.let { it /* TODO: Does this work? */ }
+      optionalCallback = value?.let { it }
     }
   
   @get:DoNotStrip
@@ -174,7 +174,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun complexEnumCallback_cxx(array: Array<Powertrain>, callback: Func_void_std__vector_Powertrain_): Unit {
-    val __result = complexEnumCallback(array, callback /* TODO: Does this work? */)
+    val __result = complexEnumCallback(array, callback)
     return __result
   }
   
@@ -243,7 +243,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callCallback_cxx(callback: Func_void): Unit {
-    val __result = callCallback(callback /* TODO: Does this work? */)
+    val __result = callCallback(callback)
     return __result
   }
   
@@ -252,7 +252,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callAll_cxx(first: Func_void, second: Func_void, third: Func_void): Unit {
-    val __result = callAll(first /* TODO: Does this work? */, second /* TODO: Does this work? */, third /* TODO: Does this work? */)
+    val __result = callAll(first, second, third)
     return __result
   }
   
@@ -261,7 +261,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callWithOptional_cxx(value: Double?, callback: Func_void_std__optional_double_): Unit {
-    val __result = callWithOptional(value, callback /* TODO: Does this work? */)
+    val __result = callWithOptional(value, callback)
     return __result
   }
   
@@ -270,7 +270,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callSumUpNTimes_cxx(callback: Func_std__shared_ptr_Promise_double__, n: Double): Promise<Double> {
-    val __result = callSumUpNTimes(callback /* TODO: Does this work? */, n)
+    val __result = callSumUpNTimes(callback, n)
     return __result
   }
   
@@ -279,7 +279,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callbackAsyncPromise_cxx(callback: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____): Promise<Double> {
-    val __result = callbackAsyncPromise(callback /* TODO: Does this work? */)
+    val __result = callbackAsyncPromise(callback)
     return __result
   }
   
@@ -288,7 +288,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callbackAsyncPromiseBuffer_cxx(callback: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____): Promise<ArrayBuffer> {
-    val __result = callbackAsyncPromiseBuffer(callback /* TODO: Does this work? */)
+    val __result = callbackAsyncPromiseBuffer(callback)
     return __result
   }
   
@@ -306,7 +306,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun getValueFromJSCallbackAndWait_cxx(getValue: Func_std__shared_ptr_Promise_double__): Promise<Double> {
-    val __result = getValueFromJSCallbackAndWait(getValue /* TODO: Does this work? */)
+    val __result = getValueFromJSCallbackAndWait(getValue)
     return __result
   }
   
@@ -315,7 +315,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun getValueFromJsCallback_cxx(callback: Func_std__shared_ptr_Promise_std__string__, andThenCall: Func_void_std__string): Promise<Unit> {
-    val __result = getValueFromJsCallback(callback /* TODO: Does this work? */, andThenCall /* TODO: Does this work? */)
+    val __result = getValueFromJsCallback(callback, andThenCall)
     return __result
   }
   

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -112,16 +112,16 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @set:Keep
   abstract var optionalOldEnum: OldEnum?
   
-  @get:DoNotStrip
-  @get:Keep
-  @set:DoNotStrip
-  @set:Keep
   abstract var optionalCallback: ((value: Double) -> Unit)?
   
   private var optionalCallback_cxx: ((value: Double) -> Unit)?
+    @Keep
+    @DoNotStrip
     get() {
       return optionalCallback
     }
+    @Keep
+    @DoNotStrip
     set(value) {
       optionalCallback = value
     }
@@ -169,8 +169,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @Keep
   abstract fun bounceEnums(array: Array<Powertrain>): Array<Powertrain>
   
-  @DoNotStrip
-  @Keep
   abstract fun complexEnumCallback(array: Array<Powertrain>, callback: (array: Array<Powertrain>) -> Unit): Unit
   
   @DoNotStrip
@@ -240,8 +238,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @Keep
   abstract fun awaitPromise(promise: Promise<Unit>): Promise<Unit>
   
-  @DoNotStrip
-  @Keep
   abstract fun callCallback(callback: () -> Unit): Unit
   
   @DoNotStrip
@@ -251,8 +247,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     return __result
   }
   
-  @DoNotStrip
-  @Keep
   abstract fun callAll(first: () -> Unit, second: () -> Unit, third: () -> Unit): Unit
   
   @DoNotStrip
@@ -262,8 +256,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     return __result
   }
   
-  @DoNotStrip
-  @Keep
   abstract fun callWithOptional(value: Double?, callback: (maybe: Double?) -> Unit): Unit
   
   @DoNotStrip
@@ -273,8 +265,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     return __result
   }
   
-  @DoNotStrip
-  @Keep
   abstract fun callSumUpNTimes(callback: () -> Promise<Double>, n: Double): Promise<Double>
   
   @DoNotStrip
@@ -284,8 +274,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     return __result
   }
   
-  @DoNotStrip
-  @Keep
   abstract fun callbackAsyncPromise(callback: () -> Promise<Promise<Double>>): Promise<Double>
   
   @DoNotStrip
@@ -295,8 +283,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     return __result
   }
   
-  @DoNotStrip
-  @Keep
   abstract fun callbackAsyncPromiseBuffer(callback: () -> Promise<Promise<ArrayBuffer>>): Promise<ArrayBuffer>
   
   @DoNotStrip
@@ -306,8 +292,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     return __result
   }
   
-  @DoNotStrip
-  @Keep
   abstract fun getComplexCallback(): (value: Double) -> Unit
   
   @DoNotStrip
@@ -317,8 +301,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     throw Error("not yet implemented!")
   }
   
-  @DoNotStrip
-  @Keep
   abstract fun getValueFromJSCallbackAndWait(getValue: () -> Promise<Double>): Promise<Double>
   
   @DoNotStrip
@@ -328,8 +310,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     return __result
   }
   
-  @DoNotStrip
-  @Keep
   abstract fun getValueFromJsCallback(callback: () -> Promise<String>, andThenCall: (valueFromJs: String) -> Unit): Promise<Unit>
   
   @DoNotStrip
@@ -351,8 +331,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @Keep
   abstract fun getDriver(car: Car): Person?
   
-  @DoNotStrip
-  @Keep
   abstract fun jsStyleObjectAsParameters(params: JsStyleStruct): Unit
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -21,8 +21,8 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "LocalVariableName", "PropertyName", "FunctionName",
-  "RedundantSuppression", "RedundantUnitReturnType"
+  "RedundantSuppression", "RedundantUnitReturnType",
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -118,12 +118,12 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     @Keep
     @DoNotStrip
     get() {
-      return optionalCallback
+      return optionalCallback?.let { Func_void_double_java(it) }
     }
     @Keep
     @DoNotStrip
     set(value) {
-      optionalCallback = value?.let { it.toLambda() }
+      optionalCallback = value?.let { it /* TODO: Does this work? */ }
     }
   
   @get:DoNotStrip
@@ -174,7 +174,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun complexEnumCallback_cxx(array: Array<Powertrain>, callback: Func_void_std__vector_Powertrain_): Unit {
-    val __result = complexEnumCallback(array, callback.toLambda())
+    val __result = complexEnumCallback(array, callback /* TODO: Does this work? */)
     return __result
   }
   
@@ -243,7 +243,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callCallback_cxx(callback: Func_void): Unit {
-    val __result = callCallback(callback.toLambda())
+    val __result = callCallback(callback /* TODO: Does this work? */)
     return __result
   }
   
@@ -252,7 +252,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callAll_cxx(first: Func_void, second: Func_void, third: Func_void): Unit {
-    val __result = callAll(first.toLambda(), second.toLambda(), third.toLambda())
+    val __result = callAll(first /* TODO: Does this work? */, second /* TODO: Does this work? */, third /* TODO: Does this work? */)
     return __result
   }
   
@@ -261,7 +261,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callWithOptional_cxx(value: Double?, callback: Func_void_std__optional_double_): Unit {
-    val __result = callWithOptional(value, callback.toLambda())
+    val __result = callWithOptional(value, callback /* TODO: Does this work? */)
     return __result
   }
   
@@ -270,7 +270,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callSumUpNTimes_cxx(callback: Func_std__shared_ptr_Promise_double__, n: Double): Promise<Double> {
-    val __result = callSumUpNTimes(callback.toLambda(), n)
+    val __result = callSumUpNTimes(callback /* TODO: Does this work? */, n)
     return __result
   }
   
@@ -279,7 +279,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callbackAsyncPromise_cxx(callback: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____): Promise<Double> {
-    val __result = callbackAsyncPromise(callback.toLambda())
+    val __result = callbackAsyncPromise(callback /* TODO: Does this work? */)
     return __result
   }
   
@@ -288,7 +288,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun callbackAsyncPromiseBuffer_cxx(callback: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____): Promise<ArrayBuffer> {
-    val __result = callbackAsyncPromiseBuffer(callback.toLambda())
+    val __result = callbackAsyncPromiseBuffer(callback /* TODO: Does this work? */)
     return __result
   }
   
@@ -298,7 +298,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @Keep
   private fun getComplexCallback_cxx(): Func_void_double {
     val __result = getComplexCallback()
-    throw Error("not yet implemented!")
+    return Func_void_double_java(__result)
   }
   
   abstract fun getValueFromJSCallbackAndWait(getValue: () -> Promise<Double>): Promise<Double>
@@ -306,7 +306,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun getValueFromJSCallbackAndWait_cxx(getValue: Func_std__shared_ptr_Promise_double__): Promise<Double> {
-    val __result = getValueFromJSCallbackAndWait(getValue.toLambda())
+    val __result = getValueFromJSCallbackAndWait(getValue /* TODO: Does this work? */)
     return __result
   }
   
@@ -315,7 +315,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   private fun getValueFromJsCallback_cxx(callback: Func_std__shared_ptr_Promise_std__string__, andThenCall: Func_void_std__string): Promise<Unit> {
-    val __result = getValueFromJsCallback(callback.toLambda(), andThenCall.toLambda())
+    val __result = getValueFromJsCallback(callback /* TODO: Does this work? */, andThenCall /* TODO: Does this work? */)
     return __result
   }
   

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -112,6 +112,12 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @get:Keep
   @set:DoNotStrip
   @set:Keep
+  abstract var optionalCallback: ((value: Double) -> Unit)?
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
   abstract var someVariant: Variant_String_Double
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -118,6 +118,14 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @set:Keep
   abstract var optionalCallback: ((value: Double) -> Unit)?
   
+  private var optionalCallback_cxx: ((value: Double) -> Unit)?
+    get() {
+      return optionalCallback
+    }
+    set(value) {
+      optionalCallback = value
+    }
+  
   @get:DoNotStrip
   @get:Keep
   @set:DoNotStrip
@@ -346,6 +354,13 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   abstract fun jsStyleObjectAsParameters(params: JsStyleStruct): Unit
+  
+  @DoNotStrip
+  @Keep
+  private fun jsStyleObjectAsParameters_cxx(params: JsStyleStruct): Unit {
+    val __result = jsStyleObjectAsParameters(params)
+    return __result
+  }
   
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -19,7 +19,11 @@ import com.margelo.nitro.core.*
  */
 @DoNotStrip
 @Keep
-@Suppress("RedundantSuppression", "KotlinJniMissingFunction", "PropertyName", "RedundantUnitReturnType", "unused")
+@Suppress(
+  "KotlinJniMissingFunction", "unused",
+  "LocalVariableName", "PropertyName", "FunctionName",
+  "RedundantSuppression", "RedundantUnitReturnType"
+)
 abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   private var mHybridData: HybridData = initHybrid()
@@ -163,7 +167,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  private fun complexEnumCallback(array: Array<Powertrain>, callback: Func_void_std__vector_Powertrain_): Unit {
+  private fun complexEnumCallback_cxx(array: Array<Powertrain>, callback: Func_void_std__vector_Powertrain_): Unit {
     val __result = complexEnumCallback(array, callback.toLambda())
     return __result
   }
@@ -234,7 +238,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  private fun callCallback(callback: Func_void): Unit {
+  private fun callCallback_cxx(callback: Func_void): Unit {
     val __result = callCallback(callback.toLambda())
     return __result
   }
@@ -245,7 +249,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  private fun callAll(first: Func_void, second: Func_void, third: Func_void): Unit {
+  private fun callAll_cxx(first: Func_void, second: Func_void, third: Func_void): Unit {
     val __result = callAll(first.toLambda(), second.toLambda(), third.toLambda())
     return __result
   }
@@ -256,7 +260,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  private fun callWithOptional(value: Double?, callback: Func_void_std__optional_double_): Unit {
+  private fun callWithOptional_cxx(value: Double?, callback: Func_void_std__optional_double_): Unit {
     val __result = callWithOptional(value, callback.toLambda())
     return __result
   }
@@ -267,7 +271,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  private fun callSumUpNTimes(callback: Func_std__shared_ptr_Promise_double__, n: Double): Promise<Double> {
+  private fun callSumUpNTimes_cxx(callback: Func_std__shared_ptr_Promise_double__, n: Double): Promise<Double> {
     val __result = callSumUpNTimes(callback.toLambda(), n)
     return __result
   }
@@ -278,7 +282,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  private fun callbackAsyncPromise(callback: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____): Promise<Double> {
+  private fun callbackAsyncPromise_cxx(callback: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____): Promise<Double> {
     val __result = callbackAsyncPromise(callback.toLambda())
     return __result
   }
@@ -289,7 +293,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  private fun callbackAsyncPromiseBuffer(callback: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____): Promise<ArrayBuffer> {
+  private fun callbackAsyncPromiseBuffer_cxx(callback: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____): Promise<ArrayBuffer> {
     val __result = callbackAsyncPromiseBuffer(callback.toLambda())
     return __result
   }
@@ -300,11 +304,18 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  private fun getComplexCallback_cxx(): Func_void_double {
+    val __result = getComplexCallback()
+    throw Error("not yet implemented!")
+  }
+  
+  @DoNotStrip
+  @Keep
   abstract fun getValueFromJSCallbackAndWait(getValue: () -> Promise<Double>): Promise<Double>
   
   @DoNotStrip
   @Keep
-  private fun getValueFromJSCallbackAndWait(getValue: Func_std__shared_ptr_Promise_double__): Promise<Double> {
+  private fun getValueFromJSCallbackAndWait_cxx(getValue: Func_std__shared_ptr_Promise_double__): Promise<Double> {
     val __result = getValueFromJSCallbackAndWait(getValue.toLambda())
     return __result
   }
@@ -315,7 +326,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  private fun getValueFromJsCallback(callback: Func_std__shared_ptr_Promise_std__string__, andThenCall: Func_void_std__string): Promise<Unit> {
+  private fun getValueFromJsCallback_cxx(callback: Func_std__shared_ptr_Promise_std__string__, andThenCall: Func_void_std__string): Promise<Unit> {
     val __result = getValueFromJsCallback(callback.toLambda(), andThenCall.toLambda())
     return __result
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -300,13 +300,6 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  private fun getComplexCallback(): Func_void_double {
-    val __result = getComplexCallback()
-    return __result
-  }
-  
-  @DoNotStrip
-  @Keep
   abstract fun getValueFromJSCallbackAndWait(getValue: () -> Promise<Double>): Promise<Double>
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -21,7 +21,7 @@ import com.margelo.nitro.core.*
 @Keep
 @Suppress(
   "KotlinJniMissingFunction", "unused",
-  "RedundantSuppression", "RedundantUnitReturnType",
+  "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
@@ -114,7 +114,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   abstract var optionalCallback: ((value: Double) -> Unit)?
   
-  private var optionalCallback_cxx: ((value: Double) -> Unit)?
+  private var optionalCallback_cxx: Func_void_double?
     @Keep
     @DoNotStrip
     get() {
@@ -123,7 +123,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     @Keep
     @DoNotStrip
     set(value) {
-      optionalCallback = value
+      optionalCallback = value?.let { it.toLambda() }
     }
   
   @get:DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/ImageSize.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/ImageSize.kt
@@ -19,4 +19,6 @@ import com.margelo.nitro.core.*
 data class ImageSize(
   val width: Double,
   val height: Double
-)
+) {
+  /* main constructor */
+}

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/ImageSize.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/ImageSize.kt
@@ -16,9 +16,12 @@ import com.margelo.nitro.core.*
  */
 @DoNotStrip
 @Keep
-data class ImageSize(
-  val width: Double,
-  val height: Double
-) {
+data class ImageSize
+  @DoNotStrip
+  @Keep
+  constructor(
+    val width: Double,
+    val height: Double
+  ) {
   /* main constructor */
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/JsStyleStruct.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/JsStyleStruct.kt
@@ -20,8 +20,4 @@ data class JsStyleStruct(
   val value: Double,
   val onChanged: (num: Double) -> Unit
 ) {
-  @DoNotStrip
-  @Keep
-  private constructor(value: Double, onChanged: Func_void_double)
-               : this(value, onChanged.toLambda())
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/JsStyleStruct.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/JsStyleStruct.kt
@@ -16,10 +16,13 @@ import com.margelo.nitro.core.*
  */
 @DoNotStrip
 @Keep
-data class JsStyleStruct(
-  val value: Double,
-  val onChanged: (num: Double) -> Unit
-) {
+data class JsStyleStruct
+  @DoNotStrip
+  @Keep
+  constructor(
+    val value: Double,
+    val onChanged: (num: Double) -> Unit
+  ) {
   @DoNotStrip
   @Keep
   @Suppress("unused")

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/JsStyleStruct.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/JsStyleStruct.kt
@@ -19,4 +19,9 @@ import com.margelo.nitro.core.*
 data class JsStyleStruct(
   val value: Double,
   val onChanged: (num: Double) -> Unit
-)
+) {
+  @DoNotStrip
+  @Keep
+  private constructor(value: Double, onChanged: Func_void_double)
+               : this(value, onChanged.toLambda())
+}

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/JsStyleStruct.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/JsStyleStruct.kt
@@ -20,4 +20,9 @@ data class JsStyleStruct(
   val value: Double,
   val onChanged: (num: Double) -> Unit
 ) {
+  @DoNotStrip
+  @Keep
+  @Suppress("unused")
+  private constructor(value: Double, onChanged: Func_void_double)
+               : this(value, onChanged as (num: Double) -> Unit)
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Person.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Person.kt
@@ -19,4 +19,6 @@ import com.margelo.nitro.core.*
 data class Person(
   val name: String,
   val age: Double
-)
+) {
+  /* main constructor */
+}

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Person.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Person.kt
@@ -16,9 +16,12 @@ import com.margelo.nitro.core.*
  */
 @DoNotStrip
 @Keep
-data class Person(
-  val name: String,
-  val age: Double
-) {
+data class Person
+  @DoNotStrip
+  @Keep
+  constructor(
+    val name: String,
+    val age: Double
+  ) {
   /* main constructor */
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.cpp
@@ -73,6 +73,14 @@ namespace margelo::nitro::image::bridge::swift {
     return swiftPart.toUnsafe();
   }
   
+  // pragma MARK: std::function<void(double /* value */)>
+  Func_void_double create_Func_void_double(void* _Nonnull swiftClosureWrapper) {
+    auto swiftClosure = NitroImage::Func_void_double::fromUnsafe(swiftClosureWrapper);
+    return [swiftClosure = std::move(swiftClosure)](double value) mutable -> void {
+      swiftClosure.call(value);
+    };
+  }
+  
   // pragma MARK: std::function<void(const std::vector<Powertrain>& /* array */)>
   Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* _Nonnull swiftClosureWrapper) {
     auto swiftClosure = NitroImage::Func_void_std__vector_Powertrain_::fromUnsafe(swiftClosureWrapper);
@@ -101,14 +109,6 @@ namespace margelo::nitro::image::bridge::swift {
   Func_void_int64_t create_Func_void_int64_t(void* _Nonnull swiftClosureWrapper) {
     auto swiftClosure = NitroImage::Func_void_int64_t::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](int64_t result) mutable -> void {
-      swiftClosure.call(result);
-    };
-  }
-  
-  // pragma MARK: std::function<void(double /* result */)>
-  Func_void_double create_Func_void_double(void* _Nonnull swiftClosureWrapper) {
-    auto swiftClosure = NitroImage::Func_void_double::fromUnsafe(swiftClosureWrapper);
-    return [swiftClosure = std::move(swiftClosure)](double result) mutable -> void {
       swiftClosure.call(result);
     };
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -875,6 +875,15 @@ namespace margelo::nitro::image::bridge::swift {
     return Result<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>::withError(error);
   }
   
+  // pragma MARK: Result<std::function<void(double /* value */)>>
+  using Result_std__function_void_double____value______ = Result<std::function<void(double /* value */)>>;
+  inline Result_std__function_void_double____value______ create_Result_std__function_void_double____value______(const std::function<void(double /* value */)>& value) {
+    return Result<std::function<void(double /* value */)>>::withValue(value);
+  }
+  inline Result_std__function_void_double____value______ create_Result_std__function_void_double____value______(const std::exception_ptr& error) {
+    return Result<std::function<void(double /* value */)>>::withError(error);
+  }
+  
   // pragma MARK: Result<Car>
   using Result_Car_ = Result<Car>;
   inline Result_Car_ create_Result_Car_(const Car& value) {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -216,6 +216,37 @@ namespace margelo::nitro::image::bridge::swift {
     return std::optional<OldEnum>(value);
   }
   
+  // pragma MARK: std::function<void(double /* value */)>
+  /**
+   * Specialized version of `std::function<void(double)>`.
+   */
+  using Func_void_double = std::function<void(double /* value */)>;
+  /**
+   * Wrapper class for a `std::function<void(double / * value * /)>`, this can be used from Swift.
+   */
+  class Func_void_double_Wrapper final {
+  public:
+    explicit Func_void_double_Wrapper(std::function<void(double /* value */)>&& func): _function(std::make_shared<std::function<void(double /* value */)>>(std::move(func))) {}
+    inline void call(double value) const {
+      _function->operator()(value);
+    }
+  private:
+    std::shared_ptr<std::function<void(double /* value */)>> _function;
+  };
+  Func_void_double create_Func_void_double(void* _Nonnull swiftClosureWrapper);
+  inline Func_void_double_Wrapper wrap_Func_void_double(Func_void_double value) {
+    return Func_void_double_Wrapper(std::move(value));
+  }
+  
+  // pragma MARK: std::optional<std::function<void(double /* value */)>>
+  /**
+   * Specialized version of `std::optional<std::function<void(double / * value * /)>>`.
+   */
+  using std__optional_std__function_void_double____value______ = std::optional<std::function<void(double /* value */)>>;
+  inline std::optional<std::function<void(double /* value */)>> create_std__optional_std__function_void_double____value______(const std::function<void(double /* value */)>& value) {
+    return std::optional<std::function<void(double /* value */)>>(value);
+  }
+  
   // pragma MARK: std::vector<double>
   /**
    * Specialized version of `std::vector<double>`.
@@ -409,28 +440,6 @@ namespace margelo::nitro::image::bridge::swift {
   }
   inline PromiseHolder<double> wrap_std__shared_ptr_Promise_double__(std::shared_ptr<Promise<double>> promise) {
     return PromiseHolder<double>(std::move(promise));
-  }
-  
-  // pragma MARK: std::function<void(double /* result */)>
-  /**
-   * Specialized version of `std::function<void(double)>`.
-   */
-  using Func_void_double = std::function<void(double /* result */)>;
-  /**
-   * Wrapper class for a `std::function<void(double / * result * /)>`, this can be used from Swift.
-   */
-  class Func_void_double_Wrapper final {
-  public:
-    explicit Func_void_double_Wrapper(std::function<void(double /* result */)>&& func): _function(std::make_shared<std::function<void(double /* result */)>>(std::move(func))) {}
-    inline void call(double result) const {
-      _function->operator()(result);
-    }
-  private:
-    std::shared_ptr<std::function<void(double /* result */)>> _function;
-  };
-  Func_void_double create_Func_void_double(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_double_Wrapper wrap_Func_void_double(Func_void_double value) {
-    return Func_void_double_Wrapper(std::move(value));
   }
   
   // pragma MARK: std::optional<Person>

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -42,9 +42,9 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include <vector>
 #include "Powertrain.hpp"
 #include "OldEnum.hpp"
+#include <functional>
 #include <variant>
 #include "Person.hpp"
-#include <functional>
 #include <NitroModules/AnyMap.hpp>
 #include <NitroModules/Promise.hpp>
 #include <exception>
@@ -165,6 +165,13 @@ namespace margelo::nitro::image {
     }
     inline void setOptionalOldEnum(std::optional<OldEnum> optionalOldEnum) noexcept override {
       _swiftPart.setOptionalOldEnum(optionalOldEnum);
+    }
+    inline std::optional<std::function<void(double /* value */)>> getOptionalCallback() noexcept override {
+      auto __result = _swiftPart.getOptionalCallback();
+      return __result;
+    }
+    inline void setOptionalCallback(const std::optional<std::function<void(double /* value */)>>& optionalCallback) noexcept override {
+      _swiftPart.setOptionalCallback(optionalCallback);
     }
     inline std::variant<std::string, double> getSomeVariant() noexcept override {
       auto __result = _swiftPart.getSomeVariant();

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -417,6 +417,14 @@ namespace margelo::nitro::image {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline std::function<void(double /* value */)> getComplexCallback() override {
+      auto __result = _swiftPart.getComplexCallback();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::shared_ptr<Promise<double>> getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) override {
       auto __result = _swiftPart.getValueFromJSCallbackAndWait(getValue);
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_double__.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_double__.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(() -> Promise<Double>)` as a class.
+ * Wraps a Swift `() -> Promise<Double>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_std__shared_ptr_Promise_double__ {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: (() -> Promise<Double>)
+  private let closure: () -> Promise<Double>
 
-  public init(_ closure: @escaping (() -> Promise<Double>)) {
+  public init(_ closure: @escaping () -> Promise<Double>) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(() -> Promise<Promise<Double>>)` as a class.
+ * Wraps a Swift `() -> Promise<Promise<Double>>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: (() -> Promise<Promise<Double>>)
+  private let closure: () -> Promise<Promise<Double>>
 
-  public init(_ closure: @escaping (() -> Promise<Promise<Double>>)) {
+  public init(_ closure: @escaping () -> Promise<Promise<Double>>) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(() -> Promise<Promise<ArrayBufferHolder>>)` as a class.
+ * Wraps a Swift `() -> Promise<Promise<ArrayBufferHolder>>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: (() -> Promise<Promise<ArrayBufferHolder>>)
+  private let closure: () -> Promise<Promise<ArrayBufferHolder>>
 
-  public init(_ closure: @escaping (() -> Promise<Promise<ArrayBufferHolder>>)) {
+  public init(_ closure: @escaping () -> Promise<Promise<ArrayBufferHolder>>) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__string__.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__string__.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(() -> Promise<String>)` as a class.
+ * Wraps a Swift `() -> Promise<String>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_std__shared_ptr_Promise_std__string__ {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: (() -> Promise<String>)
+  private let closure: () -> Promise<String>
 
-  public init(_ closure: @escaping (() -> Promise<String>)) {
+  public init(_ closure: @escaping () -> Promise<String>) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(() -> Void)` as a class.
+ * Wraps a Swift `() -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: (() -> Void)
+  private let closure: () -> Void
 
-  public init(_ closure: @escaping (() -> Void)) {
+  public init(_ closure: @escaping () -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_Car.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_Car.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `((_ value: Car) -> Void)` as a class.
+ * Wraps a Swift `(_ value: Car) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_Car {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: ((_ value: Car) -> Void)
+  private let closure: (_ value: Car) -> Void
 
-  public init(_ closure: @escaping ((_ value: Car) -> Void)) {
+  public init(_ closure: @escaping (_ value: Car) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_double.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_double.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `((_ num: Double) -> Void)` as a class.
+ * Wraps a Swift `(_ num: Double) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_double {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: ((_ num: Double) -> Void)
+  private let closure: (_ num: Double) -> Void
 
-  public init(_ closure: @escaping ((_ num: Double) -> Void)) {
+  public init(_ closure: @escaping (_ num: Double) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_int64_t.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_int64_t.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `((_ value: Int64) -> Void)` as a class.
+ * Wraps a Swift `(_ value: Int64) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_int64_t {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: ((_ value: Int64) -> Void)
+  private let closure: (_ value: Int64) -> Void
 
-  public init(_ closure: @escaping ((_ value: Int64) -> Void)) {
+  public init(_ closure: @escaping (_ value: Int64) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__exception_ptr.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__exception_ptr.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `((_ error: Error) -> Void)` as a class.
+ * Wraps a Swift `(_ error: Error) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__exception_ptr {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: ((_ error: Error) -> Void)
+  private let closure: (_ error: Error) -> Void
 
-  public init(_ closure: @escaping ((_ error: Error) -> Void)) {
+  public init(_ closure: @escaping (_ error: Error) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__optional_double_.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__optional_double_.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `((_ maybe: Double?) -> Void)` as a class.
+ * Wraps a Swift `(_ maybe: Double?) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__optional_double_ {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: ((_ maybe: Double?) -> Void)
+  private let closure: (_ maybe: Double?) -> Void
 
-  public init(_ closure: @escaping ((_ maybe: Double?) -> Void)) {
+  public init(_ closure: @escaping (_ maybe: Double?) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_ArrayBuffer_.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_ArrayBuffer_.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `((_ value: ArrayBufferHolder) -> Void)` as a class.
+ * Wraps a Swift `(_ value: ArrayBufferHolder) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__shared_ptr_ArrayBuffer_ {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: ((_ value: ArrayBufferHolder) -> Void)
+  private let closure: (_ value: ArrayBufferHolder) -> Void
 
-  public init(_ closure: @escaping ((_ value: ArrayBufferHolder) -> Void)) {
+  public init(_ closure: @escaping (_ value: ArrayBufferHolder) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_double__.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_double__.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `((_ value: Promise<Double>) -> Void)` as a class.
+ * Wraps a Swift `(_ value: Promise<Double>) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__shared_ptr_Promise_double__ {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: ((_ value: Promise<Double>) -> Void)
+  private let closure: (_ value: Promise<Double>) -> Void
 
-  public init(_ closure: @escaping ((_ value: Promise<Double>) -> Void)) {
+  public init(_ closure: @escaping (_ value: Promise<Double>) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `((_ value: Promise<ArrayBufferHolder>) -> Void)` as a class.
+ * Wraps a Swift `(_ value: Promise<ArrayBufferHolder>) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: ((_ value: Promise<ArrayBufferHolder>) -> Void)
+  private let closure: (_ value: Promise<ArrayBufferHolder>) -> Void
 
-  public init(_ closure: @escaping ((_ value: Promise<ArrayBufferHolder>) -> Void)) {
+  public init(_ closure: @escaping (_ value: Promise<ArrayBufferHolder>) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__string.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__string.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `((_ valueFromJs: String) -> Void)` as a class.
+ * Wraps a Swift `(_ valueFromJs: String) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__string {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: ((_ valueFromJs: String) -> Void)
+  private let closure: (_ valueFromJs: String) -> Void
 
-  public init(_ closure: @escaping ((_ valueFromJs: String) -> Void)) {
+  public init(_ closure: @escaping (_ valueFromJs: String) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__vector_Powertrain_.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Func_void_std__vector_Powertrain_.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `((_ array: [Powertrain]) -> Void)` as a class.
+ * Wraps a Swift `(_ array: [Powertrain]) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__vector_Powertrain_ {
   public typealias bridge = margelo.nitro.image.bridge.swift
 
-  private let closure: ((_ array: [Powertrain]) -> Void)
+  private let closure: (_ array: [Powertrain]) -> Void
 
-  public init(_ closure: @escaping ((_ array: [Powertrain]) -> Void)) {
+  public init(_ closure: @escaping (_ array: [Powertrain]) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -17,7 +17,7 @@ public protocol HybridImageSpec_protocol: AnyObject {
 
   // Methods
   func toArrayBuffer(format: ImageFormat) throws -> Double
-  func saveToFile(path: String, onFinished: @escaping ((_ path: String) -> Void)) throws -> Void
+  func saveToFile(path: String, onFinished: @escaping (_ path: String) -> Void) throws -> Void
 }
 
 /// See ``HybridImageSpec``

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec_cxx.swift
@@ -138,7 +138,7 @@ public class HybridImageSpec_cxx {
   @inline(__always)
   public func saveToFile(path: std.string, onFinished: bridge.Func_void_std__string) -> bridge.Result_void_ {
     do {
-      try self.__implementation.saveToFile(path: String(path), onFinished: { () -> ((String) -> Void) in
+      try self.__implementation.saveToFile(path: String(path), onFinished: { () -> (String) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_std__string(onFinished)
         return { (__path: String) -> Void in
           __wrappedFunction.call(std.string(__path))

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -23,6 +23,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
   var optionalArray: [String]? { get set }
   var optionalEnum: Powertrain? { get set }
   var optionalOldEnum: OldEnum? { get set }
+  var optionalCallback: (((_ value: Double) -> Void))? { get set }
   var someVariant: Variant_String_Double { get set }
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -23,7 +23,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
   var optionalArray: [String]? { get set }
   var optionalEnum: Powertrain? { get set }
   var optionalOldEnum: OldEnum? { get set }
-  var optionalCallback: (((_ value: Double) -> Void))? { get set }
+  var optionalCallback: ((_ value: Double) -> Void)? { get set }
   var someVariant: Variant_String_Double { get set }
 
   // Methods
@@ -36,7 +36,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
   func bounceNumbers(array: [Double]) throws -> [Double]
   func bounceStructs(array: [Person]) throws -> [Person]
   func bounceEnums(array: [Powertrain]) throws -> [Powertrain]
-  func complexEnumCallback(array: [Powertrain], callback: @escaping ((_ array: [Powertrain]) -> Void)) throws -> Void
+  func complexEnumCallback(array: [Powertrain], callback: @escaping (_ array: [Powertrain]) -> Void) throws -> Void
   func createMap() throws -> AnyMapHolder
   func mapRoundtrip(map: AnyMapHolder) throws -> AnyMapHolder
   func funcThatThrows() throws -> Double
@@ -52,14 +52,14 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
   func awaitAndGetPromise(promise: Promise<Double>) throws -> Promise<Double>
   func awaitAndGetComplexPromise(promise: Promise<Car>) throws -> Promise<Car>
   func awaitPromise(promise: Promise<Void>) throws -> Promise<Void>
-  func callCallback(callback: @escaping (() -> Void)) throws -> Void
-  func callAll(first: @escaping (() -> Void), second: @escaping (() -> Void), third: @escaping (() -> Void)) throws -> Void
-  func callWithOptional(value: Double?, callback: @escaping ((_ maybe: Double?) -> Void)) throws -> Void
-  func callSumUpNTimes(callback: @escaping (() -> Promise<Double>), n: Double) throws -> Promise<Double>
-  func callbackAsyncPromise(callback: @escaping (() -> Promise<Promise<Double>>)) throws -> Promise<Double>
-  func callbackAsyncPromiseBuffer(callback: @escaping (() -> Promise<Promise<ArrayBufferHolder>>)) throws -> Promise<ArrayBufferHolder>
-  func getValueFromJSCallbackAndWait(getValue: @escaping (() -> Promise<Double>)) throws -> Promise<Double>
-  func getValueFromJsCallback(callback: @escaping (() -> Promise<String>), andThenCall: @escaping ((_ valueFromJs: String) -> Void)) throws -> Promise<Void>
+  func callCallback(callback: @escaping () -> Void) throws -> Void
+  func callAll(first: @escaping () -> Void, second: @escaping () -> Void, third: @escaping () -> Void) throws -> Void
+  func callWithOptional(value: Double?, callback: @escaping (_ maybe: Double?) -> Void) throws -> Void
+  func callSumUpNTimes(callback: @escaping () -> Promise<Double>, n: Double) throws -> Promise<Double>
+  func callbackAsyncPromise(callback: @escaping () -> Promise<Promise<Double>>) throws -> Promise<Double>
+  func callbackAsyncPromiseBuffer(callback: @escaping () -> Promise<Promise<ArrayBufferHolder>>) throws -> Promise<ArrayBufferHolder>
+  func getValueFromJSCallbackAndWait(getValue: @escaping () -> Promise<Double>) throws -> Promise<Double>
+  func getValueFromJsCallback(callback: @escaping () -> Promise<String>, andThenCall: @escaping (_ valueFromJs: String) -> Void) throws -> Promise<Void>
   func getCar() throws -> Car
   func isCarElectric(car: Car) throws -> Bool
   func getDriver(car: Car) throws -> Person?

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -58,6 +58,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
   func callSumUpNTimes(callback: @escaping () -> Promise<Double>, n: Double) throws -> Promise<Double>
   func callbackAsyncPromise(callback: @escaping () -> Promise<Promise<Double>>) throws -> Promise<Double>
   func callbackAsyncPromiseBuffer(callback: @escaping () -> Promise<Promise<ArrayBufferHolder>>) throws -> Promise<ArrayBufferHolder>
+  func getComplexCallback() throws -> (_ value: Double) -> Void
   func getValueFromJSCallbackAndWait(getValue: @escaping () -> Promise<Double>) throws -> Promise<Double>
   func getValueFromJsCallback(callback: @escaping () -> Promise<String>, andThenCall: @escaping (_ valueFromJs: String) -> Void) throws -> Promise<Void>
   func getCar() throws -> Car

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -313,6 +313,37 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     }
   }
   
+  public var optionalCallback: bridge.std__optional_std__function_void_double____value______ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_std__function_void_double____value______ in
+        if let __unwrappedValue = self.__implementation.optionalCallback {
+          return bridge.create_std__optional_std__function_void_double____value______({ () -> bridge.Func_void_double in
+            let __closureWrapper = Func_void_double(__unwrappedValue)
+            return bridge.create_Func_void_double(__closureWrapper.toUnsafe())
+          }())
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.optionalCallback = { () -> (((_ value: Double) -> Void))? in
+        if let __unwrapped = newValue.value {
+          return { () -> ((Double) -> Void) in
+            let __wrappedFunction = bridge.wrap_Func_void_double(__unwrapped)
+            return { (__value: Double) -> Void in
+              __wrappedFunction.call(__value)
+            }
+          }()
+        } else {
+          return nil
+        }
+      }()
+    }
+  }
+  
   public var someVariant: bridge.std__variant_std__string__double_ {
     @inline(__always)
     get {

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -329,9 +329,9 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     }
     @inline(__always)
     set {
-      self.__implementation.optionalCallback = { () -> (((_ value: Double) -> Void))? in
+      self.__implementation.optionalCallback = { () -> ((_ value: Double) -> Void)? in
         if let __unwrapped = newValue.value {
-          return { () -> ((Double) -> Void) in
+          return { () -> (Double) -> Void in
             let __wrappedFunction = bridge.wrap_Func_void_double(__unwrapped)
             return { (__value: Double) -> Void in
               __wrappedFunction.call(__value)
@@ -510,7 +510,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public func complexEnumCallback(array: bridge.std__vector_Powertrain_, callback: bridge.Func_void_std__vector_Powertrain_) -> bridge.Result_void_ {
     do {
-      try self.__implementation.complexEnumCallback(array: array.map({ __item in __item }), callback: { () -> (([Powertrain]) -> Void) in
+      try self.__implementation.complexEnumCallback(array: array.map({ __item in __item }), callback: { () -> ([Powertrain]) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_std__vector_Powertrain_(callback)
         return { (__array: [Powertrain]) -> Void in
           __wrappedFunction.call({ () -> bridge.std__vector_Powertrain_ in
@@ -830,7 +830,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public func callCallback(callback: bridge.Func_void) -> bridge.Result_void_ {
     do {
-      try self.__implementation.callCallback(callback: { () -> (() -> Void) in
+      try self.__implementation.callCallback(callback: { () -> () -> Void in
         let __wrappedFunction = bridge.wrap_Func_void(callback)
         return { () -> Void in
           __wrappedFunction.call()
@@ -846,17 +846,17 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public func callAll(first: bridge.Func_void, second: bridge.Func_void, third: bridge.Func_void) -> bridge.Result_void_ {
     do {
-      try self.__implementation.callAll(first: { () -> (() -> Void) in
+      try self.__implementation.callAll(first: { () -> () -> Void in
         let __wrappedFunction = bridge.wrap_Func_void(first)
         return { () -> Void in
           __wrappedFunction.call()
         }
-      }(), second: { () -> (() -> Void) in
+      }(), second: { () -> () -> Void in
         let __wrappedFunction = bridge.wrap_Func_void(second)
         return { () -> Void in
           __wrappedFunction.call()
         }
-      }(), third: { () -> (() -> Void) in
+      }(), third: { () -> () -> Void in
         let __wrappedFunction = bridge.wrap_Func_void(third)
         return { () -> Void in
           __wrappedFunction.call()
@@ -872,7 +872,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public func callWithOptional(value: bridge.std__optional_double_, callback: bridge.Func_void_std__optional_double_) -> bridge.Result_void_ {
     do {
-      try self.__implementation.callWithOptional(value: value.value, callback: { () -> ((Double?) -> Void) in
+      try self.__implementation.callWithOptional(value: value.value, callback: { () -> (Double?) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_std__optional_double_(callback)
         return { (__maybe: Double?) -> Void in
           __wrappedFunction.call({ () -> bridge.std__optional_double_ in
@@ -894,7 +894,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public func callSumUpNTimes(callback: bridge.Func_std__shared_ptr_Promise_double__, n: Double) -> bridge.Result_std__shared_ptr_Promise_double___ {
     do {
-      let __result = try self.__implementation.callSumUpNTimes(callback: { () -> (() -> Promise<Double>) in
+      let __result = try self.__implementation.callSumUpNTimes(callback: { () -> () -> Promise<Double> in
         let __wrappedFunction = bridge.wrap_Func_std__shared_ptr_Promise_double__(callback)
         return { () -> Promise<Double> in
           let __result = __wrappedFunction.call()
@@ -939,7 +939,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public func callbackAsyncPromise(callback: bridge.Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____) -> bridge.Result_std__shared_ptr_Promise_double___ {
     do {
-      let __result = try self.__implementation.callbackAsyncPromise(callback: { () -> (() -> Promise<Promise<Double>>) in
+      let __result = try self.__implementation.callbackAsyncPromise(callback: { () -> () -> Promise<Promise<Double>> in
         let __wrappedFunction = bridge.wrap_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(callback)
         return { () -> Promise<Promise<Double>> in
           let __result = __wrappedFunction.call()
@@ -984,7 +984,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public func callbackAsyncPromiseBuffer(callback: bridge.Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____) -> bridge.Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____ {
     do {
-      let __result = try self.__implementation.callbackAsyncPromiseBuffer(callback: { () -> (() -> Promise<Promise<ArrayBufferHolder>>) in
+      let __result = try self.__implementation.callbackAsyncPromiseBuffer(callback: { () -> () -> Promise<Promise<ArrayBufferHolder>> in
         let __wrappedFunction = bridge.wrap_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(callback)
         return { () -> Promise<Promise<ArrayBufferHolder>> in
           let __result = __wrappedFunction.call()
@@ -1029,7 +1029,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public func getValueFromJSCallbackAndWait(getValue: bridge.Func_std__shared_ptr_Promise_double__) -> bridge.Result_std__shared_ptr_Promise_double___ {
     do {
-      let __result = try self.__implementation.getValueFromJSCallbackAndWait(getValue: { () -> (() -> Promise<Double>) in
+      let __result = try self.__implementation.getValueFromJSCallbackAndWait(getValue: { () -> () -> Promise<Double> in
         let __wrappedFunction = bridge.wrap_Func_std__shared_ptr_Promise_double__(getValue)
         return { () -> Promise<Double> in
           let __result = __wrappedFunction.call()
@@ -1074,7 +1074,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public func getValueFromJsCallback(callback: bridge.Func_std__shared_ptr_Promise_std__string__, andThenCall: bridge.Func_void_std__string) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      let __result = try self.__implementation.getValueFromJsCallback(callback: { () -> (() -> Promise<String>) in
+      let __result = try self.__implementation.getValueFromJsCallback(callback: { () -> () -> Promise<String> in
         let __wrappedFunction = bridge.wrap_Func_std__shared_ptr_Promise_std__string__(callback)
         return { () -> Promise<String> in
           let __result = __wrappedFunction.call()
@@ -1100,7 +1100,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
             return __promise
           }()
         }
-      }(), andThenCall: { () -> ((String) -> Void) in
+      }(), andThenCall: { () -> (String) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_std__string(andThenCall)
         return { (__valueFromJs: String) -> Void in
           __wrappedFunction.call(std.string(__valueFromJs))

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -1027,6 +1027,21 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   }
   
   @inline(__always)
+  public func getComplexCallback() -> bridge.Result_std__function_void_double____value______ {
+    do {
+      let __result = try self.__implementation.getComplexCallback()
+      let __resultCpp = { () -> bridge.Func_void_double in
+        let __closureWrapper = Func_void_double(__result)
+        return bridge.create_Func_void_double(__closureWrapper.toUnsafe())
+      }()
+      return bridge.create_Result_std__function_void_double____value______(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__function_void_double____value______(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public func getValueFromJSCallbackAndWait(getValue: bridge.Func_std__shared_ptr_Promise_double__) -> bridge.Result_std__shared_ptr_Promise_double___ {
     do {
       let __result = try self.__implementation.getValueFromJSCallbackAndWait(getValue: { () -> () -> Promise<Double> in

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/JsStyleStruct.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/JsStyleStruct.swift
@@ -18,7 +18,7 @@ public extension JsStyleStruct {
   /**
    * Create a new instance of `JsStyleStruct`.
    */
-  init(value: Double, onChanged: @escaping ((_ num: Double) -> Void)) {
+  init(value: Double, onChanged: @escaping (_ num: Double) -> Void) {
     self.init(value, { () -> bridge.Func_void_double in
       let __closureWrapper = Func_void_double(onChanged)
       return bridge.create_Func_void_double(__closureWrapper.toUnsafe())
@@ -36,10 +36,10 @@ public extension JsStyleStruct {
     }
   }
   
-  var onChanged: ((_ num: Double) -> Void) {
+  var onChanged: (_ num: Double) -> Void {
     @inline(__always)
     get {
-      return { () -> ((Double) -> Void) in
+      return { () -> (Double) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_double(self.__onChanged)
         return { (__num: Double) -> Void in
           __wrappedFunction.call(__num)

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -81,6 +81,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("callSumUpNTimes", &HybridTestObjectCppSpec::callSumUpNTimes);
       prototype.registerHybridMethod("callbackAsyncPromise", &HybridTestObjectCppSpec::callbackAsyncPromise);
       prototype.registerHybridMethod("callbackAsyncPromiseBuffer", &HybridTestObjectCppSpec::callbackAsyncPromiseBuffer);
+      prototype.registerHybridMethod("getComplexCallback", &HybridTestObjectCppSpec::getComplexCallback);
       prototype.registerHybridMethod("getValueFromJSCallbackAndWait", &HybridTestObjectCppSpec::getValueFromJSCallbackAndWait);
       prototype.registerHybridMethod("getValueFromJsCallback", &HybridTestObjectCppSpec::getValueFromJsCallback);
       prototype.registerHybridMethod("getCar", &HybridTestObjectCppSpec::getCar);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -39,6 +39,8 @@ namespace margelo::nitro::image {
       prototype.registerHybridSetter("optionalEnum", &HybridTestObjectCppSpec::setOptionalEnum);
       prototype.registerHybridGetter("optionalOldEnum", &HybridTestObjectCppSpec::getOptionalOldEnum);
       prototype.registerHybridSetter("optionalOldEnum", &HybridTestObjectCppSpec::setOptionalOldEnum);
+      prototype.registerHybridGetter("optionalCallback", &HybridTestObjectCppSpec::getOptionalCallback);
+      prototype.registerHybridSetter("optionalCallback", &HybridTestObjectCppSpec::setOptionalCallback);
       prototype.registerHybridGetter("someVariant", &HybridTestObjectCppSpec::getSomeVariant);
       prototype.registerHybridSetter("someVariant", &HybridTestObjectCppSpec::setSomeVariant);
       prototype.registerHybridMethod("passVariant", &HybridTestObjectCppSpec::passVariant);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -151,6 +151,7 @@ namespace margelo::nitro::image {
       virtual std::shared_ptr<Promise<double>> callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) = 0;
       virtual std::shared_ptr<Promise<double>> callbackAsyncPromise(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& callback) = 0;
       virtual std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> callbackAsyncPromiseBuffer(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& callback) = 0;
+      virtual std::function<void(double /* value */)> getComplexCallback() = 0;
       virtual std::shared_ptr<Promise<double>> getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) = 0;
       virtual std::shared_ptr<Promise<void>> getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) = 0;
       virtual Car getCar() = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -42,10 +42,10 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include <vector>
 #include "Powertrain.hpp"
 #include "OldEnum.hpp"
+#include <functional>
 #include <variant>
 #include "Car.hpp"
 #include "Person.hpp"
-#include <functional>
 #include <NitroModules/AnyMap.hpp>
 #include <NitroModules/Promise.hpp>
 #include <exception>
@@ -106,6 +106,8 @@ namespace margelo::nitro::image {
       virtual void setOptionalEnum(std::optional<Powertrain> optionalEnum) = 0;
       virtual std::optional<OldEnum> getOptionalOldEnum() = 0;
       virtual void setOptionalOldEnum(std::optional<OldEnum> optionalOldEnum) = 0;
+      virtual std::optional<std::function<void(double /* value */)>> getOptionalCallback() = 0;
+      virtual void setOptionalCallback(const std::optional<std::function<void(double /* value */)>>& optionalCallback) = 0;
       virtual std::variant<std::string, double> getSomeVariant() = 0;
       virtual void setSomeVariant(const std::variant<std::string, double>& someVariant) = 0;
 

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -72,6 +72,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("callSumUpNTimes", &HybridTestObjectSwiftKotlinSpec::callSumUpNTimes);
       prototype.registerHybridMethod("callbackAsyncPromise", &HybridTestObjectSwiftKotlinSpec::callbackAsyncPromise);
       prototype.registerHybridMethod("callbackAsyncPromiseBuffer", &HybridTestObjectSwiftKotlinSpec::callbackAsyncPromiseBuffer);
+      prototype.registerHybridMethod("getComplexCallback", &HybridTestObjectSwiftKotlinSpec::getComplexCallback);
       prototype.registerHybridMethod("getValueFromJSCallbackAndWait", &HybridTestObjectSwiftKotlinSpec::getValueFromJSCallbackAndWait);
       prototype.registerHybridMethod("getValueFromJsCallback", &HybridTestObjectSwiftKotlinSpec::getValueFromJsCallback);
       prototype.registerHybridMethod("getCar", &HybridTestObjectSwiftKotlinSpec::getCar);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -37,6 +37,8 @@ namespace margelo::nitro::image {
       prototype.registerHybridSetter("optionalEnum", &HybridTestObjectSwiftKotlinSpec::setOptionalEnum);
       prototype.registerHybridGetter("optionalOldEnum", &HybridTestObjectSwiftKotlinSpec::getOptionalOldEnum);
       prototype.registerHybridSetter("optionalOldEnum", &HybridTestObjectSwiftKotlinSpec::setOptionalOldEnum);
+      prototype.registerHybridGetter("optionalCallback", &HybridTestObjectSwiftKotlinSpec::getOptionalCallback);
+      prototype.registerHybridSetter("optionalCallback", &HybridTestObjectSwiftKotlinSpec::setOptionalCallback);
       prototype.registerHybridGetter("someVariant", &HybridTestObjectSwiftKotlinSpec::getSomeVariant);
       prototype.registerHybridSetter("someVariant", &HybridTestObjectSwiftKotlinSpec::setSomeVariant);
       prototype.registerHybridMethod("newTestObject", &HybridTestObjectSwiftKotlinSpec::newTestObject);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -141,6 +141,7 @@ namespace margelo::nitro::image {
       virtual std::shared_ptr<Promise<double>> callSumUpNTimes(const std::function<std::shared_ptr<Promise<double>>()>& callback, double n) = 0;
       virtual std::shared_ptr<Promise<double>> callbackAsyncPromise(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>& callback) = 0;
       virtual std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> callbackAsyncPromiseBuffer(const std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>& callback) = 0;
+      virtual std::function<void(double /* value */)> getComplexCallback() = 0;
       virtual std::shared_ptr<Promise<double>> getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) = 0;
       virtual std::shared_ptr<Promise<void>> getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) = 0;
       virtual Car getCar() = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -41,9 +41,9 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include <vector>
 #include "Powertrain.hpp"
 #include "OldEnum.hpp"
+#include <functional>
 #include <variant>
 #include "Person.hpp"
-#include <functional>
 #include <NitroModules/AnyMap.hpp>
 #include <NitroModules/Promise.hpp>
 #include <exception>
@@ -103,6 +103,8 @@ namespace margelo::nitro::image {
       virtual void setOptionalEnum(std::optional<Powertrain> optionalEnum) = 0;
       virtual std::optional<OldEnum> getOptionalOldEnum() = 0;
       virtual void setOptionalOldEnum(std::optional<OldEnum> optionalOldEnum) = 0;
+      virtual std::optional<std::function<void(double /* value */)>> getOptionalCallback() = 0;
+      virtual void setOptionalCallback(const std::optional<std::function<void(double /* value */)>>& optionalCallback) = 0;
       virtual std::variant<std::string, double> getSomeVariant() = 0;
       virtual void setSomeVariant(const std::variant<std::string, double>& someVariant) = 0;
 

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -114,6 +114,7 @@ interface SharedTestObjectProps {
   callbackAsyncPromiseBuffer(
     callback: () => Promise<ArrayBuffer>
   ): Promise<ArrayBuffer>
+  getComplexCallback(): (value: number) => void
 
   // Callbacks that return values
   getValueFromJSCallbackAndWait(getValue: () => number): Promise<number>

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -56,6 +56,7 @@ interface SharedTestObjectProps {
   optionalArray?: string[]
   optionalEnum?: Powertrain
   optionalOldEnum?: OldEnum
+  optionalCallback?: (value: number) => void
 
   // Basic function tests
   simpleFunc(): void


### PR DESCRIPTION
This PR changes the way how functions work in Kotlin/Android.
Previously we only had native functions that can be passed to Kotlin.
Now we can also have actual Kotlin functions (lambdas) that can be passed to C++.

So for a `Func_void`, we now have 
- `JFunc_void`: base interface with an `invoke()` method
- `JFunc_void_cxx`: The C++-based implementation that holds a `std::function<void()>` - most likely from a jsi::Function (JNI)
- `JFunc_void_java`: The Java based implementation that holds a `() -> Unit`, which can be called from C++ using JNI

--------

Also, instead of _explicitly_ converting a `Func_void` to a `() -> Unit` (`toLambda()`), it now no longer needs to be converted to one since it always _is_ one. The Java interface `Func_void` **inherits from `() -> Unit`.

```kt
fun interface Func_void: () -> Unit {
  //                     ^ cool part
  override fun invoke() {
    // ...
  }
}
```
This way `Func_void` is always a callable.

--------

Also I added these two tests to ensure this won't break again:

- `optionalCallback?: (number) => void` test (callback property, instead of method)
- `complexReturn(): T` to harden requiresSpecialBridging for Kotlin

--------

This PR fixes a few bugs around callbacks and structs, e.g.:

- Structs that hold a Callback couldn't be passed from JS -> C++ -> Kotlin
- Callbacks couldn't be passed from Kotlin -> C++ -> JS