### PR TITLE
fix: Replace `HybridObjectSpec` (a protocol) with `HybridObject` (a base class)

### DIFF
--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -23,7 +23,7 @@ interface Math extends HybridObject {
 <div className="side-by-side-block">
 
 ```swift title="HybridMathSpec.swift (generated)"
-protocol HybridMathSpec: HybridObjectSpec {
+protocol HybridMathSpec: HybridObject {
   var pi: Double { get }
   func add(a: Double, b: Double) -> Double
 }

--- a/docs/docs/types/types.md
+++ b/docs/docs/types/types.md
@@ -146,7 +146,7 @@ These are all the types Nitro supports out of the box:
   <tr>
     <td>..any <code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/src/HybridObject.ts">HybridObject</a></code></td>
     <td><code>std::shared_ptr&lt;<a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp">HybridObject</a>&gt;</code></td>
-    <td><code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/ios/core/HybridObjectSpec.swift">HybridObjectSpec</a></code></td>
+    <td><code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/ios/core/HybridObject.swift">HybridObject</a></code></td>
     <td><code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObject.kt">HybridObject</a></code></td>
   </tr>
   <tr>

--- a/example/ios/NitroExample.xcodeproj/project.pbxproj
+++ b/example/ios/NitroExample.xcodeproj/project.pbxproj
@@ -628,7 +628,7 @@
 					"$(inherited)",
 					" ",
 				);
-				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_OBJC_INTEROP_MODE = objcxx;
@@ -705,7 +705,7 @@
 					"$(inherited)",
 					" ",
 				);
-				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_INTEROP_MODE = objcxx;
 				USE_HERMES = true;

--- a/packages/nitrogen/src/autolinking/ios/createSwiftUmbrellaHeader.ts
+++ b/packages/nitrogen/src/autolinking/ios/createSwiftUmbrellaHeader.ts
@@ -59,6 +59,7 @@ ${includes.sort().join('\n')}
 #include <NitroModules/RuntimeError.hpp>
 
 // Forward declarations of Swift defined types
+namespace NitroModules { class HybridObject; }
 ${swiftForwardDeclares.sort().join('\n')}
 
 // Include Swift defined types

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -40,9 +40,8 @@ public ${hasBaseClass ? 'override func' : 'func'} getCxxWrapper() -> ${name.Hybr
 }`.trim()
   )
   if (!hasBaseClass) {
-    // It doesn't have a base class - implement the `HybridObjectSpec` base protocol
-    classBaseClasses.push('HybridObjectSpec')
-    baseMembers.push(`public var memorySize: Int { return 0 }`)
+    // It doesn't have a base class - inherit from the `HybridObject` base class
+    classBaseClasses.push('HybridObject')
   }
 
   const protocolCode = `

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Umbrella.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Umbrella.hpp
@@ -75,6 +75,7 @@ namespace margelo::nitro::image { enum class Powertrain; }
 #include <NitroModules/RuntimeError.hpp>
 
 // Forward declarations of Swift defined types
+namespace NitroModules { class HybridObject; }
 // Forward declaration of `HybridBaseSpec_cxx` to properly resolve imports.
 namespace NitroImage { class HybridBaseSpec_cxx; }
 // Forward declaration of `HybridChildSpec_cxx` to properly resolve imports.

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -18,7 +18,7 @@ public protocol HybridBaseSpec_protocol: AnyObject {
 }
 
 /// See ``HybridBaseSpec``
-public class HybridBaseSpec_base: HybridObjectSpec {
+public class HybridBaseSpec_base: HybridObject {
   private weak var cxxWrapper: HybridBaseSpec_cxx? = nil
   public func getCxxWrapper() -> HybridBaseSpec_cxx {
   #if DEBUG
@@ -34,7 +34,6 @@ public class HybridBaseSpec_base: HybridObjectSpec {
       return cxxWrapper
     }
   }
-  public var memorySize: Int { return 0 }
 }
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -21,7 +21,7 @@ public protocol HybridImageFactorySpec_protocol: AnyObject {
 }
 
 /// See ``HybridImageFactorySpec``
-public class HybridImageFactorySpec_base: HybridObjectSpec {
+public class HybridImageFactorySpec_base: HybridObject {
   private weak var cxxWrapper: HybridImageFactorySpec_cxx? = nil
   public func getCxxWrapper() -> HybridImageFactorySpec_cxx {
   #if DEBUG
@@ -37,7 +37,6 @@ public class HybridImageFactorySpec_base: HybridObjectSpec {
       return cxxWrapper
     }
   }
-  public var memorySize: Int { return 0 }
 }
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -21,7 +21,7 @@ public protocol HybridImageSpec_protocol: AnyObject {
 }
 
 /// See ``HybridImageSpec``
-public class HybridImageSpec_base: HybridObjectSpec {
+public class HybridImageSpec_base: HybridObject {
   private weak var cxxWrapper: HybridImageSpec_cxx? = nil
   public func getCxxWrapper() -> HybridImageSpec_cxx {
   #if DEBUG
@@ -37,7 +37,6 @@ public class HybridImageSpec_base: HybridObjectSpec {
       return cxxWrapper
     }
   }
-  public var memorySize: Int { return 0 }
 }
 
 /**

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -79,7 +79,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
 }
 
 /// See ``HybridTestObjectSwiftKotlinSpec``
-public class HybridTestObjectSwiftKotlinSpec_base: HybridObjectSpec {
+public class HybridTestObjectSwiftKotlinSpec_base: HybridObject {
   private weak var cxxWrapper: HybridTestObjectSwiftKotlinSpec_cxx? = nil
   public func getCxxWrapper() -> HybridTestObjectSwiftKotlinSpec_cxx {
   #if DEBUG
@@ -95,7 +95,6 @@ public class HybridTestObjectSwiftKotlinSpec_base: HybridObjectSpec {
       return cxxWrapper
     }
   }
-  public var memorySize: Int { return 0 }
 }
 
 /**

--- a/packages/react-native-nitro-modules/README.md
+++ b/packages/react-native-nitro-modules/README.md
@@ -208,7 +208,7 @@ The following C++ / JS types are supported out of the box:
   <tr>
     <td>..any <code><a href="./src/HybridObject.ts">HybridObject</a></code></td>
     <td><code>std::shared_ptr&lt;<a href="./cpp/core/HybridObject.hpp">HybridObject</a>&gt;</code></td>
-    <td><code><a href="./ios/core/HybridObjectSpec.swift">HybridObjectSpec</a></code></td>
+    <td><code><a href="./ios/core/HybridObject.swift">HybridObject</a></code></td>
     <td><code><a href="./android/src/main/java/com/margelo/nitro/core/HybridObject.kt">HybridObject</a></code></td>
   </tr>
   <tr>

--- a/packages/react-native-nitro-modules/ios/core/HybridObject.swift
+++ b/packages/react-native-nitro-modules/ios/core/HybridObject.swift
@@ -1,5 +1,5 @@
 //
-//  HybridObjectSpec.swift
+//  HybridObject.swift
 //  NitroModules
 //
 //  Created by Marc Rousavy on 23.07.24.
@@ -8,24 +8,29 @@
 import Foundation
 
 /**
- * A base protocol for all Swift-based Hybrid Objects.
+ * The base class for all Swift-based HybridObjects.
  */
-public protocol HybridObjectSpec: AnyObject {
+public class HybridObject {
   /**
-   * Get the memory size of the Swift instance (plus any external heap allocations),
-   * in bytes.
+   * Get the memory size of any external heap allocations in bytes.
    *
    * Override this to allow tracking heap allocations such as buffers or images,
    * which will help the JS GC be more efficient in deleting large unused objects.
    *
+   * @default 0
    * @example
    * ```swift
-   * var memorySize: Int {
+   * override public var memorySize: Int {
    *   let imageSize = self.uiImage.bytesPerRow * self.uiImage.height
    *   return imageSize
    * }
    * ```
    */
+  public var memorySize: Int { return 0 }
+}
+
+@available(*, deprecated, message: "HybridObjectSpec (a protocol) has been replaced with HybridObject (a class).")
+public protocol HybridObjectSpec: AnyObject {
   var memorySize: Int { get }
 }
 

--- a/packages/react-native-nitro-modules/ios/core/HybridObject.swift
+++ b/packages/react-native-nitro-modules/ios/core/HybridObject.swift
@@ -15,7 +15,7 @@ public protocol HybridObjectSpec: AnyObject {
 /**
  * The base class for all Swift-based HybridObjects.
  */
-public class HybridObject: HybridObjectSpec {
+open class HybridObject: HybridObjectSpec {
   /**
    * Get the memory size of any external heap allocations in bytes.
    *
@@ -31,7 +31,7 @@ public class HybridObject: HybridObjectSpec {
    * }
    * ```
    */
-  public var memorySize: Int { return 0 }
+  open var memorySize: Int { return 0 }
 }
 
 public extension HybridObjectSpec {

--- a/packages/react-native-nitro-modules/ios/core/HybridObject.swift
+++ b/packages/react-native-nitro-modules/ios/core/HybridObject.swift
@@ -7,10 +7,15 @@
 
 import Foundation
 
+@available(*, deprecated, message: "HybridObjectSpec (a protocol) has been replaced with HybridObject (a class).")
+public protocol HybridObjectSpec: AnyObject {
+  var memorySize: Int { get }
+}
+
 /**
  * The base class for all Swift-based HybridObjects.
  */
-public class HybridObject {
+public class HybridObject: HybridObjectSpec {
   /**
    * Get the memory size of any external heap allocations in bytes.
    *
@@ -27,11 +32,6 @@ public class HybridObject {
    * ```
    */
   public var memorySize: Int { return 0 }
-}
-
-@available(*, deprecated, message: "HybridObjectSpec (a protocol) has been replaced with HybridObject (a class).")
-public protocol HybridObjectSpec: AnyObject {
-  var memorySize: Int { get }
 }
 
 public extension HybridObjectSpec {


### PR DESCRIPTION
In Swift, `HybridObject` is now a base class instead of a protocol.