### PR TITLE
feat: Update `memorySize` when a HybridObject makes a round-trip

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1296,5 +1296,33 @@ export function getTests(
         NitroModules.updateMemorySize(testObject)
       }).didNotThrow()
     ),
+    createTest('NitroModules.buildType holds a string', () =>
+      it(() => {
+        return NitroModules.buildType
+      })
+        .didNotThrow()
+        .didReturn('string')
+    ),
+    createTest('NitroModules.getAllHybridObjectNames() returns an array', () =>
+      it(() => {
+        return NitroModules.getAllHybridObjectNames()
+      })
+        .didNotThrow()
+        .toBeArray()
+    ),
+    createTest('NitroModules.hasHybridObject(testObject.name) to be true', () =>
+      it(() => {
+        return NitroModules.hasHybridObject(testObject.name)
+      })
+        .didNotThrow()
+        .equals(true)
+    ),
+    createTest('NitroModules.hasNativeState(testObject) to be true', () =>
+      it(() => {
+        return NitroModules.hasNativeState(testObject)
+      })
+        .didNotThrow()
+        .equals(true)
+    ),
   ]
 }

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1303,12 +1303,37 @@ export function getTests(
         .didNotThrow()
         .didReturn('string')
     ),
+    createTest('NitroModules.version holds a string', () =>
+      it(() => {
+        return NitroModules.version
+      })
+        .didNotThrow()
+        .didReturn('string')
+    ),
     createTest('NitroModules.getAllHybridObjectNames() returns an array', () =>
       it(() => {
         return NitroModules.getAllHybridObjectNames()
       })
         .didNotThrow()
         .toBeArray()
+    ),
+    createTest('NitroModules.box(testObject) returns an object', () =>
+      it(() => {
+        return NitroModules.box(testObject)
+      })
+        .didNotThrow()
+        .didReturn('object')
+    ),
+    createTest(
+      'NitroModules.box(testObject).unbox() returns the same object',
+      () =>
+        it(() => {
+          const boxed = NitroModules.box(testObject)
+          const original = boxed.unbox()
+          return original === testObject
+        })
+          .didNotThrow()
+          .equals(true)
     ),
     createTest('NitroModules.hasHybridObject(testObject.name) to be true', () =>
       it(() => {

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -9,7 +9,10 @@ import {
 import type { State } from './Testers'
 import { it } from './Testers'
 import { stringify } from './utils'
-import { getHybridObjectConstructor } from 'react-native-nitro-modules'
+import {
+  getHybridObjectConstructor,
+  NitroModules,
+} from 'react-native-nitro-modules'
 import { InteractionManager } from 'react-native'
 
 type TestResult =
@@ -1287,6 +1290,11 @@ export function getTests(
       })
         .didNotThrow()
         .equals(true)
+    ),
+    createTest('NitroModules.updateMemorySize(obj) works (roundtrip)', () =>
+      it(() => {
+        NitroModules.updateMemorySize(testObject)
+      }).didNotThrow()
     ),
   ]
 }

--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -50,7 +50,7 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
     jsi::Value value = cachedObject->second->lock(runtime);
     if (!value.isUndefined()) {
       // 1.2. It is still alive - we can use it instead of creating a new one! But first, let's update memory-size
-      value.asObject(runtime).setExternalMemoryPressure(runtime, getExternalMemorySize());
+      value.getObject(runtime).setExternalMemoryPressure(runtime, getExternalMemorySize());
       // 1.3. Return it now
       return value;
     }

--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -49,7 +49,9 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
     OwningLock<jsi::WeakObject> lock = cachedObject->second.lock();
     jsi::Value object = cachedObject->second->lock(runtime);
     if (!object.isUndefined()) {
-      // 1.2. It is still alive - we can use it instead of creating a new one!
+      // 1.2. It is still alive - we can use it instead of creating a new one! But first, let's update memory-size
+      object.setExternalMemoryPressure(runtime, getExternalMemorySize());
+      // 1.3. Return it now
       return object;
     }
   }

--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -47,12 +47,12 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
   if (cachedObject != _objectCache.end()) {
     // 1.1. We have a WeakObject, try to see if it is still alive
     OwningLock<jsi::WeakObject> lock = cachedObject->second.lock();
-    jsi::Value object = cachedObject->second->lock(runtime);
-    if (!object.isUndefined()) {
+    jsi::Value value = cachedObject->second->lock(runtime);
+    if (!value.isUndefined()) {
       // 1.2. It is still alive - we can use it instead of creating a new one! But first, let's update memory-size
-      object.setExternalMemoryPressure(runtime, getExternalMemorySize());
+      value.asObject(runtime).setExternalMemoryPressure(runtime, getExternalMemorySize());
       // 1.3. Return it now
-      return object;
+      return value;
     }
   }
 

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
@@ -7,8 +7,8 @@
 
 #include "HybridNitroModulesProxy.hpp"
 #include "HybridObjectRegistry.hpp"
-#include "NitroDefines.hpp"
 #include "JSIConverter.hpp"
+#include "NitroDefines.hpp"
 
 namespace margelo::nitro {
 

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
@@ -21,6 +21,7 @@ void HybridNitroModulesProxy::loadHybridMethods() {
     prototype.registerHybridMethod("getAllHybridObjectNames", &HybridNitroModulesProxy::getAllHybridObjectNames);
 
     prototype.registerHybridMethod("box", &HybridNitroModulesProxy::box);
+    prototype.registerHybridMethod("updateMemorySize", &HybridNitroModulesProxy::updateMemorySize);
 
     prototype.registerRawHybridMethod("hasNativeState", 1, &HybridNitroModulesProxy::hasNativeState);
 

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
@@ -8,6 +8,7 @@
 #include "HybridNitroModulesProxy.hpp"
 #include "HybridObjectRegistry.hpp"
 #include "NitroDefines.hpp"
+#include "JSIConverter.hpp"
 
 namespace margelo::nitro {
 
@@ -51,6 +52,12 @@ jsi::Value HybridNitroModulesProxy::hasNativeState(jsi::Runtime& runtime, const 
     return false;
   }
   return args[0].getObject(runtime).hasNativeState(runtime);
+}
+
+std::shared_ptr<HybridObject> HybridNitroModulesProxy::updateMemorySize(const std::shared_ptr<HybridObject>& hybridObject) {
+  // If a hybridObject goes from Native -> JS, it will update it's memory size internally (in `HybridObject::toObject(..)`).
+  // This is all that function does.
+  return hybridObject;
 }
 
 // Build Info

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.hpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.hpp
@@ -37,6 +37,7 @@ public:
 
   // Helpers
   std::shared_ptr<BoxedHybridObject> box(const std::shared_ptr<HybridObject>& hybridObject);
+  std::shared_ptr<HybridObject> updateMemorySize(const std::shared_ptr<HybridObject>& hybridObject);
   jsi::Value hasNativeState(jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* args, size_t size);
 
   // Build Info

--- a/packages/react-native-nitro-modules/src/NitroModulesProxy.ts
+++ b/packages/react-native-nitro-modules/src/NitroModulesProxy.ts
@@ -69,4 +69,12 @@ export interface NitroModulesProxy extends HybridObject {
    * Returns whether the given {@linkcode object} has NativeState or not.
    */
   hasNativeState(object: unknown): boolean
+
+  /**
+   * Re-calculates `memorySize` of the given {@linkcode HybridObject} and notifies
+   * the JS VM about the newly updated memory footprint.
+   *
+   * This is achieved by just doing a round-trip from JS -> native -> JS.
+   */
+  updateMemorySize(obj: HybridObject): HybridObject
 }


### PR DESCRIPTION
This internally updates the memory-size each time a HybridObject gets passed goes from native to JS (because it calls `HybridObject::toObject(...)`, which now does that).

Also, a new API is added: `NitroModules.updateMemorySize(hybridObject)` which is doing exactly that.