### PR TITLE
fix: Remove `REACT_NATIVE_VERSION` checks

### DIFF
--- a/packages/nitrogen/src/autolinking/android/createHybridObjectInitializer.ts
+++ b/packages/nitrogen/src/autolinking/android/createHybridObjectInitializer.ts
@@ -18,17 +18,7 @@ export function createHybridObjectIntializer(): SourceFile[] {
   const autolinkingClassName = `${NitroConfig.getAndroidCxxLibName()}OnLoad`
 
   const jniRegistrations = getJNINativeRegistrations()
-    .map((r) => {
-      const code = `${r.namespace}::${r.className}::registerNatives();`
-      if (r.ifGuard != null) {
-        return `
-#if ${r.ifGuard}
-${code}
-#endif`.trim()
-      } else {
-        return code
-      }
-    })
+    .map((r) => `${r.namespace}::${r.className}::registerNatives();`)
     .filter(isNotDuplicate)
 
   const autolinkedHybridObjects = NitroConfig.getAutolinkedHybridObjects()

--- a/packages/nitrogen/src/syntax/kotlin/JNINativeRegistrations.ts
+++ b/packages/nitrogen/src/syntax/kotlin/JNINativeRegistrations.ts
@@ -4,7 +4,6 @@ export interface JNINativeRegistration {
   namespace: string
   className: string
   import: SourceImport
-  ifGuard?: string
 }
 
 const jniNativeRegistrations: JNINativeRegistration[] = []

--- a/packages/nitrogen/src/views/CppHybridViewComponent.ts
+++ b/packages/nitrogen/src/views/CppHybridViewComponent.ts
@@ -70,10 +70,8 @@ ${createFileMetadataString(`${component}.hpp`)}
 
 #pragma once
 
-#include <NitroModules/NitroDefines.hpp>
-#if REACT_NATIVE_VERSION_MINOR >= 78
-
 #include <optional>
+#include <NitroModules/NitroDefines.hpp>
 #include <NitroModules/NitroHash.hpp>
 #include <NitroModules/CachedProp.hpp>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
@@ -158,10 +156,6 @@ namespace ${namespace} {
   /* The actual view for "${spec.name}" needs to be implemented in platform-specific code. */
 
 } // namespace ${namespace}
-
-#else
-#warning "View Component '${HybridT}' will be unavailable in React Native, because it requires React Native 78 or higher."
-#endif
 `.trim()
 
   // .cpp code
@@ -193,12 +187,11 @@ ${name}([&]() -> CachedProp<${type}> {
 ${createFileMetadataString(`${component}.cpp`)}
 
 #include "${component}.hpp"
-#include <NitroModules/NitroDefines.hpp>
-#if REACT_NATIVE_VERSION_MINOR >= 78
 
 #include <string>
 #include <exception>
 #include <utility>
+#include <NitroModules/NitroDefines.hpp>
 #include <NitroModules/JSIConverter.hpp>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/core/ShadowNode.h>
@@ -241,8 +234,6 @@ namespace ${namespace} {
   }
 
 } // namespace ${namespace}
-
-#endif
 `.trim()
 
   const files: SourceFile[] = [

--- a/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
+++ b/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
@@ -109,10 +109,8 @@ ${createFileMetadataString(`J${stateUpdaterName}.hpp`)}
 
 #pragma once
 
-#include <NitroModules/NitroDefines.hpp>
-#if REACT_NATIVE_VERSION_MINOR >= 78
-
 #include <fbjni/fbjni.h>
+#include <NitroModules/NitroDefines.hpp>
 #include <react/fabric/StateWrapperImpl.h>
 #include "${JHybridTSpec}.hpp"
 
@@ -138,8 +136,6 @@ public:
 };
 
 } // namespace ${cxxNamespace}
-
-#endif
   `.trim()
 
   const propsUpdaterCalls = spec.properties.map((p) => {
@@ -154,10 +150,8 @@ if (props.${name}.isDirty) {
 ${createFileMetadataString(`J${stateUpdaterName}.cpp`)}
 
 #include "J${stateUpdaterName}.hpp"
-#include <NitroModules/NitroDefines.hpp>
-#if REACT_NATIVE_VERSION_MINOR >= 78
-
 #include "views/${component}.hpp"
+#include <NitroModules/NitroDefines.hpp>
 
 namespace ${cxxNamespace} {
 
@@ -182,8 +176,6 @@ void J${stateUpdaterName}::updateViewProps(jni::alias_ref<jni::JClass>,
 }
 
 } // namespace ${cxxNamespace}
-
-#endif
 `.trim()
 
   addJNINativeRegistration({
@@ -194,7 +186,6 @@ void J${stateUpdaterName}::updateViewProps(jni::alias_ref<jni::JClass>,
       space: 'user',
       language: 'c++',
     },
-    ifGuard: `REACT_NATIVE_VERSION_MINOR >= 78`,
   })
 
   return [

--- a/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
+++ b/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
@@ -47,10 +47,9 @@ if (newViewProps.${name}.isDirty) {
 ${createFileMetadataString(`${component}.mm`)}
 
 #import "${component}.hpp"
-#include <NitroModules/NitroDefines.hpp>
-#if REACT_NATIVE_VERSION_MINOR >= 78
 
 #import <memory>
+#import <NitroModules/NitroDefines.hpp>
 #import <react/renderer/componentregistry/ComponentDescriptorProvider.h>
 #import <React/RCTViewComponentView.h>
 #import <React/RCTComponentViewFactory.h>
@@ -123,8 +122,6 @@ using namespace ${namespace}::views;
 }
 
 @end
-
-#endif
   `
 
   return [

--- a/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/NitroImageOnLoad.cpp
@@ -59,9 +59,7 @@ int initialize(JavaVM* vm) {
     margelo::nitro::image::JHybridBaseSpec::registerNatives();
     margelo::nitro::image::JHybridChildSpec::registerNatives();
     margelo::nitro::image::JHybridTestViewSpec::registerNatives();
-    #if REACT_NATIVE_VERSION_MINOR >= 78
     margelo::nitro::image::views::JHybridTestViewStateUpdater::registerNatives();
-    #endif
 
     // Register Nitro Hybrid Objects
     HybridObjectRegistry::registerHybridObjectConstructor(

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
@@ -6,10 +6,8 @@
 ///
 
 #include "JHybridTestViewStateUpdater.hpp"
-#include <NitroModules/NitroDefines.hpp>
-#if REACT_NATIVE_VERSION_MINOR >= 78
-
 #include "views/HybridTestViewComponent.hpp"
+#include <NitroModules/NitroDefines.hpp>
 
 namespace margelo::nitro::image::views {
 
@@ -39,5 +37,3 @@ void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass>,
 }
 
 } // namespace margelo::nitro::image::views
-
-#endif

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.hpp
@@ -7,10 +7,8 @@
 
 #pragma once
 
-#include <NitroModules/NitroDefines.hpp>
-#if REACT_NATIVE_VERSION_MINOR >= 78
-
 #include <fbjni/fbjni.h>
+#include <NitroModules/NitroDefines.hpp>
 #include <react/fabric/StateWrapperImpl.h>
 #include "JHybridTestViewSpec.hpp"
 
@@ -36,5 +34,3 @@ public:
 };
 
 } // namespace margelo::nitro::image::views
-
-#endif

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -6,10 +6,9 @@
 ///
 
 #import "HybridTestViewComponent.hpp"
-#include <NitroModules/NitroDefines.hpp>
-#if REACT_NATIVE_VERSION_MINOR >= 78
 
 #import <memory>
+#import <NitroModules/NitroDefines.hpp>
 #import <react/renderer/componentregistry/ComponentDescriptorProvider.h>
 #import <React/RCTViewComponentView.h>
 #import <React/RCTComponentViewFactory.h>
@@ -89,5 +88,3 @@ using namespace margelo::nitro::image::views;
 }
 
 @end
-
-#endif

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
@@ -6,12 +6,11 @@
 ///
 
 #include "HybridTestViewComponent.hpp"
-#include <NitroModules/NitroDefines.hpp>
-#if REACT_NATIVE_VERSION_MINOR >= 78
 
 #include <string>
 #include <exception>
 #include <utility>
+#include <NitroModules/NitroDefines.hpp>
 #include <NitroModules/JSIConverter.hpp>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/core/ShadowNode.h>
@@ -77,5 +76,3 @@ namespace margelo::nitro::image::views {
   }
 
 } // namespace margelo::nitro::image::views
-
-#endif

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
@@ -7,10 +7,8 @@
 
 #pragma once
 
-#include <NitroModules/NitroDefines.hpp>
-#if REACT_NATIVE_VERSION_MINOR >= 78
-
 #include <optional>
+#include <NitroModules/NitroDefines.hpp>
 #include <NitroModules/NitroHash.hpp>
 #include <NitroModules/CachedProp.hpp>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
@@ -96,7 +94,3 @@ namespace margelo::nitro::image::views {
   /* The actual view for "TestView" needs to be implemented in platform-specific code. */
 
 } // namespace margelo::nitro::image::views
-
-#else
-#warning "View Component 'HybridTestView' will be unavailable in React Native, because it requires React Native 78 or higher."
-#endif

--- a/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
@@ -52,14 +52,4 @@
 #define SWIFT_NONCOPYABLE
 #endif
 
-// React Native Support
-#if __has_include(<cxxreact/ReactNativeVersion.h>)
-#include <cxxreact/ReactNativeVersion.h>
-#endif
-#ifndef REACT_NATIVE_VERSION_MINOR
-#define REACT_NATIVE_VERSION_MAJOR 0
-#define REACT_NATIVE_VERSION_MINOR 0
-#define REACT_NATIVE_VERSION_PATCH 0
-#endif
-
 #endif /* NitroDefines_h */


### PR DESCRIPTION
Instead of the complex and messy `#if REACT_NATIVE_VERSION_MINOR >= 78` check which requires trying to figure out what RN version the user has, we just don't check that anymore.

Instead, the library author is just responsible for telling his users that Nitro Views require RN 78 or higher. This simplifies a lot on the Nitro side of things.