### PR TITLE
feat: Add example to pass a HybridView to a normal HybridObject

### DIFF
--- a/example/src/screens/ViewScreen.tsx
+++ b/example/src/screens/ViewScreen.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, View, Text, Button, Platform } from 'react-native'
 import { NitroModules } from 'react-native-nitro-modules'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useColors } from '../useColors'
-import { TestView } from 'react-native-nitro-image'
+import { HybridTestObjectSwiftKotlin, TestView } from 'react-native-nitro-image'
 import { useIsFocused } from '@react-navigation/native'
 
 const VIEWS_X = 15
@@ -25,6 +25,8 @@ export function ViewScreenImpl() {
             f: (ref) => {
               console.log(`Ref initialized!`)
               ref.someMethod()
+              const isBlue = HybridTestObjectSwiftKotlin.getIsViewBlue(ref)
+              console.log(`Is View blue: ${isBlue}`)
             },
           }}
           style={styles.view}

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -306,4 +306,8 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
     override fun newTestObject(): HybridTestObjectSwiftKotlinSpec {
         return HybridTestObjectKotlin()
     }
+
+    override fun getIsViewBlue(view: HybridTestViewSpec): Boolean {
+        return view.isBlue
+    }
 }

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -308,6 +308,7 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
     }
 
     override fun getIsViewBlue(view: HybridTestViewSpec): Boolean {
-        return view.isBlue
+        val cast = view as? HybridTestView ?: return false
+        return cast.isBlue
     }
 }

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -487,4 +487,8 @@ std::shared_ptr<HybridChildSpec> HybridTestObjectCpp::castBase(const std::shared
   return child;
 }
 
+bool HybridTestObjectCpp::getIsViewBlue(const std::shared_ptr<HybridTestViewSpec>& view) {
+  return view->getIsBlue();
+}
+
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -149,7 +149,7 @@ public:
   std::shared_ptr<HybridBaseSpec> bounceBase(const std::shared_ptr<HybridBaseSpec>& base) override;
   std::shared_ptr<HybridBaseSpec> bounceChildBase(const std::shared_ptr<HybridChildSpec>& child) override;
   std::shared_ptr<HybridChildSpec> castBase(const std::shared_ptr<HybridBaseSpec>& base) override;
-  
+
   bool getIsViewBlue(const std::shared_ptr<HybridTestViewSpec>& view) override;
 
   // Raw JSI functions

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -149,6 +149,8 @@ public:
   std::shared_ptr<HybridBaseSpec> bounceBase(const std::shared_ptr<HybridBaseSpec>& base) override;
   std::shared_ptr<HybridBaseSpec> bounceChildBase(const std::shared_ptr<HybridChildSpec>& child) override;
   std::shared_ptr<HybridChildSpec> castBase(const std::shared_ptr<HybridBaseSpec>& base) override;
+  
+  bool getIsViewBlue(const std::shared_ptr<HybridTestViewSpec>& view) override;
 
   // Raw JSI functions
   jsi::Value rawJsiFunc(jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* args, size_t count);

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -313,4 +313,9 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     }
     return child
   }
+
+  func getIsViewBlue(view: any HybridTestViewSpec) throws -> Bool {
+    guard let view = view as? HybridTestView else { return false }
+    return view.isBlue
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -29,6 +29,8 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 namespace margelo::nitro::image { struct MapWrapper; }
 // Forward declaration of `JsStyleStruct` to properly resolve imports.
 namespace margelo::nitro::image { struct JsStyleStruct; }
+// Forward declaration of `HybridTestViewSpec` to properly resolve imports.
+namespace margelo::nitro::image { class HybridTestViewSpec; }
 
 #include <memory>
 #include "HybridTestObjectSwiftKotlinSpec.hpp"
@@ -75,6 +77,8 @@ namespace margelo::nitro::image { struct JsStyleStruct; }
 #include "JFunc_void_std__string.hpp"
 #include "JsStyleStruct.hpp"
 #include "JJsStyleStruct.hpp"
+#include "HybridTestViewSpec.hpp"
+#include "JHybridTestViewSpec.hpp"
 
 namespace margelo::nitro::image {
 
@@ -758,6 +762,11 @@ namespace margelo::nitro::image {
     static const auto method = _javaPart->getClass()->getMethod<jni::local_ref<JHybridChildSpec::javaobject>(jni::alias_ref<JHybridBaseSpec::javaobject> /* base */)>("castBase");
     auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridBaseSpec>(base)->getJavaPart());
     return JNISharedPtr::make_shared_from_jni<JHybridChildSpec>(jni::make_global(__result));
+  }
+  bool JHybridTestObjectSwiftKotlinSpec::getIsViewBlue(const std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>& view) {
+    static const auto method = _javaPart->getClass()->getMethod<jboolean(jni::alias_ref<JHybridTestViewSpec::javaobject> /* view */)>("getIsViewBlue");
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridTestViewSpec>(view)->getJavaPart());
+    return static_cast<bool>(__result);
   }
 
 } // namespace margelo::nitro::image

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -128,6 +128,7 @@ namespace margelo::nitro::image {
     std::shared_ptr<margelo::nitro::image::HybridBaseSpec> bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) override;
     std::shared_ptr<margelo::nitro::image::HybridBaseSpec> bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) override;
     std::shared_ptr<margelo::nitro::image::HybridChildSpec> castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) override;
+    bool getIsViewBlue(const std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>& view) override;
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -386,6 +386,10 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   abstract fun castBase(base: HybridBaseSpec): HybridChildSpec
+  
+  @DoNotStrip
+  @Keep
+  abstract fun getIsViewBlue(view: HybridTestViewSpec): Boolean
 
   private external fun initHybrid(): HybridData
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -828,6 +828,18 @@ namespace margelo::nitro::image::bridge::swift {
   using std__weak_ptr_margelo__nitro__image__HybridChildSpec_ = std::weak_ptr<margelo::nitro::image::HybridChildSpec>;
   inline std__weak_ptr_margelo__nitro__image__HybridChildSpec_ weakify_std__shared_ptr_margelo__nitro__image__HybridChildSpec_(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& strong) { return strong; }
   
+  // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>
+  /**
+   * Specialized version of `std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>`.
+   */
+  using std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_ = std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>;
+  std::shared_ptr<margelo::nitro::image::HybridTestViewSpec> create_std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_(void* _Nonnull swiftUnsafePointer);
+  void* _Nonnull get_std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_(std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_ cppType);
+  
+  // pragma MARK: std::weak_ptr<margelo::nitro::image::HybridTestViewSpec>
+  using std__weak_ptr_margelo__nitro__image__HybridTestViewSpec_ = std::weak_ptr<margelo::nitro::image::HybridTestViewSpec>;
+  inline std__weak_ptr_margelo__nitro__image__HybridTestViewSpec_ weakify_std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_(const std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>& strong) { return strong; }
+  
   // pragma MARK: Result<std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec>>
   using Result_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec__ = Result<std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec>>;
   inline Result_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec__ create_Result_std__shared_ptr_margelo__nitro__image__HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<margelo::nitro::image::HybridTestObjectSwiftKotlinSpec>& value) {
@@ -1034,17 +1046,5 @@ namespace margelo::nitro::image::bridge::swift {
   inline Result_std__shared_ptr_margelo__nitro__image__HybridBaseSpec__ create_Result_std__shared_ptr_margelo__nitro__image__HybridBaseSpec__(const std::exception_ptr& error) {
     return Result<std::shared_ptr<margelo::nitro::image::HybridBaseSpec>>::withError(error);
   }
-  
-  // pragma MARK: std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>
-  /**
-   * Specialized version of `std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>`.
-   */
-  using std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_ = std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>;
-  std::shared_ptr<margelo::nitro::image::HybridTestViewSpec> create_std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_(std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_ cppType);
-  
-  // pragma MARK: std::weak_ptr<margelo::nitro::image::HybridTestViewSpec>
-  using std__weak_ptr_margelo__nitro__image__HybridTestViewSpec_ = std::weak_ptr<margelo::nitro::image::HybridTestViewSpec>;
-  inline std__weak_ptr_margelo__nitro__image__HybridTestViewSpec_ weakify_std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_(const std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>& strong) { return strong; }
 
 } // namespace margelo::nitro::image::bridge::swift

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -36,6 +36,8 @@ namespace margelo::nitro::image { struct JsStyleStruct; }
 namespace margelo::nitro::image { class HybridChildSpec; }
 // Forward declaration of `HybridBaseSpec` to properly resolve imports.
 namespace margelo::nitro::image { class HybridBaseSpec; }
+// Forward declaration of `HybridTestViewSpec` to properly resolve imports.
+namespace margelo::nitro::image { class HybridTestViewSpec; }
 
 #include <memory>
 #include "HybridTestObjectSwiftKotlinSpec.hpp"
@@ -58,6 +60,7 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include "JsStyleStruct.hpp"
 #include "HybridChildSpec.hpp"
 #include "HybridBaseSpec.hpp"
+#include "HybridTestViewSpec.hpp"
 
 #include "NitroImage-Swift-Cxx-Umbrella.hpp"
 
@@ -573,6 +576,14 @@ namespace margelo::nitro::image {
     }
     inline std::shared_ptr<margelo::nitro::image::HybridChildSpec> castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) override {
       auto __result = _swiftPart.castBase(base);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline bool getIsViewBlue(const std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>& view) override {
+      auto __result = _swiftPart.getIsViewBlue(view);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -78,6 +78,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func bounceBase(base: (any HybridBaseSpec)) throws -> (any HybridBaseSpec)
   func bounceChildBase(child: (any HybridChildSpec)) throws -> (any HybridBaseSpec)
   func castBase(base: (any HybridBaseSpec)) throws -> (any HybridChildSpec)
+  func getIsViewBlue(view: (any HybridTestViewSpec)) throws -> Bool
 }
 
 /// See ``HybridTestObjectSwiftKotlinSpec``

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -1427,4 +1427,20 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
       return bridge.create_Result_std__shared_ptr_margelo__nitro__image__HybridChildSpec__(__exceptionPtr)
     }
   }
+  
+  @inline(__always)
+  public final func getIsViewBlue(view: bridge.std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_) -> bridge.Result_bool_ {
+    do {
+      let __result = try self.__implementation.getIsViewBlue(view: { () -> HybridTestViewSpec in
+        let __unsafePointer = bridge.get_std__shared_ptr_margelo__nitro__image__HybridTestViewSpec_(view)
+        let __instance = HybridTestViewSpec_cxx.fromUnsafe(__unsafePointer)
+        return __instance.getHybridTestViewSpec()
+      }())
+      let __resultCpp = __result
+      return bridge.create_Result_bool_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_bool_(__exceptionPtr)
+    }
+  }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -101,6 +101,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("bounceBase", &HybridTestObjectCppSpec::bounceBase);
       prototype.registerHybridMethod("bounceChildBase", &HybridTestObjectCppSpec::bounceChildBase);
       prototype.registerHybridMethod("castBase", &HybridTestObjectCppSpec::castBase);
+      prototype.registerHybridMethod("getIsViewBlue", &HybridTestObjectCppSpec::getIsViewBlue);
     });
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -35,6 +35,8 @@ namespace margelo::nitro::image { struct JsStyleStruct; }
 namespace margelo::nitro::image { class HybridChildSpec; }
 // Forward declaration of `HybridBaseSpec` to properly resolve imports.
 namespace margelo::nitro::image { class HybridBaseSpec; }
+// Forward declaration of `HybridTestViewSpec` to properly resolve imports.
+namespace margelo::nitro::image { class HybridTestViewSpec; }
 
 #include <tuple>
 #include <string>
@@ -57,6 +59,7 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include "JsStyleStruct.hpp"
 #include "HybridChildSpec.hpp"
 #include "HybridBaseSpec.hpp"
+#include "HybridTestViewSpec.hpp"
 
 namespace margelo::nitro::image {
 
@@ -175,6 +178,7 @@ namespace margelo::nitro::image {
       virtual std::shared_ptr<margelo::nitro::image::HybridBaseSpec> bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridBaseSpec> bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridChildSpec> castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) = 0;
+      virtual bool getIsViewBlue(const std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>& view) = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -92,6 +92,7 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("bounceBase", &HybridTestObjectSwiftKotlinSpec::bounceBase);
       prototype.registerHybridMethod("bounceChildBase", &HybridTestObjectSwiftKotlinSpec::bounceChildBase);
       prototype.registerHybridMethod("castBase", &HybridTestObjectSwiftKotlinSpec::castBase);
+      prototype.registerHybridMethod("getIsViewBlue", &HybridTestObjectSwiftKotlinSpec::getIsViewBlue);
     });
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -35,6 +35,8 @@ namespace margelo::nitro::image { struct JsStyleStruct; }
 namespace margelo::nitro::image { class HybridChildSpec; }
 // Forward declaration of `HybridBaseSpec` to properly resolve imports.
 namespace margelo::nitro::image { class HybridBaseSpec; }
+// Forward declaration of `HybridTestViewSpec` to properly resolve imports.
+namespace margelo::nitro::image { class HybridTestViewSpec; }
 
 #include <memory>
 #include "HybridTestObjectSwiftKotlinSpec.hpp"
@@ -56,6 +58,7 @@ namespace margelo::nitro::image { class HybridBaseSpec; }
 #include "JsStyleStruct.hpp"
 #include "HybridChildSpec.hpp"
 #include "HybridBaseSpec.hpp"
+#include "HybridTestViewSpec.hpp"
 
 namespace margelo::nitro::image {
 
@@ -165,6 +168,7 @@ namespace margelo::nitro::image {
       virtual std::shared_ptr<margelo::nitro::image::HybridBaseSpec> bounceBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridBaseSpec> bounceChildBase(const std::shared_ptr<margelo::nitro::image::HybridChildSpec>& child) = 0;
       virtual std::shared_ptr<margelo::nitro::image::HybridChildSpec> castBase(const std::shared_ptr<margelo::nitro::image::HybridBaseSpec>& base) = 0;
+      virtual bool getIsViewBlue(const std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>& view) = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -1,4 +1,5 @@
 import { type HybridObject, type AnyMap } from 'react-native-nitro-modules'
+import type { TestView } from './TestView.nitro'
 
 // Tuples become `std::tuple<...>` in C++.
 // In contrast to arrays, they are length-checked, and can have different types inside them.
@@ -153,6 +154,9 @@ interface SharedTestObjectProps {
   bounceBase(base: Base): Base
   bounceChildBase(child: Child): Base
   castBase(base: Base): Child
+
+  // Views
+  getIsViewBlue(view: TestView): boolean
 }
 
 // This is a C++-based `HybridObject`.


### PR DESCRIPTION
In this example, we test the case where we can pass a `HybridView` (reference) to a normal `HybridObject`.

This is pretty powerful, because as you can see it doesn't matter whether the `HybridObject` is implemented in C++, Swift or Kotlin - we can always pass a reference to the View to it.

The View can even be downcast to the actual class in Swift or Kotlin, and in C++ you can access all exported JS methods.

Examples:

### Kotlin

https://github.com/mrousavy/nitro/blob/86b7b49f27073af3e68c428d01e1360e9eddaab4/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt#L310-L313

### Swift

https://github.com/mrousavy/nitro/blob/86b7b49f27073af3e68c428d01e1360e9eddaab4/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift#L317-L320

### C++

https://github.com/mrousavy/nitro/blob/86b7b49f27073af3e68c428d01e1360e9eddaab4/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp#L490-L492


In JS, you'd do:

```tsx
const testObject = new HybridTestObject() // <-- C++, Swift or Kotlin

function App() {
  return (
    <TestView
      hybridRef={{
        f: (ref) => {
          const isBlue = testObject.getIsBlue(ref)
          console.log(isBlue)
        },
      }}
    />
  )
}
```