### PR TITLE
fix: Generate `@JvmName` prop for Kotlin methods

### DIFF
--- a/packages/nitrogen/src/syntax/Method.ts
+++ b/packages/nitrogen/src/syntax/Method.ts
@@ -34,6 +34,12 @@ export interface MethodModifiers {
    * it from being stripped from the binary by the Java compiler or ProGuard.
    */
   doNotStrip?: boolean
+  /**
+   * An extra `@JvmName` property.
+   * - If `true`, it's identical to the method name.
+   * - If a `string`, it's a custom passed name.
+   */
+  jvmName?: string | boolean
 }
 
 export class Method implements CodeNode {
@@ -120,6 +126,13 @@ ${signature} {
         if (modifiers?.virtual) signature = `abstract ${signature}`
         if (modifiers?.doNotStrip)
           signature = `@DoNotStrip\n@Keep\n${signature}`
+        if (modifiers?.jvmName) {
+          const jvmName =
+            typeof modifiers.jvmName === 'string'
+              ? modifiers.jvmName
+              : this.name
+          signature = `@JvmName("${jvmName}")\n${signature}`
+        }
 
         if (body == null) {
           return signature

--- a/packages/nitrogen/src/syntax/Method.ts
+++ b/packages/nitrogen/src/syntax/Method.ts
@@ -124,8 +124,6 @@ ${signature} {
         if (modifiers?.inline) signature = `inline ${signature}`
         if (modifiers?.override) signature = `override ${signature}`
         if (modifiers?.virtual) signature = `abstract ${signature}`
-        if (modifiers?.doNotStrip)
-          signature = `@DoNotStrip\n@Keep\n${signature}`
         if (modifiers?.jvmName) {
           const jvmName =
             typeof modifiers.jvmName === 'string'
@@ -133,6 +131,8 @@ ${signature} {
               : this.name
           signature = `@JvmName("${jvmName}")\n${signature}`
         }
+        if (modifiers?.doNotStrip)
+          signature = `@DoNotStrip\n@Keep\n${signature}`
 
         if (body == null) {
           return signature

--- a/packages/nitrogen/src/syntax/kotlin/KotlinHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinHybridObject.ts
@@ -59,7 +59,8 @@ ${imports.join('\n')}
 @Suppress(
   "KotlinJniMissingFunction", "unused",
   "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
-  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName",
+  "INAPPLICABLE_JVM_NAME"
 )
 abstract class ${name.HybridTSpec}: ${kotlinBase}() {
   @DoNotStrip

--- a/packages/nitrogen/src/syntax/kotlin/KotlinHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinHybridObject.ts
@@ -143,13 +143,18 @@ ${code}
 
 @DoNotStrip
 @Keep
+@JvmName("${method.name}_cxx")
 private fun ${method.name}_cxx(${paramsSignature.join(', ')}): ${bridgedReturn.getTypeCode('kotlin')} {
   val __result = ${method.name}(${paramsForward.join(', ')})
   return ${returnForward}
 }
     `.trim()
   } else {
-    const code = method.getCode('kotlin', { doNotStrip: true, virtual: true })
+    const code = method.getCode('kotlin', {
+      doNotStrip: true,
+      virtual: true,
+      jvmName: true,
+    })
     return code
   }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridBaseSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridBaseSpec.kt
@@ -21,7 +21,8 @@ import com.margelo.nitro.core.*
 @Suppress(
   "KotlinJniMissingFunction", "unused",
   "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
-  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName",
+  "INAPPLICABLE_JVM_NAME"
 )
 abstract class HybridBaseSpec: HybridObject() {
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridChildSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridChildSpec.kt
@@ -21,7 +21,8 @@ import com.margelo.nitro.core.*
 @Suppress(
   "KotlinJniMissingFunction", "unused",
   "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
-  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName",
+  "INAPPLICABLE_JVM_NAME"
 )
 abstract class HybridChildSpec: HybridBaseSpec() {
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
@@ -41,24 +41,24 @@ abstract class HybridImageFactorySpec: HybridObject() {
   
 
   // Methods
-  @JvmName("loadImageFromFile")
   @DoNotStrip
   @Keep
+  @JvmName("loadImageFromFile")
   abstract fun loadImageFromFile(path: String): HybridImageSpec
   
-  @JvmName("loadImageFromURL")
   @DoNotStrip
   @Keep
+  @JvmName("loadImageFromURL")
   abstract fun loadImageFromURL(path: String): HybridImageSpec
   
-  @JvmName("loadImageFromSystemName")
   @DoNotStrip
   @Keep
+  @JvmName("loadImageFromSystemName")
   abstract fun loadImageFromSystemName(path: String): HybridImageSpec
   
-  @JvmName("bounceBack")
   @DoNotStrip
   @Keep
+  @JvmName("bounceBack")
   abstract fun bounceBack(image: HybridImageSpec): HybridImageSpec
 
   private external fun initHybrid(): HybridData

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
@@ -21,7 +21,8 @@ import com.margelo.nitro.core.*
 @Suppress(
   "KotlinJniMissingFunction", "unused",
   "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
-  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName",
+  "INAPPLICABLE_JVM_NAME"
 )
 abstract class HybridImageFactorySpec: HybridObject() {
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
@@ -40,18 +40,22 @@ abstract class HybridImageFactorySpec: HybridObject() {
   
 
   // Methods
+  @JvmName("loadImageFromFile")
   @DoNotStrip
   @Keep
   abstract fun loadImageFromFile(path: String): HybridImageSpec
   
+  @JvmName("loadImageFromURL")
   @DoNotStrip
   @Keep
   abstract fun loadImageFromURL(path: String): HybridImageSpec
   
+  @JvmName("loadImageFromSystemName")
   @DoNotStrip
   @Keep
   abstract fun loadImageFromSystemName(path: String): HybridImageSpec
   
+  @JvmName("bounceBack")
   @DoNotStrip
   @Keep
   abstract fun bounceBack(image: HybridImageSpec): HybridImageSpec

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -52,6 +52,7 @@ abstract class HybridImageSpec: HybridObject() {
   abstract var someSettableProp: Double
 
   // Methods
+  @JvmName("toArrayBuffer")
   @DoNotStrip
   @Keep
   abstract fun toArrayBuffer(format: ImageFormat): Double
@@ -60,6 +61,7 @@ abstract class HybridImageSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("saveToFile_cxx")
   private fun saveToFile_cxx(path: String, onFinished: Func_void_std__string): Unit {
     val __result = saveToFile(path, onFinished)
     return __result

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -53,9 +53,9 @@ abstract class HybridImageSpec: HybridObject() {
   abstract var someSettableProp: Double
 
   // Methods
-  @JvmName("toArrayBuffer")
   @DoNotStrip
   @Keep
+  @JvmName("toArrayBuffer")
   abstract fun toArrayBuffer(format: ImageFormat): Double
   
   abstract fun saveToFile(path: String, onFinished: (path: String) -> Unit): Unit

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -21,7 +21,8 @@ import com.margelo.nitro.core.*
 @Suppress(
   "KotlinJniMissingFunction", "unused",
   "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
-  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName",
+  "INAPPLICABLE_JVM_NAME"
 )
 abstract class HybridImageSpec: HybridObject() {
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -21,7 +21,8 @@ import com.margelo.nitro.core.*
 @Suppress(
   "KotlinJniMissingFunction", "unused",
   "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
-  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName",
+  "INAPPLICABLE_JVM_NAME"
 )
 abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -129,49 +129,49 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   abstract var someVariant: Variant_String_Double
 
   // Methods
-  @JvmName("newTestObject")
   @DoNotStrip
   @Keep
+  @JvmName("newTestObject")
   abstract fun newTestObject(): HybridTestObjectSwiftKotlinSpec
   
-  @JvmName("simpleFunc")
   @DoNotStrip
   @Keep
+  @JvmName("simpleFunc")
   abstract fun simpleFunc(): Unit
   
-  @JvmName("addNumbers")
   @DoNotStrip
   @Keep
+  @JvmName("addNumbers")
   abstract fun addNumbers(a: Double, b: Double): Double
   
-  @JvmName("addStrings")
   @DoNotStrip
   @Keep
+  @JvmName("addStrings")
   abstract fun addStrings(a: String, b: String): String
   
-  @JvmName("multipleArguments")
   @DoNotStrip
   @Keep
+  @JvmName("multipleArguments")
   abstract fun multipleArguments(num: Double, str: String, boo: Boolean): Unit
   
-  @JvmName("bounceStrings")
   @DoNotStrip
   @Keep
+  @JvmName("bounceStrings")
   abstract fun bounceStrings(array: Array<String>): Array<String>
   
-  @JvmName("bounceNumbers")
   @DoNotStrip
   @Keep
+  @JvmName("bounceNumbers")
   abstract fun bounceNumbers(array: DoubleArray): DoubleArray
   
-  @JvmName("bounceStructs")
   @DoNotStrip
   @Keep
+  @JvmName("bounceStructs")
   abstract fun bounceStructs(array: Array<Person>): Array<Person>
   
-  @JvmName("bounceEnums")
   @DoNotStrip
   @Keep
+  @JvmName("bounceEnums")
   abstract fun bounceEnums(array: Array<Powertrain>): Array<Powertrain>
   
   abstract fun complexEnumCallback(array: Array<Powertrain>, callback: (array: Array<Powertrain>) -> Unit): Unit
@@ -184,89 +184,89 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     return __result
   }
   
-  @JvmName("createMap")
   @DoNotStrip
   @Keep
+  @JvmName("createMap")
   abstract fun createMap(): AnyMap
   
-  @JvmName("mapRoundtrip")
   @DoNotStrip
   @Keep
+  @JvmName("mapRoundtrip")
   abstract fun mapRoundtrip(map: AnyMap): AnyMap
   
-  @JvmName("bounceMap")
   @DoNotStrip
   @Keep
+  @JvmName("bounceMap")
   abstract fun bounceMap(map: Map<String, Variant_Double_Boolean>): Map<String, Variant_Double_Boolean>
   
-  @JvmName("extractMap")
   @DoNotStrip
   @Keep
+  @JvmName("extractMap")
   abstract fun extractMap(mapWrapper: MapWrapper): Map<String, String>
   
-  @JvmName("funcThatThrows")
   @DoNotStrip
   @Keep
+  @JvmName("funcThatThrows")
   abstract fun funcThatThrows(): Double
   
-  @JvmName("funcThatThrowsBeforePromise")
   @DoNotStrip
   @Keep
+  @JvmName("funcThatThrowsBeforePromise")
   abstract fun funcThatThrowsBeforePromise(): Promise<Unit>
   
-  @JvmName("throwError")
   @DoNotStrip
   @Keep
+  @JvmName("throwError")
   abstract fun throwError(error: Throwable): Unit
   
-  @JvmName("tryOptionalParams")
   @DoNotStrip
   @Keep
+  @JvmName("tryOptionalParams")
   abstract fun tryOptionalParams(num: Double, boo: Boolean, str: String?): String
   
-  @JvmName("tryMiddleParam")
   @DoNotStrip
   @Keep
+  @JvmName("tryMiddleParam")
   abstract fun tryMiddleParam(num: Double, boo: Boolean?, str: String): String
   
-  @JvmName("tryOptionalEnum")
   @DoNotStrip
   @Keep
+  @JvmName("tryOptionalEnum")
   abstract fun tryOptionalEnum(value: Powertrain?): Powertrain?
   
-  @JvmName("calculateFibonacciSync")
   @DoNotStrip
   @Keep
+  @JvmName("calculateFibonacciSync")
   abstract fun calculateFibonacciSync(value: Double): Long
   
-  @JvmName("calculateFibonacciAsync")
   @DoNotStrip
   @Keep
+  @JvmName("calculateFibonacciAsync")
   abstract fun calculateFibonacciAsync(value: Double): Promise<Long>
   
-  @JvmName("wait")
   @DoNotStrip
   @Keep
+  @JvmName("wait")
   abstract fun wait(seconds: Double): Promise<Unit>
   
-  @JvmName("promiseThrows")
   @DoNotStrip
   @Keep
+  @JvmName("promiseThrows")
   abstract fun promiseThrows(): Promise<Unit>
   
-  @JvmName("awaitAndGetPromise")
   @DoNotStrip
   @Keep
+  @JvmName("awaitAndGetPromise")
   abstract fun awaitAndGetPromise(promise: Promise<Double>): Promise<Double>
   
-  @JvmName("awaitAndGetComplexPromise")
   @DoNotStrip
   @Keep
+  @JvmName("awaitAndGetComplexPromise")
   abstract fun awaitAndGetComplexPromise(promise: Promise<Car>): Promise<Car>
   
-  @JvmName("awaitPromise")
   @DoNotStrip
   @Keep
+  @JvmName("awaitPromise")
   abstract fun awaitPromise(promise: Promise<Unit>): Promise<Unit>
   
   abstract fun callCallback(callback: () -> Unit): Unit
@@ -359,19 +359,19 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     return __result
   }
   
-  @JvmName("getCar")
   @DoNotStrip
   @Keep
+  @JvmName("getCar")
   abstract fun getCar(): Car
   
-  @JvmName("isCarElectric")
   @DoNotStrip
   @Keep
+  @JvmName("isCarElectric")
   abstract fun isCarElectric(car: Car): Boolean
   
-  @JvmName("getDriver")
   @DoNotStrip
   @Keep
+  @JvmName("getDriver")
   abstract fun getDriver(car: Car): Person?
   
   abstract fun jsStyleObjectAsParameters(params: JsStyleStruct): Unit
@@ -384,59 +384,59 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
     return __result
   }
   
-  @JvmName("createArrayBuffer")
   @DoNotStrip
   @Keep
+  @JvmName("createArrayBuffer")
   abstract fun createArrayBuffer(): ArrayBuffer
   
-  @JvmName("getBufferLastItem")
   @DoNotStrip
   @Keep
+  @JvmName("getBufferLastItem")
   abstract fun getBufferLastItem(buffer: ArrayBuffer): Double
   
-  @JvmName("setAllValuesTo")
   @DoNotStrip
   @Keep
+  @JvmName("setAllValuesTo")
   abstract fun setAllValuesTo(buffer: ArrayBuffer, value: Double): Unit
   
-  @JvmName("createArrayBufferAsync")
   @DoNotStrip
   @Keep
+  @JvmName("createArrayBufferAsync")
   abstract fun createArrayBufferAsync(): Promise<ArrayBuffer>
   
-  @JvmName("createChild")
   @DoNotStrip
   @Keep
+  @JvmName("createChild")
   abstract fun createChild(): HybridChildSpec
   
-  @JvmName("createBase")
   @DoNotStrip
   @Keep
+  @JvmName("createBase")
   abstract fun createBase(): HybridBaseSpec
   
-  @JvmName("createBaseActualChild")
   @DoNotStrip
   @Keep
+  @JvmName("createBaseActualChild")
   abstract fun createBaseActualChild(): HybridBaseSpec
   
-  @JvmName("bounceChild")
   @DoNotStrip
   @Keep
+  @JvmName("bounceChild")
   abstract fun bounceChild(child: HybridChildSpec): HybridChildSpec
   
-  @JvmName("bounceBase")
   @DoNotStrip
   @Keep
+  @JvmName("bounceBase")
   abstract fun bounceBase(base: HybridBaseSpec): HybridBaseSpec
   
-  @JvmName("bounceChildBase")
   @DoNotStrip
   @Keep
+  @JvmName("bounceChildBase")
   abstract fun bounceChildBase(child: HybridChildSpec): HybridBaseSpec
   
-  @JvmName("castBase")
   @DoNotStrip
   @Keep
+  @JvmName("castBase")
   abstract fun castBase(base: HybridBaseSpec): HybridChildSpec
 
   private external fun initHybrid(): HybridData

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -128,38 +128,47 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   abstract var someVariant: Variant_String_Double
 
   // Methods
+  @JvmName("newTestObject")
   @DoNotStrip
   @Keep
   abstract fun newTestObject(): HybridTestObjectSwiftKotlinSpec
   
+  @JvmName("simpleFunc")
   @DoNotStrip
   @Keep
   abstract fun simpleFunc(): Unit
   
+  @JvmName("addNumbers")
   @DoNotStrip
   @Keep
   abstract fun addNumbers(a: Double, b: Double): Double
   
+  @JvmName("addStrings")
   @DoNotStrip
   @Keep
   abstract fun addStrings(a: String, b: String): String
   
+  @JvmName("multipleArguments")
   @DoNotStrip
   @Keep
   abstract fun multipleArguments(num: Double, str: String, boo: Boolean): Unit
   
+  @JvmName("bounceStrings")
   @DoNotStrip
   @Keep
   abstract fun bounceStrings(array: Array<String>): Array<String>
   
+  @JvmName("bounceNumbers")
   @DoNotStrip
   @Keep
   abstract fun bounceNumbers(array: DoubleArray): DoubleArray
   
+  @JvmName("bounceStructs")
   @DoNotStrip
   @Keep
   abstract fun bounceStructs(array: Array<Person>): Array<Person>
   
+  @JvmName("bounceEnums")
   @DoNotStrip
   @Keep
   abstract fun bounceEnums(array: Array<Powertrain>): Array<Powertrain>
@@ -168,75 +177,93 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("complexEnumCallback_cxx")
   private fun complexEnumCallback_cxx(array: Array<Powertrain>, callback: Func_void_std__vector_Powertrain_): Unit {
     val __result = complexEnumCallback(array, callback)
     return __result
   }
   
+  @JvmName("createMap")
   @DoNotStrip
   @Keep
   abstract fun createMap(): AnyMap
   
+  @JvmName("mapRoundtrip")
   @DoNotStrip
   @Keep
   abstract fun mapRoundtrip(map: AnyMap): AnyMap
   
+  @JvmName("bounceMap")
   @DoNotStrip
   @Keep
   abstract fun bounceMap(map: Map<String, Variant_Double_Boolean>): Map<String, Variant_Double_Boolean>
   
+  @JvmName("extractMap")
   @DoNotStrip
   @Keep
   abstract fun extractMap(mapWrapper: MapWrapper): Map<String, String>
   
+  @JvmName("funcThatThrows")
   @DoNotStrip
   @Keep
   abstract fun funcThatThrows(): Double
   
+  @JvmName("funcThatThrowsBeforePromise")
   @DoNotStrip
   @Keep
   abstract fun funcThatThrowsBeforePromise(): Promise<Unit>
   
+  @JvmName("throwError")
   @DoNotStrip
   @Keep
   abstract fun throwError(error: Throwable): Unit
   
+  @JvmName("tryOptionalParams")
   @DoNotStrip
   @Keep
   abstract fun tryOptionalParams(num: Double, boo: Boolean, str: String?): String
   
+  @JvmName("tryMiddleParam")
   @DoNotStrip
   @Keep
   abstract fun tryMiddleParam(num: Double, boo: Boolean?, str: String): String
   
+  @JvmName("tryOptionalEnum")
   @DoNotStrip
   @Keep
   abstract fun tryOptionalEnum(value: Powertrain?): Powertrain?
   
+  @JvmName("calculateFibonacciSync")
   @DoNotStrip
   @Keep
   abstract fun calculateFibonacciSync(value: Double): Long
   
+  @JvmName("calculateFibonacciAsync")
   @DoNotStrip
   @Keep
   abstract fun calculateFibonacciAsync(value: Double): Promise<Long>
   
+  @JvmName("wait")
   @DoNotStrip
   @Keep
   abstract fun wait(seconds: Double): Promise<Unit>
   
+  @JvmName("promiseThrows")
   @DoNotStrip
   @Keep
   abstract fun promiseThrows(): Promise<Unit>
   
+  @JvmName("awaitAndGetPromise")
   @DoNotStrip
   @Keep
   abstract fun awaitAndGetPromise(promise: Promise<Double>): Promise<Double>
   
+  @JvmName("awaitAndGetComplexPromise")
   @DoNotStrip
   @Keep
   abstract fun awaitAndGetComplexPromise(promise: Promise<Car>): Promise<Car>
   
+  @JvmName("awaitPromise")
   @DoNotStrip
   @Keep
   abstract fun awaitPromise(promise: Promise<Unit>): Promise<Unit>
@@ -245,6 +272,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("callCallback_cxx")
   private fun callCallback_cxx(callback: Func_void): Unit {
     val __result = callCallback(callback)
     return __result
@@ -254,6 +282,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("callAll_cxx")
   private fun callAll_cxx(first: Func_void, second: Func_void, third: Func_void): Unit {
     val __result = callAll(first, second, third)
     return __result
@@ -263,6 +292,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("callWithOptional_cxx")
   private fun callWithOptional_cxx(value: Double?, callback: Func_void_std__optional_double_): Unit {
     val __result = callWithOptional(value, callback)
     return __result
@@ -272,6 +302,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("callSumUpNTimes_cxx")
   private fun callSumUpNTimes_cxx(callback: Func_std__shared_ptr_Promise_double__, n: Double): Promise<Double> {
     val __result = callSumUpNTimes(callback, n)
     return __result
@@ -281,6 +312,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("callbackAsyncPromise_cxx")
   private fun callbackAsyncPromise_cxx(callback: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____): Promise<Double> {
     val __result = callbackAsyncPromise(callback)
     return __result
@@ -290,6 +322,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("callbackAsyncPromiseBuffer_cxx")
   private fun callbackAsyncPromiseBuffer_cxx(callback: Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____): Promise<ArrayBuffer> {
     val __result = callbackAsyncPromiseBuffer(callback)
     return __result
@@ -299,6 +332,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("getComplexCallback_cxx")
   private fun getComplexCallback_cxx(): Func_void_double {
     val __result = getComplexCallback()
     return Func_void_double_java(__result)
@@ -308,6 +342,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("getValueFromJSCallbackAndWait_cxx")
   private fun getValueFromJSCallbackAndWait_cxx(getValue: Func_std__shared_ptr_Promise_double__): Promise<Double> {
     val __result = getValueFromJSCallbackAndWait(getValue)
     return __result
@@ -317,19 +352,23 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("getValueFromJsCallback_cxx")
   private fun getValueFromJsCallback_cxx(callback: Func_std__shared_ptr_Promise_std__string__, andThenCall: Func_void_std__string): Promise<Unit> {
     val __result = getValueFromJsCallback(callback, andThenCall)
     return __result
   }
   
+  @JvmName("getCar")
   @DoNotStrip
   @Keep
   abstract fun getCar(): Car
   
+  @JvmName("isCarElectric")
   @DoNotStrip
   @Keep
   abstract fun isCarElectric(car: Car): Boolean
   
+  @JvmName("getDriver")
   @DoNotStrip
   @Keep
   abstract fun getDriver(car: Car): Person?
@@ -338,51 +377,63 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  @JvmName("jsStyleObjectAsParameters_cxx")
   private fun jsStyleObjectAsParameters_cxx(params: JsStyleStruct): Unit {
     val __result = jsStyleObjectAsParameters(params)
     return __result
   }
   
+  @JvmName("createArrayBuffer")
   @DoNotStrip
   @Keep
   abstract fun createArrayBuffer(): ArrayBuffer
   
+  @JvmName("getBufferLastItem")
   @DoNotStrip
   @Keep
   abstract fun getBufferLastItem(buffer: ArrayBuffer): Double
   
+  @JvmName("setAllValuesTo")
   @DoNotStrip
   @Keep
   abstract fun setAllValuesTo(buffer: ArrayBuffer, value: Double): Unit
   
+  @JvmName("createArrayBufferAsync")
   @DoNotStrip
   @Keep
   abstract fun createArrayBufferAsync(): Promise<ArrayBuffer>
   
+  @JvmName("createChild")
   @DoNotStrip
   @Keep
   abstract fun createChild(): HybridChildSpec
   
+  @JvmName("createBase")
   @DoNotStrip
   @Keep
   abstract fun createBase(): HybridBaseSpec
   
+  @JvmName("createBaseActualChild")
   @DoNotStrip
   @Keep
   abstract fun createBaseActualChild(): HybridBaseSpec
   
+  @JvmName("bounceChild")
   @DoNotStrip
   @Keep
   abstract fun bounceChild(child: HybridChildSpec): HybridChildSpec
   
+  @JvmName("bounceBase")
   @DoNotStrip
   @Keep
   abstract fun bounceBase(base: HybridBaseSpec): HybridBaseSpec
   
+  @JvmName("bounceChildBase")
   @DoNotStrip
   @Keep
   abstract fun bounceChildBase(child: HybridChildSpec): HybridBaseSpec
   
+  @JvmName("castBase")
   @DoNotStrip
   @Keep
   abstract fun castBase(base: HybridBaseSpec): HybridChildSpec

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestViewSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestViewSpec.kt
@@ -60,9 +60,9 @@ abstract class HybridTestViewSpec: HybridView() {
     }
 
   // Methods
-  @JvmName("someFunc")
   @DoNotStrip
   @Keep
+  @JvmName("someFunc")
   abstract fun someFunc(someParam: Double): Boolean
 
   private external fun initHybrid(): HybridData

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestViewSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestViewSpec.kt
@@ -59,6 +59,7 @@ abstract class HybridTestViewSpec: HybridView() {
     }
 
   // Methods
+  @JvmName("someFunc")
   @DoNotStrip
   @Keep
   abstract fun someFunc(someParam: Double): Boolean

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestViewSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestViewSpec.kt
@@ -22,7 +22,8 @@ import com.margelo.nitro.views.*
 @Suppress(
   "KotlinJniMissingFunction", "unused",
   "RedundantSuppression", "RedundantUnitReturnType", "SimpleRedundantLet",
-  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
+  "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName",
+  "INAPPLICABLE_JVM_NAME"
 )
 abstract class HybridTestViewSpec: HybridView() {
   @DoNotStrip

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -30,7 +30,7 @@ public:
   Promise(const Promise&) = delete;
 
 private:
-  Promise() {}
+  Promise() = default;
 
 public:
   ~Promise() {

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -264,13 +264,13 @@ public:
   Promise(const Promise&) = delete;
 
 private:
-  Promise() {}
+  Promise() = default;
 
 public:
   ~Promise() {
     if (isPending()) [[unlikely]] {
       std::runtime_error error("Timeouted: Promise<void> was destroyed!");
-      reject(std::make_exception_ptr(std::move(error)));
+      reject(std::make_exception_ptr(error));
     }
   }
 


### PR DESCRIPTION
For all Kotlin methods we now also define a `@JvmName` annotation to make sure Kotlin doesn't mangle it.

I don't know if it does, but maybe Kotlin mangles private function names in the JVM space.

Might fix https://github.com/mrousavy/nitro/issues/531