### PR TITLE
fix: crash when no modules are registered

### DIFF
--- a/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
+++ b/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
@@ -32,6 +32,9 @@ std::vector<std::string> HybridObjectRegistry::getAllHybridObjectNames() {
 
 std::string HybridObjectRegistry::getAllRegisteredHybridObjectNamesToString() {
   std::vector<std::string> names = getAllHybridObjectNames();
+  if (names.empty()) {
+    return "";
+  }
   return std::accumulate(std::next(names.begin()), names.end(), names[0], [](std::string a, std::string b) { return a + ", " + b; });
 }
 


### PR DESCRIPTION
`getAllHybridObjectNames()` might return an empty array but we're trying to access the first element without checking the size.