### PR TITLE
chore: Use `HybridObjectRegistry` normally when creating views

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectRegistration.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectRegistration.ts
@@ -22,14 +22,6 @@ interface SwiftHybridObjectRegistration {
   requiredImports: SourceImport[]
 }
 
-export function getHybridObjectConstructorCall(
-  hybridObjectName: string
-): string {
-  const swiftNamespace = NitroConfig.getIosModuleName()
-  const autolinkingClassName = `${NitroConfig.getIosModuleName()}Autolinking`
-  return `${swiftNamespace}::${autolinkingClassName}::create${hybridObjectName}();`
-}
-
 export function createSwiftHybridObjectRegistration({
   hybridObjectName,
   swiftClassName,
@@ -39,6 +31,8 @@ export function createSwiftHybridObjectRegistration({
 
   const type = new HybridObjectType(hybridObjectName, 'swift', [])
   const bridge = new SwiftCxxBridgedType(type)
+  const swiftNamespace = NitroConfig.getIosModuleName()
+  const autolinkingClassName = `${NitroConfig.getIosModuleName()}Autolinking`
 
   return {
     swiftFunction: `
@@ -61,7 +55,7 @@ public static func create${hybridObjectName}() -> ${bridge.getTypeCode('swift')}
 HybridObjectRegistry::registerHybridObjectConstructor(
   "${hybridObjectName}",
   []() -> std::shared_ptr<HybridObject> {
-    ${type.getCode('c++')} hybridObject = ${getHybridObjectConstructorCall(hybridObjectName)}
+    ${type.getCode('c++')} hybridObject = ${swiftNamespace}::${autolinkingClassName}::create${hybridObjectName}();
     return hybridObject;
   }
 );

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -15,6 +15,7 @@
 #import <React/RCTComponentViewFactory.h>
 #import <React/UIView+ComponentViewProtocol.h>
 #import <UIKit/UIKit.h>
+#import <NitroModules/HybridObjectRegistry.hpp>
 
 #import "HybridTestViewSpecSwift.hpp"
 #import "NitroImage-Swift-Cxx-Umbrella.hpp"
@@ -44,8 +45,11 @@ using namespace margelo::nitro::image::views;
 
 - (instancetype) init {
   if (self = [super init]) {
-    std::shared_ptr<HybridTestViewSpec> hybridView = NitroImage::NitroImageAutolinking::createTestView();
+    std::shared_ptr<HybridObject> hybridView = HybridObjectRegistry::createHybridObject("TestView");
     _hybridView = std::dynamic_pointer_cast<HybridTestViewSpecSwift>(hybridView);
+    if (_hybridView == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to create HybridObject \"TestView\" - it is not an instance of `HybridTestViewSpecSwift`!");
+    }
     [self updateView];
   }
   return self;


### PR DESCRIPTION
This makes sure the `HybridObjectRegistry` stays a central point for registering views. Technically this would allow it to use any view in here, even if it's not autolinked. not sure if needed.