### PR TITLE
feat: Add extra path for `cloneProps` to make sure we dont ever use folly

### DIFF
--- a/packages/nitrogen/src/views/CppHybridViewComponent.ts
+++ b/packages/nitrogen/src/views/CppHybridViewComponent.ts
@@ -150,6 +150,12 @@ namespace ${namespace} {
     ${descriptorClassName}(const react::ComponentDescriptorParameters& parameters);
 
   public:
+    /**
+     * A faster path for cloning props - reuses the caching logic from \`${propsClassName}\`.
+     */
+    react::Props::Shared cloneProps(const react::PropsParserContext& context,
+                                    const react::Props::Shared& props,
+                                    react::RawProps rawProps) const override;
 #ifdef ANDROID
     void adopt(react::ShadowNode& shadowNode) const override;
 #endif
@@ -194,6 +200,7 @@ ${name}([&]() -> CachedProp<${type}> {
   }
 
   const ctorIndent = createIndentation(propsClassName.length * 2)
+  const descriptorIndent = createIndentation(descriptorClassName.length)
   const componentCode = `
 ${createFileMetadataString(`${component}.cpp`)}
 
@@ -231,6 +238,12 @@ namespace ${namespace} {
   ${descriptorClassName}::${descriptorClassName}(const react::ComponentDescriptorParameters& parameters)
     : ConcreteComponentDescriptor(parameters,
                                   react::RawPropsParser(/* enableJsiParser */ true)) {}
+
+  react::Props::Shared ${descriptorClassName}::cloneProps(const react::PropsParserContext& context,
+                          ${descriptorIndent}          const react::Props::Shared& props,
+                          ${descriptorIndent}          react::RawProps rawProps) const {
+    return ${shadowNodeClassName}::Props(context, /* & */ rawProps, props);
+  }
 
 #ifdef ANDROID
   void ${descriptorClassName}::adopt(react::ShadowNode& shadowNode) const {

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
@@ -63,6 +63,12 @@ namespace margelo::nitro::image::views {
     : ConcreteComponentDescriptor(parameters,
                                   react::RawPropsParser(/* enableJsiParser */ true)) {}
 
+  react::Props::Shared HybridTestViewComponentDescriptor::cloneProps(const react::PropsParserContext& context,
+                                                                     const react::Props::Shared& props,
+                                                                     react::RawProps rawProps) const {
+    return HybridTestViewShadowNode::Props(context, /* & */ rawProps, props);
+  }
+
 #ifdef ANDROID
   void HybridTestViewComponentDescriptor::adopt(react::ShadowNode& shadowNode) const {
     // This is called immediately after `ShadowNode` is created, cloned or in progress.

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
@@ -88,6 +88,12 @@ namespace margelo::nitro::image::views {
     HybridTestViewComponentDescriptor(const react::ComponentDescriptorParameters& parameters);
 
   public:
+    /**
+     * A faster path for cloning props - reuses the caching logic from `HybridTestViewProps`.
+     */
+    react::Props::Shared cloneProps(const react::PropsParserContext& context,
+                                    const react::Props::Shared& props,
+                                    react::RawProps rawProps) const override;
 #ifdef ANDROID
     void adopt(react::ShadowNode& shadowNode) const override;
 #endif

--- a/packages/react-native-nitro-modules/src/views/getHostComponent.ts
+++ b/packages/react-native-nitro-modules/src/views/getHostComponent.ts
@@ -33,10 +33,10 @@ type CleanView<THybridView> = WrapFunctionsInObjects<
 /**
  * Finds and returns a native view (aka {@linkcode HostComponent}) via the given {@linkcode name}.
  */
-export function getHostComponent<THybridView>(
+export function getHostComponent<Props>(
   name: string,
-  getViewConfig: () => ViewConfig<CleanView<THybridView>>
-): HostComponent<ViewProps & CleanView<THybridView>> {
+  getViewConfig: () => ViewConfig<RemoveHybridObjectBase<Props>>
+): HostComponent<ViewProps & CleanView<Props>> {
   if (NativeComponentRegistry == null) {
     throw new Error(
       `NativeComponentRegistry is not available on ${Platform.OS}!`


### PR DESCRIPTION
it's disabled by RN right now anyways, but just in case.