### PR TITLE
perf: Cache last `getExternalMemorySize()` to avoid Runtime calls each time

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -52,7 +52,7 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
       // 1.2. It is still alive - we can use it instead of creating a new one! But first, let's update memory-size
       size_t externalMemorySize = getExternalMemorySize();
       if (externalMemorySize != _lastExternalMemorySize) {
-        value.getObject(runtime).setExternalMemoryPressure(runtime, getExternalMemorySize());
+        value.getObject(runtime).setExternalMemoryPressure(runtime, externalMemorySize);
         _lastExternalMemorySize = externalMemorySize;
       }
       // 1.3. Return it now

--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp
@@ -137,6 +137,7 @@ private:
   static constexpr auto TAG = "HybridObject";
   const char* _name = TAG;
   std::unordered_map<jsi::Runtime*, BorrowingReference<jsi::WeakObject>> _objectCache;
+  size_t _lastExternalMemorySize = 0;
 };
 
 } // namespace margelo::nitro


### PR DESCRIPTION
so this is a micro-optimization. not sure if we want to keep it because it makes the code a tiny bit more complex.

When a C++ `HybridObject` gets passed to JS, `toObject(runtime)` is called on it. This always updates the `setExternalMemoryPressure(..)` on the object so the JS GC knows it's weight.

Previously we always set it, even if the memory pressure is the same size. Now we compare it to it's previous value before re-setting it again.