### PR TITLE
fix: Rename `TypeInfo.hpp` to `NitroTypeInfo.hpp`

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -15,7 +15,7 @@ struct JSIConverter;
 #include "CountTrailingOptionals.hpp"
 #include "JSIConverter.hpp"
 #include "NitroDefines.hpp"
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 #include <exception>
 #include <functional>
 #include <jsi/jsi.h>

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -7,7 +7,7 @@
 #include "AssertPromiseState.hpp"
 #include "NitroDefines.hpp"
 #include "ThreadPool.hpp"
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 #include <exception>
 #include <future>
 #include <jsi/jsi.h>

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -6,8 +6,8 @@
 
 #include "AssertPromiseState.hpp"
 #include "NitroDefines.hpp"
-#include "ThreadPool.hpp"
 #include "NitroTypeInfo.hpp"
+#include "ThreadPool.hpp"
 #include <exception>
 #include <future>
 #include <jsi/jsi.h>

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
@@ -12,7 +12,7 @@ struct JSIConverter;
 
 #include "JSIConverter.hpp"
 
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 #include <exception>
 #include <jsi/jsi.h>
 

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+HostObject.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+HostObject.hpp
@@ -6,7 +6,7 @@
 
 #include "IsSharedPtrTo.hpp"
 #include "NitroDefines.hpp"
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 #include <jsi/jsi.h>
 #include <type_traits>
 

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+HybridObject.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+HybridObject.hpp
@@ -11,7 +11,7 @@ class HybridObject;
 
 #include "IsSharedPtrTo.hpp"
 #include "NitroDefines.hpp"
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 #include <jsi/jsi.h>
 #include <type_traits>
 

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Tuple.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Tuple.hpp
@@ -12,7 +12,7 @@ struct JSIConverter;
 
 #include "JSIConverter.hpp"
 
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 #include <jsi/jsi.h>
 #include <memory>
 #include <tuple>

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Variant.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Variant.hpp
@@ -18,7 +18,7 @@ struct JSIConverter;
 #include "JSIConverter.hpp"
 
 #include "AnyMap.hpp"
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 #include <jsi/jsi.h>
 #include <memory>
 #include <variant>

--- a/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
+++ b/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
@@ -8,7 +8,7 @@
 #include "HybridObjectPrototype.hpp"
 #include "NitroDefines.hpp"
 #include "NitroLogger.hpp"
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 
 namespace margelo::nitro {
 

--- a/packages/react-native-nitro-modules/cpp/utils/AssertPromiseState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/AssertPromiseState.hpp
@@ -13,7 +13,7 @@ class Promise;
 } // namespace margelo::nitro
 
 #include "Promise.hpp"
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 #include <exception>
 #include <string>
 

--- a/packages/react-native-nitro-modules/cpp/utils/AssertPromiseState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/AssertPromiseState.hpp
@@ -12,8 +12,8 @@ template <typename TResult>
 class Promise;
 } // namespace margelo::nitro
 
-#include "Promise.hpp"
 #include "NitroTypeInfo.hpp"
+#include "Promise.hpp"
 #include <exception>
 #include <string>
 

--- a/packages/react-native-nitro-modules/cpp/utils/NitroTypeInfo.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/NitroTypeInfo.hpp
@@ -1,5 +1,5 @@
 //
-//  TypeInfo.hpp
+//  NitroNitroTypeInfo.hpp
 //  Nitro
 //
 //  Created by Marc Rousavy on 17.07.24.

--- a/packages/react-native-nitro-modules/cpp/utils/NitroTypeInfo.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/NitroTypeInfo.hpp
@@ -1,5 +1,5 @@
 //
-//  NitroNitroTypeInfo.hpp
+//  NitroTypeInfo.hpp
 //  Nitro
 //
 //  Created by Marc Rousavy on 17.07.24.

--- a/packages/react-native-nitro-modules/ios/core/HybridContext.hpp
+++ b/packages/react-native-nitro-modules/ios/core/HybridContext.hpp
@@ -13,7 +13,7 @@ class HybridObject;
 
 #include "HybridObject.hpp"
 #include "NitroLogger.hpp"
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 #include <memory>
 
 namespace margelo::nitro {

--- a/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "TypeInfo.hpp"
+#include "NitroTypeInfo.hpp"
 #include <exception>
 #include <string>
 


### PR DESCRIPTION
TypeInfo.hpp collided with Boost's typeinfo.hpp