### PR TITLE
fix: Append `.gitattributes` file as well

### DIFF
--- a/packages/nitrogen/src/createGitAttributes.ts
+++ b/packages/nitrogen/src/createGitAttributes.ts
@@ -1,8 +1,9 @@
 import fs from 'fs/promises'
 import path from 'path'
 
-export async function createGitAttributes(folder: string): Promise<void> {
+export async function createGitAttributes(folder: string): Promise<string> {
   const file = path.join(folder, '.gitattributes')
   // Marks all files in this current folder as "generated"
   await fs.writeFile(file, `* linguist-generated`)
+  return file
 }

--- a/packages/nitrogen/src/nitrogen.ts
+++ b/packages/nitrogen/src/nitrogen.ts
@@ -228,7 +228,8 @@ export async function runNitrogen({
   try {
     if (NitroConfig.getCreateGitAttributes()) {
       // write a .gitattributes file
-      await createGitAttributes(outputDirectory)
+      const file = await createGitAttributes(outputDirectory)
+      filesAfter.push(file)
     }
   } catch {
     Logger.error(`❌ Failed to write ${chalk.dim(`.gitattributes`)}!`)


### PR DESCRIPTION
When I run nitrogen, it creates a `.gitattributes` file. On the next run, it removes it again.

This PR fixes that.