### PR TITLE
chore: Disable `-Wexceptions` warning on Android specific `catch` block

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -109,12 +109,15 @@ public:
         std::string message = exception.what();
         throw jsi::JSError(runtime, funcName + ": " + message);
 #ifdef ANDROID
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wexceptions"
         // Workaround for https://github.com/mrousavy/nitro/issues/382
       } catch (const std::runtime_error& exception) {
         // Some exception was thrown - add method name information and re-throw as `JSError`.
         std::string funcName = getHybridFuncFullName<THybrid>(kind, name, hybridInstance.get());
         std::string message = exception.what();
         throw jsi::JSError(runtime, funcName + ": " + message);
+#pragma clang diagnostic pop
 #endif
       } catch (...) {
         // Some unknown exception was thrown - add method name information and re-throw as `JSError`.


### PR DESCRIPTION
Because of that RN bug where `std::exception` subclasses are not catchable by a `std::exception` catch block, we have to have an additional `std::runtime_error` catch block. Theoretically we also need a `jni::JniException` catch block, and any kind of other error that can be thrown, but for now this is okay.

This is a warning in clang, so we ignore the warning until it is fixed in react-native.