### PR TITLE
fix: Fix `f.path` sometimes being undefined

### DIFF
--- a/packages/nitrogen/src/createGitAttributes.ts
+++ b/packages/nitrogen/src/createGitAttributes.ts
@@ -1,9 +1,13 @@
 import fs from 'fs/promises'
 import path from 'path'
 
+const GIT_ATTRIBUTES_CONTENT = `
+* linguist-generated
+`
+
 export async function createGitAttributes(folder: string): Promise<string> {
   const file = path.join(folder, '.gitattributes')
   // Marks all files in this current folder as "generated"
-  await fs.writeFile(file, `* linguist-generated`)
+  await fs.writeFile(file, GIT_ATTRIBUTES_CONTENT.trim() + '\n', 'utf-8')
   return file
 }

--- a/packages/nitrogen/src/createGitAttributes.ts
+++ b/packages/nitrogen/src/createGitAttributes.ts
@@ -1,8 +1,9 @@
 import fs from 'fs/promises'
 import path from 'path'
 
-export async function createGitAttributes(folder: string): Promise<void> {
+export async function createGitAttributes(folder: string): Promise<string> {
   const file = path.join(folder, '.gitattributes')
   // Marks all files in this current folder as "generated"
   await fs.writeFile(file, `* linguist-generated`)
+  return file
 }

--- a/packages/nitrogen/src/getFiles.ts
+++ b/packages/nitrogen/src/getFiles.ts
@@ -1,5 +1,10 @@
-import { promises as fs } from 'fs'
+import { Dirent, promises as fs } from 'fs'
 import path from 'path'
+
+function getFilePath(file: Dirent, rootDir: string): string {
+  const dir = file.parentPath ?? file.path ?? rootDir
+  return path.join(dir, file.name)
+}
 
 export async function getFiles(directory: string): Promise<string[]> {
   try {
@@ -8,7 +13,7 @@ export async function getFiles(directory: string): Promise<string[]> {
       withFileTypes: true,
     })
 
-    return files.filter((f) => f.isFile()).map((f) => path.join(f.path, f.name))
+    return files.filter((f) => f.isFile()).map((f) => getFilePath(f, directory))
   } catch (error) {
     if (
       typeof error === 'object' &&

--- a/packages/nitrogen/src/nitrogen.ts
+++ b/packages/nitrogen/src/nitrogen.ts
@@ -228,7 +228,8 @@ export async function runNitrogen({
   try {
     if (NitroConfig.getCreateGitAttributes()) {
       // write a .gitattributes file
-      await createGitAttributes(outputDirectory)
+      const file = await createGitAttributes(outputDirectory)
+      filesAfter.push(file)
     }
   } catch {
     Logger.error(`❌ Failed to write ${chalk.dim(`.gitattributes`)}!`)


### PR DESCRIPTION
Apparently sometimes `f.path` can be `undefined`, e.g. for a `.gitattributes` file - as reported by @thecynicalpaul in https://github.com/mrousavy/nitro/issues/528.

I couldn't reproduce the issue, but this PR fixes this.