### PR TITLE
perf: Make `OwningReference`/`BorrowingReference` only allocate memory block once and remove locking

### DIFF
--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference+Owning.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference+Owning.hpp
@@ -20,9 +20,9 @@ BorrowingReference<T>::BorrowingReference(const OwningReference<T>& ref) {
 
 template <typename T>
 OwningReference<T> BorrowingReference<T>::lock() const {
-  std::unique_lock lock(*_mutex);
+  std::unique_lock lock(_state->mutex);
 
-  if (*_isDeleted) {
+  if (_state->isDeleted) {
     // return nullptr
     return OwningReference<T>();
   }

--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference+Owning.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference+Owning.hpp
@@ -14,11 +14,8 @@ namespace margelo::nitro {
 template <typename T>
 BorrowingReference<T>::BorrowingReference(const OwningReference<T>& ref) {
   _value = ref._value;
-  _isDeleted = ref._isDeleted;
-  _strongRefCount = ref._strongRefCount;
-  _weakRefCount = ref._weakRefCount;
-  _mutex = ref._mutex;
-  (*_weakRefCount)++;
+  _state = ref._state;
+  (_state->weakRefCount)++;
 }
 
 template <typename T>

--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference+Owning.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference+Owning.hpp
@@ -15,7 +15,7 @@ template <typename T>
 BorrowingReference<T>::BorrowingReference(const OwningReference<T>& ref) {
   _value = ref._value;
   _state = ref._state;
-  (_state->weakRefCount)++;
+  _state->weakRefCount++;
 }
 
 template <typename T>

--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
@@ -48,7 +48,7 @@ public:
 
     if (_state != nullptr) {
       // destroy previous pointer
-      (_state->weakRefCount)--;
+      _state->weakRefCount--;
       maybeDestroy();
     }
 
@@ -56,7 +56,7 @@ public:
     _state = ref._state;
     if (_state != nullptr) {
       // increment new pointer
-      (_state->weakRefCount)++;
+      _state->weakRefCount++;
     }
 
     return *this;
@@ -68,7 +68,7 @@ public:
       return;
     }
 
-    (_state->weakRefCount)--;
+    _state->weakRefCount--;
     maybeDestroy();
   }
 

--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
@@ -31,7 +31,7 @@ public:
   BorrowingReference() : _value(nullptr), _state(nullptr) {}
 
   BorrowingReference(const BorrowingReference& ref) : _value(ref._value), _state(ref._state) {
-    if (_state->weakRefCount != nullptr) {
+    if (_state != nullptr) {
       // increment ref count after copy
       _state->weakRefCount++;
     }

--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "ReferenceState.hpp"
 #include <atomic>
 #include <cstddef>
 #include <mutex>
@@ -27,56 +28,47 @@ private:
   explicit BorrowingReference(const OwningReference<T>& ref);
 
 public:
-  BorrowingReference() : _value(nullptr), _isDeleted(nullptr), _strongRefCount(nullptr), _weakRefCount(nullptr), _mutex(nullptr) {}
+  BorrowingReference() : _value(nullptr), _state(nullptr) {}
 
-  BorrowingReference(const BorrowingReference& ref)
-      : _value(ref._value), _isDeleted(ref._isDeleted), _strongRefCount(ref._strongRefCount), _weakRefCount(ref._weakRefCount),
-        _mutex(ref._mutex) {
-    if (_weakRefCount != nullptr) {
+  BorrowingReference(const BorrowingReference& ref) : _value(ref._value), _state(ref._state) {
+    if (_state->weakRefCount != nullptr) {
       // increment ref count after copy
-      (*_weakRefCount)++;
+      _state->weakRefCount++;
     }
   }
 
-  BorrowingReference(BorrowingReference&& ref)
-      : _value(ref._value), _isDeleted(ref._isDeleted), _strongRefCount(ref._strongRefCount), _weakRefCount(ref._weakRefCount),
-        _mutex(ref._mutex) {
+  BorrowingReference(BorrowingReference&& ref) : _value(ref._value), _state(ref._state) {
     ref._value = nullptr;
-    ref._isDeleted = nullptr;
-    ref._strongRefCount = nullptr;
-    ref._weakRefCount = nullptr;
+    ref._state = nullptr;
   }
 
   BorrowingReference& operator=(const BorrowingReference& ref) {
     if (this == &ref)
       return *this;
 
-    if (_weakRefCount != nullptr) {
+    if (_state != nullptr) {
       // destroy previous pointer
-      (*_weakRefCount)--;
+      (_state->weakRefCount)--;
       maybeDestroy();
     }
 
     _value = ref._value;
-    _isDeleted = ref._isDeleted;
-    _strongRefCount = ref._strongRefCount;
-    _weakRefCount = ref._weakRefCount;
-    _mutex = ref._mutex;
-    if (_weakRefCount != nullptr) {
+    _state = ref._state;
+    if (_state != nullptr) {
       // increment new pointer
-      (*_weakRefCount)++;
+      (_state->weakRefCount)++;
     }
 
     return *this;
   }
 
   ~BorrowingReference() {
-    if (_weakRefCount == nullptr) {
+    if (_state == nullptr) {
       // we are just a dangling nullptr.
       return;
     }
 
-    (*_weakRefCount)--;
+    (_state->weakRefCount)--;
     maybeDestroy();
   }
 
@@ -91,29 +83,26 @@ public:
 
 private:
   void maybeDestroy() {
-    _mutex->lock();
+    _state->mutex.lock();
 
-    if (*_strongRefCount == 0 && *_weakRefCount == 0) {
+    if (_state->strongRefCount == 0 && _state->weakRefCount == 0) {
       // free the full memory if there are no more references at all
-      if (!(*_isDeleted)) {
+      if (!_state->isDeleted) [[unlikely]] {
+        // This should've happened in OwningReference already..
         delete _value;
+        _state->isDeleted = true;
       }
-      delete _isDeleted;
-      delete _strongRefCount;
-      delete _weakRefCount;
-      _mutex->unlock();
+      _state->mutex.unlock();
+      delete _state;
       return;
     }
 
-    _mutex->unlock();
+    _state->mutex.unlock();
   }
 
 private:
   T* _value;
-  bool* _isDeleted;
-  std::atomic_size_t* _strongRefCount;
-  std::atomic_size_t* _weakRefCount;
-  std::recursive_mutex* _mutex;
+  ReferenceState* _state;
 };
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/utils/OwningLock.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/OwningLock.hpp
@@ -34,7 +34,7 @@ template <typename T>
 class OwningLock final {
 public:
   ~OwningLock() {
-    _reference._mutex->unlock();
+    _reference._state->mutex.unlock();
   }
 
   OwningLock() = delete;
@@ -43,7 +43,7 @@ public:
 
 private:
   explicit OwningLock(const OwningReference<T>& reference) : _reference(reference) {
-    _reference._mutex->lock();
+    _reference._state->mutex.lock();
   }
 
 private:

--- a/packages/react-native-nitro-modules/cpp/utils/OwningReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/OwningReference.hpp
@@ -191,7 +191,7 @@ public:
 
 private:
   void maybeDestroy() {
-    _state->mutex->lock();
+    _state->mutex.lock();
 
     if (_state->strongRefCount == 0) {
       // after no strong references exist anymore
@@ -200,12 +200,12 @@ private:
 
     if (_state->strongRefCount == 0 && _state->weakRefCount == 0) {
       // free the full memory if there are no more references at all
-      _state->mutex->unlock();
+      _state->mutex.unlock();
       delete _state;
       return;
     }
 
-    _state->mutex->unlock();
+    _state->mutex.unlock();
   }
 
   void forceDestroy() {

--- a/packages/react-native-nitro-modules/cpp/utils/OwningReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/OwningReference.hpp
@@ -39,7 +39,7 @@ public:
   OwningReference(const OwningReference& ref) : _value(ref._value), _state(ref._state) {
     if (_state != nullptr) {
       // increment ref count after copy
-      (_state->strongRefCount)++;
+      _state->strongRefCount++;
     }
   }
 
@@ -54,7 +54,7 @@ public:
 
     if (_state != nullptr) {
       // destroy previous pointer
-      (_state->strongRefCount)--;
+      _state->strongRefCount--;
       maybeDestroy();
     }
 
@@ -62,7 +62,7 @@ public:
     _state = ref._state;
     if (_state != nullptr) {
       // increment new pointer
-      (_state->strongRefCount)++;
+      _state->strongRefCount++;
     }
 
     return *this;
@@ -71,7 +71,7 @@ public:
 private:
   // BorrowingReference<T> -> OwningReference<T> Lock-constructor
   OwningReference(const BorrowingReference<T>& ref) : _value(ref._value), _state(ref._state) {
-    (_state->strongRefCount)++;
+    _state->strongRefCount++;
   }
 
 private:
@@ -92,7 +92,7 @@ public:
     }
 
     // decrement strong ref count on destroy
-    (_state->strongRefCount)--;
+    _state->strongRefCount--;
     maybeDestroy();
   }
 

--- a/packages/react-native-nitro-modules/cpp/utils/OwningReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/OwningReference.hpp
@@ -10,6 +10,7 @@
 #include "BorrowingReference.hpp"
 #include "NitroDefines.hpp"
 #include "OwningLock.hpp"
+#include "ReferenceState.hpp"
 #include <atomic>
 #include <cstddef>
 #include <mutex>
@@ -31,48 +32,37 @@ public:
   using Pointee = T;
 
 public:
-  OwningReference() : _value(nullptr), _isDeleted(nullptr), _strongRefCount(nullptr), _weakRefCount(nullptr), _mutex(nullptr) {}
+  OwningReference() : _value(nullptr), _state(nullptr) {}
 
-  explicit OwningReference(T* value)
-      : _value(value), _isDeleted(new bool(false)), _strongRefCount(new std::atomic_size_t(1)), _weakRefCount(new std::atomic_size_t(0)),
-        _mutex(new std::recursive_mutex()) {}
+  explicit OwningReference(T* value) : _value(value), _state(new ReferenceState()) {}
 
-  OwningReference(const OwningReference& ref)
-      : _value(ref._value), _isDeleted(ref._isDeleted), _strongRefCount(ref._strongRefCount), _weakRefCount(ref._weakRefCount),
-        _mutex(ref._mutex) {
-    if (_strongRefCount != nullptr) {
+  OwningReference(const OwningReference& ref) : _value(ref._value), _state(ref._state) {
+    if (_state != nullptr) {
       // increment ref count after copy
-      (*_strongRefCount)++;
+      (_state->strongRefCount)++;
     }
   }
 
-  OwningReference(OwningReference&& ref)
-      : _value(ref._value), _isDeleted(ref._isDeleted), _strongRefCount(ref._strongRefCount), _weakRefCount(ref._weakRefCount),
-        _mutex(ref._mutex) {
+  OwningReference(OwningReference&& ref) : _value(ref._value), _state(ref._state) {
     ref._value = nullptr;
-    ref._isDeleted = nullptr;
-    ref._strongRefCount = nullptr;
-    ref._weakRefCount = nullptr;
+    ref._state = nullptr;
   }
 
   OwningReference& operator=(const OwningReference& ref) {
     if (this == &ref)
       return *this;
 
-    if (_strongRefCount != nullptr) {
+    if (_state != nullptr) {
       // destroy previous pointer
-      (*_strongRefCount)--;
+      (_state->strongRefCount)--;
       maybeDestroy();
     }
 
     _value = ref._value;
-    _isDeleted = ref._isDeleted;
-    _strongRefCount = ref._strongRefCount;
-    _weakRefCount = ref._weakRefCount;
-    _mutex = ref._mutex;
-    if (_strongRefCount != nullptr) {
+    _state = ref._state;
+    if (_state != nullptr) {
       // increment new pointer
-      (*_strongRefCount)++;
+      (_state->strongRefCount)++;
     }
 
     return *this;
@@ -80,19 +70,15 @@ public:
 
 private:
   // BorrowingReference<T> -> OwningReference<T> Lock-constructor
-  OwningReference(const BorrowingReference<T>& ref)
-      : _value(ref._value), _isDeleted(ref._isDeleted), _strongRefCount(ref._strongRefCount), _weakRefCount(ref._weakRefCount),
-        _mutex(ref._mutex) {
-    (*_strongRefCount)++;
+  OwningReference(const BorrowingReference<T>& ref) : _value(ref._value), _state(ref._state) {
+    (_state->strongRefCount)++;
   }
 
 private:
   // OwningReference<C> -> OwningReference<T> Cast-constructor
   template <typename OldT>
-  OwningReference(T* value, const OwningReference<OldT>& originalRef)
-      : _value(value), _isDeleted(originalRef._isDeleted), _strongRefCount(originalRef._strongRefCount),
-        _weakRefCount(originalRef._weakRefCount), _mutex(originalRef._mutex) {
-    (*_strongRefCount)++;
+  OwningReference(T* value, const OwningReference<OldT>& originalRef) : _value(value), _state(originalRef._state) {
+    _state->strongRefCount++;
   }
 
   template <typename C>
@@ -100,13 +86,13 @@ private:
 
 public:
   ~OwningReference() {
-    if (_strongRefCount == nullptr) {
+    if (_state == nullptr) {
       // we are just a dangling nullptr.
       return;
     }
 
     // decrement strong ref count on destroy
-    --(*_strongRefCount);
+    (_state->strongRefCount)--;
     maybeDestroy();
   }
 
@@ -135,7 +121,7 @@ public:
    Get whether the `OwningReference<T>` is still pointing to a valid value, or not.
    */
   inline bool hasValue() const {
-    return _value != nullptr && !(*_isDeleted);
+    return _value != nullptr && _state != nullptr && !_state->isDeleted;
   }
 
   /**
@@ -153,7 +139,7 @@ public:
    This will block as long as one or more `OwningLock<T>`s of this `OwningReference<T>` are still alive.
    */
   void destroy() {
-    std::unique_lock lock(*_mutex);
+    std::unique_lock lock(_state->mutex);
 
     forceDestroy();
   }
@@ -182,9 +168,9 @@ public:
   }
 
   inline bool operator==(T* other) const {
-    std::unique_lock lock(*_mutex);
+    std::unique_lock lock(_state->mutex);
 
-    if (*_isDeleted) {
+    if (_state == nullptr || _state->isDeleted) {
       return other == nullptr;
     } else {
       return other == _value;
@@ -205,32 +191,30 @@ public:
 
 private:
   void maybeDestroy() {
-    _mutex->lock();
+    _state->mutex->lock();
 
-    if (*_strongRefCount == 0) {
+    if (_state->strongRefCount == 0) {
       // after no strong references exist anymore
       forceDestroy();
     }
 
-    if (*_strongRefCount == 0 && *_weakRefCount == 0) {
+    if (_state->strongRefCount == 0 && _state->weakRefCount == 0) {
       // free the full memory if there are no more references at all
-      delete _isDeleted;
-      delete _strongRefCount;
-      delete _weakRefCount;
-      _mutex->unlock();
+      _state->mutex->unlock();
+      delete _state;
       return;
     }
 
-    _mutex->unlock();
+    _state->mutex->unlock();
   }
 
   void forceDestroy() {
-    if (*_isDeleted) {
+    if (_state->isDeleted) {
       // it has already been destroyed.
       return;
     }
     delete _value;
-    *_isDeleted = true;
+    _state->isDeleted = true;
   }
 
 public:
@@ -239,10 +223,7 @@ public:
 
 private:
   T* _value;
-  bool* _isDeleted;
-  std::atomic_size_t* _strongRefCount;
-  std::atomic_size_t* _weakRefCount;
-  std::recursive_mutex* _mutex;
+  ReferenceState* _state;
 };
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
@@ -1,0 +1,23 @@
+//
+//  ReferenceState.hpp
+//  react-native-nitro
+//
+//  Created by Marc Rousavy on 03.02.24.
+//
+
+#pragma once
+
+#include <atomic>
+
+namespace margelo::nitro {
+
+struct ReferenceState {
+  bool isDeleted;
+  std::atomic_size_t strongRefCount;
+  std::atomic_size_t weakRefCount;
+  std::mutex mutex;
+
+  explicit ReferenceState() : isDeleted(false), strongRefCount(1), weakRefCount(0) {}
+};
+
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <atomic>
+#include <mutex>
 
 namespace margelo::nitro {
 

--- a/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
@@ -12,13 +12,21 @@
 
 namespace margelo::nitro {
 
+/**
+ * Holds state for an `OwningReference` (or `BorrowingReference`).
+ *
+ * The state tracks the amount of strong- and weak- references to any kind of value,
+ * including an extra `isDeleted` flag that specifies whether the value has been force-deleted.
+ *
+ * Also, a `mutex` allows for thread-safe access of the `isDeleted` flag.
+ */
 struct ReferenceState {
-  bool isDeleted;
   std::atomic_size_t strongRefCount;
   std::atomic_size_t weakRefCount;
+  bool isDeleted;
   std::mutex mutex;
 
-  explicit ReferenceState() : isDeleted(false), strongRefCount(1), weakRefCount(0) {}
+  explicit ReferenceState() : strongRefCount(1), weakRefCount(0), isDeleted(false) {}
 };
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
@@ -26,6 +26,14 @@ struct ReferenceState {
   bool isDeleted;
   std::mutex mutex;
 
+  /**
+   * Decrements the strong ref count by one, and returns whether the value should be deleted.
+   */
+  inline bool decrementStrongRefCount() {
+    size_t oldRefCount = strongRefCount.fetch_sub(1);
+    return oldRefCount <= 1;
+  }
+
   explicit ReferenceState() : strongRefCount(1), weakRefCount(0), isDeleted(false) {}
 };
 


### PR DESCRIPTION
This should speed up allocations of new `OwningReference`/`BorrowingReference` types!

- Instead of 4x `new T*`, we now only allocate a single state block: `new ReferenceState` - which is a struct.
- This PR also removes all mutex locking operations of `OwningReference` and `BorrowingReference`! 🥳 Only `OwningLock` and `destroy()` need to lock the mutex :)