### PR TITLE
fix: Rename `HybridObjectSpec` -> `HybridObject` protocol

### DIFF
--- a/docs/docs/nitrogen.md
+++ b/docs/docs/nitrogen.md
@@ -23,7 +23,7 @@ interface Math extends HybridObject {
 <div className="side-by-side-block">
 
 ```swift title="HybridMathSpec.swift (generated)"
-protocol HybridMathSpec: HybridObjectSpec {
+protocol HybridMathSpec: HybridObject {
   var pi: Double { get }
   func add(a: Double, b: Double) -> Double
 }

--- a/docs/docs/types/types.md
+++ b/docs/docs/types/types.md
@@ -146,7 +146,7 @@ These are all the types Nitro supports out of the box:
   <tr>
     <td>..any <code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/src/HybridObject.ts">HybridObject</a></code></td>
     <td><code>std::shared_ptr&lt;<a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp">HybridObject</a>&gt;</code></td>
-    <td><code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/ios/core/HybridObjectSpec.swift">HybridObjectSpec</a></code></td>
+    <td><code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/ios/core/HybridObject.swift">HybridObject</a></code></td>
     <td><code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObject.kt">HybridObject</a></code></td>
   </tr>
   <tr>

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -40,8 +40,8 @@ public ${hasBaseClass ? 'override func' : 'func'} getCxxWrapper() -> ${name.Hybr
 }`.trim()
   )
   if (!hasBaseClass) {
-    // It doesn't have a base class - implement the `HybridObjectSpec` base protocol
-    classBaseClasses.push('HybridObjectSpec')
+    // It doesn't have a base class - implement the `HybridObject` base protocol
+    classBaseClasses.push('HybridObject')
     baseMembers.push(`public var memorySize: Int { return 0 }`)
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -18,7 +18,7 @@ public protocol HybridBaseSpec_protocol: AnyObject {
 }
 
 /// See ``HybridBaseSpec``
-public class HybridBaseSpec_base: HybridObjectSpec {
+public class HybridBaseSpec_base: HybridObject {
   private weak var cxxWrapper: HybridBaseSpec_cxx? = nil
   public func getCxxWrapper() -> HybridBaseSpec_cxx {
   #if DEBUG

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageFactorySpec.swift
@@ -21,7 +21,7 @@ public protocol HybridImageFactorySpec_protocol: AnyObject {
 }
 
 /// See ``HybridImageFactorySpec``
-public class HybridImageFactorySpec_base: HybridObjectSpec {
+public class HybridImageFactorySpec_base: HybridObject {
   private weak var cxxWrapper: HybridImageFactorySpec_cxx? = nil
   public func getCxxWrapper() -> HybridImageFactorySpec_cxx {
   #if DEBUG

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridImageSpec.swift
@@ -21,7 +21,7 @@ public protocol HybridImageSpec_protocol: AnyObject {
 }
 
 /// See ``HybridImageSpec``
-public class HybridImageSpec_base: HybridObjectSpec {
+public class HybridImageSpec_base: HybridObject {
   private weak var cxxWrapper: HybridImageSpec_cxx? = nil
   public func getCxxWrapper() -> HybridImageSpec_cxx {
   #if DEBUG

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -79,7 +79,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: AnyObject {
 }
 
 /// See ``HybridTestObjectSwiftKotlinSpec``
-public class HybridTestObjectSwiftKotlinSpec_base: HybridObjectSpec {
+public class HybridTestObjectSwiftKotlinSpec_base: HybridObject {
   private weak var cxxWrapper: HybridTestObjectSwiftKotlinSpec_cxx? = nil
   public func getCxxWrapper() -> HybridTestObjectSwiftKotlinSpec_cxx {
   #if DEBUG

--- a/packages/react-native-nitro-modules/README.md
+++ b/packages/react-native-nitro-modules/README.md
@@ -208,7 +208,7 @@ The following C++ / JS types are supported out of the box:
   <tr>
     <td>..any <code><a href="./src/HybridObject.ts">HybridObject</a></code></td>
     <td><code>std::shared_ptr&lt;<a href="./cpp/core/HybridObject.hpp">HybridObject</a>&gt;</code></td>
-    <td><code><a href="./ios/core/HybridObjectSpec.swift">HybridObjectSpec</a></code></td>
+    <td><code><a href="./ios/core/HybridObject.swift">HybridObject</a></code></td>
     <td><code><a href="./android/src/main/java/com/margelo/nitro/core/HybridObject.kt">HybridObject</a></code></td>
   </tr>
   <tr>

--- a/packages/react-native-nitro-modules/ios/core/HybridObject.swift
+++ b/packages/react-native-nitro-modules/ios/core/HybridObject.swift
@@ -1,5 +1,5 @@
 //
-//  HybridObjectSpec.swift
+//  HybridObject.swift
 //  NitroModules
 //
 //  Created by Marc Rousavy on 23.07.24.
@@ -10,7 +10,7 @@ import Foundation
 /**
  * A base protocol for all Swift-based Hybrid Objects.
  */
-public protocol HybridObjectSpec: AnyObject {
+public protocol HybridObject: AnyObject {
   /**
    * Get the memory size of the Swift instance (plus any external heap allocations),
    * in bytes.
@@ -28,6 +28,9 @@ public protocol HybridObjectSpec: AnyObject {
    */
   var memorySize: Int { get }
 }
+
+@available(*, deprecated, message: "HybridObjectSpec has been renamed to HybridObject. Update Nitrogen and re-generate your specs.")
+public typealias HybridObjectSpec = HybridObject
 
 public extension HybridObjectSpec {
   @available(*, deprecated, message: "getSizeOf(...) will now be default-computed. Please remove getSizeOf() from your code.")


### PR DESCRIPTION
Renames the `HybridObjectSpec` protocol to `HybridObject` for consistency.