### PR TITLE
fix: Fix `cxxreact` module import

### DIFF
--- a/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
@@ -52,10 +52,7 @@
 #define SWIFT_NONCOPYABLE
 #endif
 
-// React Native Support
-#if __has_include(<cxxreact/ReactNativeVersion.h>)
-#include <cxxreact/ReactNativeVersion.h>
-#endif
+// React Native Support (right now it's only stubbed out)
 #ifndef REACT_NATIVE_VERSION_MINOR
 #define REACT_NATIVE_VERSION_MAJOR 0
 #define REACT_NATIVE_VERSION_MINOR 0


### PR DESCRIPTION
In Nitro 0.22 we included `cxxreact` just to find the React Native version. 

This import broke in RN 78 because we didn't depend on `cxxreact`. So this PR removes that again, since it's gonna become unnecessary anyways in the future as the user is responsible for ensuring RN version compatibility.