### PR TITLE
fix: Mark Java `HybridObjectRegistry` as deprecated

### DIFF
--- a/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.hpp
@@ -20,6 +20,7 @@ public:
   static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/HybridObjectRegistry;";
 
 public:
+  [[deprecated("HybridObjects should be registered from C++ instead. Either autolink them using `nitro.json`, or add them manually in HybridObjectRegistry.")]]
   static void registerHybridObjectConstructor(jni::alias_ref<jni::JClass> clazz, std::string hybridObjectName,
                                               jni::alias_ref<JHybridObjectInitializer> constructorFn);
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.hpp
@@ -21,7 +21,7 @@ public:
 
 public:
   [[deprecated("HybridObjects should be registered from C++ instead. Either autolink them using `nitro.json`, "
-               "or add them manually in HybridObjectRegistry.")]]
+               "or add them manually in the C++ HybridObjectRegistry.")]]
   static void registerHybridObjectConstructor(jni::alias_ref<jni::JClass> clazz, std::string hybridObjectName,
                                               jni::alias_ref<JHybridObjectInitializer> constructorFn);
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.hpp
@@ -20,7 +20,8 @@ public:
   static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/HybridObjectRegistry;";
 
 public:
-  [[deprecated("HybridObjects should be registered from C++ instead. Either autolink them using `nitro.json`, or add them manually in HybridObjectRegistry.")]]
+  [[deprecated("HybridObjects should be registered from C++ instead. Either autolink them using `nitro.json`, or add them manually in "
+               "HybridObjectRegistry.")]]
   static void registerHybridObjectConstructor(jni::alias_ref<jni::JClass> clazz, std::string hybridObjectName,
                                               jni::alias_ref<JHybridObjectInitializer> constructorFn);
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/registry/JHybridObjectRegistry.hpp
@@ -20,8 +20,8 @@ public:
   static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/core/HybridObjectRegistry;";
 
 public:
-  [[deprecated("HybridObjects should be registered from C++ instead. Either autolink them using `nitro.json`, or add them manually in "
-               "HybridObjectRegistry.")]]
+  [[deprecated("HybridObjects should be registered from C++ instead. Either autolink them using `nitro.json`, "
+               "or add them manually in HybridObjectRegistry.")]]
   static void registerHybridObjectConstructor(jni::alias_ref<jni::JClass> clazz, std::string hybridObjectName,
                                               jni::alias_ref<JHybridObjectInitializer> constructorFn);
 

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObjectInitializer.java
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObjectInitializer.java
@@ -4,8 +4,12 @@ import androidx.annotation.Keep;
 
 import com.facebook.proguard.annotations.DoNotStrip;
 
+/**
+ * @deprecated HybridObjects should be registered from C++ instead. Either autolink them using `nitro.json`, or add them manually in the C++ `HybridObjectRegistry`.
+ */
 @Keep
 @DoNotStrip
+@Deprecated(forRemoval = true)
 public interface HybridObjectInitializer {
     @Keep
     @DoNotStrip

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObjectRegistry.java
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObjectRegistry.java
@@ -20,6 +20,8 @@ public class HybridObjectRegistry {
      * Registers the given HybridObject in the `HybridObjectRegistry`.
      * It will be uniquely identified via it's `hybridObjectName`, and can be initialized from
      * JS using `NitroModules.createHybridObject<T>(name)` - which will call the `constructorFn` here.
+     * @deprecated HybridObjects should be registered from C++ instead. Either autolink them using `nitro.json`, or add them manually in HybridObjectRegistry.
      */
+    @Deprecated(forRemoval = true)
     public static native void registerHybridObjectConstructor(String hybridObjectName, HybridObjectInitializer initializer);
 }

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObjectRegistry.java
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObjectRegistry.java
@@ -20,7 +20,7 @@ public class HybridObjectRegistry {
      * Registers the given HybridObject in the `HybridObjectRegistry`.
      * It will be uniquely identified via it's `hybridObjectName`, and can be initialized from
      * JS using `NitroModules.createHybridObject<T>(name)` - which will call the `constructorFn` here.
-     * @deprecated HybridObjects should be registered from C++ instead. Either autolink them using `nitro.json`, or add them manually in HybridObjectRegistry.
+     * @deprecated HybridObjects should be registered from C++ instead. Either autolink them using `nitro.json`, or add them manually in the C++ `HybridObjectRegistry`.
      */
     @Deprecated(forRemoval = true)
     public static native void registerHybridObjectConstructor(String hybridObjectName, HybridObjectInitializer initializer);


### PR DESCRIPTION
HybridObjects should be registered from C++ instead.