### PR TITLE
fix: Record fromCpp jni can't find kotlin data class constructor

### DIFF
--- a/packages/nitrogen/src/syntax/types/RecordType.ts
+++ b/packages/nitrogen/src/syntax/types/RecordType.ts
@@ -29,7 +29,7 @@ export class RecordType implements Type {
       case 'swift':
         return `Dictionary<${keyCode}, ${valueCode}>`
       case 'kotlin':
-        return `Map<${keyCode}, ${valueCode}>`
+        return `HashMap<${keyCode}, ${valueCode}>`
       default:
         throw new Error(
           `Language ${language} is not yet supported for RecordType!`


### PR DESCRIPTION
#### Context
I'm currently working on [react-native-fast-io](https://github.com/callstackincubator/react-native-fast-io) on a spec compliant fetch implementation.
For that the library has to accept a headers argument as `Record<string, string>` type.

### Problem
When specifying the following nitro type
```ts
export type RequestOptions = {
  headers: Record<string, string>
}

export interface Network extends HybridObject<{ ios: 'swift'; android: 'kotlin' }> {
  request(opts: RequestOptions): Promise<void>
}
```

It will generate the following kotlin data class definition
```kotlin
/**
 * Represents the JavaScript object/struct "RequestOptions".
 */
@DoNotStrip
@Keep
data class RequestOptions
  @DoNotStrip
  @Keep
  constructor(
    val headers: HashMap<String, String>
  ) {
  /* main constructor */
}
```

and the following c++ JRequestOptions fromCpp definition:
```c++

  public:
    /**
     * Create a Java/Kotlin-based struct by copying all values from the given C++ struct to Java.
     */
    [[maybe_unused]]
    static jni::local_ref<JRequestOptions::javaobject> fromCpp(const RequestOptions& value) {
      return newInstance(
        [&]() {
          auto __map = jni::JHashMap<jni::JString, jni::JString>::create(value.headers.size());
          for (const auto& __entry : value.headers) {
            __map->put(jni::make_jstring(__entry.first), jni::make_jstring(__entry.second));
          }
          return __map;
        }()
      );
    }
  };

```
which will create a `jni::JHashMap` and then call `newInstance` with the following type signature `Ljava/util/HashMap;`
which will then fail because it can't find the data class constructor,
because the requested native type is `java.util.HashMap` but the kotlin constructor accepts any `kotlin.collection.Map`.

To fix this the kotlin data class type needs to be changed to HashMap.

I've tested the change and it fixed the problem. Tho I don't know if this will break at other points and the change needs a proper review.
