### PR TITLE
fix: HybridView is now a union type..

### DIFF
--- a/packages/nitrogen/src/createPlatformSpec.ts
+++ b/packages/nitrogen/src/createPlatformSpec.ts
@@ -7,6 +7,8 @@ import {
   isAnyHybridSubclass,
   isDirectlyHybridObject,
   type Language,
+  isHybridViewProps,
+  isHybridViewMethods,
 } from './getPlatformSpecs.js'
 import type { HybridObjectSpec } from './syntax/HybridObjectSpec.js'
 import { Property } from './syntax/Property.js'
@@ -46,7 +48,9 @@ function getHybridObjectSpec(type: Type, language: Language): HybridObjectSpec {
     const name = symbol.getEscapedName()
 
     // It's a Hybrid View - the props & methods are passed as type parameters instead of interface body.
-    const [props, methods] = type.getTypeArguments()
+    const unions = type.getIntersectionTypes()
+    const props = unions.find((t) => isHybridViewProps(t))
+    const methods = unions.find((t) => isHybridViewMethods(t))
     if (props == null)
       throw new Error(
         `Props cannot be null! ${name}<...> (HybridView) requires type arguments.`

--- a/packages/nitrogen/src/createPlatformSpec.ts
+++ b/packages/nitrogen/src/createPlatformSpec.ts
@@ -47,7 +47,7 @@ function getHybridObjectSpec(type: Type, language: Language): HybridObjectSpec {
     const symbol = type.getAliasSymbolOrThrow()
     const name = symbol.getEscapedName()
 
-    // It's a Hybrid View - the props & methods are passed as type parameters instead of interface body.
+    // It's a Hybrid View - the `Props & Methods` types are just intersected together.
     const unions = type.getIntersectionTypes()
     const props = unions.find((t) => isHybridViewProps(t))
     const methods = unions.find((t) => isHybridViewMethods(t))

--- a/packages/nitrogen/src/getPlatformSpecs.ts
+++ b/packages/nitrogen/src/getPlatformSpecs.ts
@@ -127,9 +127,9 @@ export function isHybridViewMethods(type: Type): boolean {
 }
 
 export function isHybridView(type: Type): boolean {
+  // HybridViews are type aliases for `HybridView`, and `Props & Methods` are just intersected together.
   const unionTypes = type.getIntersectionTypes()
   for (const union of unionTypes) {
-    // HybridViews are type aliases for `HybridView`
     const symbol = union.getSymbol()
     if (symbol == null) return false
     return symbol.getName() === 'HybridViewTag'

--- a/packages/nitrogen/src/getPlatformSpecs.ts
+++ b/packages/nitrogen/src/getPlatformSpecs.ts
@@ -118,11 +118,23 @@ export function isDirectlyHybridObject(type: Type): boolean {
 export function extendsHybridObject(type: Type, recursive: boolean): boolean {
   return extendsType(type, 'HybridObject', recursive)
 }
+
+export function isHybridViewProps(type: Type): boolean {
+  return extendsType(type, 'HybridViewProps', true)
+}
+export function isHybridViewMethods(type: Type): boolean {
+  return extendsType(type, 'HybridViewMethods', true)
+}
+
 export function isHybridView(type: Type): boolean {
-  // HybridViews are type aliases for `HybridView`
-  const symbol = type.getSymbol()
-  if (symbol == null) return false
-  return symbol.getName() === 'HybridView'
+  const unionTypes = type.getIntersectionTypes()
+  for (const union of unionTypes) {
+    // HybridViews are type aliases for `HybridView`
+    const symbol = union.getSymbol()
+    if (symbol == null) return false
+    return symbol.getName() === 'HybridViewTag'
+  }
+  return false
 }
 
 export function isAnyHybridSubclass(type: Type): boolean {

--- a/packages/react-native-nitro-modules/src/views/HybridView.ts
+++ b/packages/react-native-nitro-modules/src/views/HybridView.ts
@@ -1,4 +1,3 @@
-import type { HostComponent, ViewProps } from 'react-native'
 import type { HybridObject } from '../HybridObject'
 
 /**
@@ -58,37 +57,6 @@ export interface HybridViewProps {
 export interface HybridViewMethods {}
 
 /**
- * Represents all default props a Nitro HybridView has.
- */
-interface DefaultHybridViewProps<Object> extends ViewProps {
-  /**
-   * A `ref` to the {@linkcode HybridObject} this Hybrid View is rendering.
-   *
-   * The `hybridRef` property expects a stable Ref object received from `useRef` or `createRef`.
-   * @example
-   * ```jsx
-   * function App() {
-   *   return (
-   *     <HybridScrollView
-   *       hybridRef={{ f: (ref) => {
-   *         ref.current.scrollTo(400)
-   *       }
-   *     />
-   *   )
-   * }
-   * ```
-   */
-  hybridRef?: { f: (ref: Object) => void }
-}
-
-// Due to a React limitation, functions cannot be passed to native directly
-// because RN converts them to booleans (`true`). Nitro knows this and just
-// wraps functions as objects - the original function is stored in `f`.
-type WrapFunctionsInObjects<Props> = {
-  [K in keyof Props]: Props[K] extends Function ? { f: Props[K] } : Props[K]
-}
-
-/**
  * The type of a {@linkcode DefaultHybridViewProps.hybridRef hybridRef}.
  * @example
  * ```ts
@@ -116,6 +84,11 @@ export type HybridRef<
 > = HybridObject & Props & Methods
 
 /**
+ * This interface acts as a tag for Hybrid Views so nitrogen detects them.
+ */
+interface HybridViewTag extends HybridObject {}
+
+/**
  * Represents a Nitro Hybrid View.
  *
  * The Hybrid View's implementation is in native iOS or Android, and is backed
@@ -135,15 +108,8 @@ export type HybridRef<
  * export type ScrollView = HybridView<ScrollViewProps, ScrollViewMethods>
  * ```
  */
-export interface HybridView<
+export type HybridView<
   Props extends HybridViewProps,
   Methods extends HybridViewMethods = {},
-  // @ts-expect-error
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   Platforms extends ViewPlatformSpec = { ios: 'swift'; android: 'kotlin' },
-  Object = HybridRef<Props, Methods>,
-> extends HostComponent<
-    WrapFunctionsInObjects<Props> & DefaultHybridViewProps<Object>
-  > {
-  /* no custom properties */
-}
+> = HybridViewTag & HybridObject<Platforms> & Props & Methods

--- a/packages/react-native-nitro-modules/src/views/getHostComponent.ts
+++ b/packages/react-native-nitro-modules/src/views/getHostComponent.ts
@@ -43,7 +43,11 @@ interface DefaultHybridViewProps<RefType> extends ViewProps {
 // because RN converts them to booleans (`true`). Nitro knows this and just
 // wraps functions as objects - the original function is stored in `f`.
 type WrapFunctionsInObjects<Props> = {
-  [K in keyof Props]: Props[K] extends Function ? { f: Props[K] } : Props[K]
+  [K in keyof Props]: Props[K] extends Function
+    ? { f: Props[K] }
+    : Props[K] extends Function | undefined
+      ? { f: Props[K] }
+      : Props[K]
 }
 
 /**
@@ -59,7 +63,7 @@ export type ReactNativeView<
   Methods extends HybridViewMethods,
 > = HostComponent<
   WrapFunctionsInObjects<
-    DefaultHybridViewProps<HybridView<Props, Methods>> & Props & Methods
+    DefaultHybridViewProps<HybridView<Props, Methods>> & Props
   >
 >
 

--- a/packages/react-native-nitro-modules/src/views/getHostComponent.ts
+++ b/packages/react-native-nitro-modules/src/views/getHostComponent.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'react-native'
+import { Platform, type HostComponent, type ViewProps } from 'react-native'
 // @ts-expect-error this unfortunately isn't typed or default-exported.
 import * as NativeComponentRegistry from 'react-native/Libraries/NativeComponent/NativeComponentRegistry'
 import type {
@@ -16,6 +16,54 @@ export interface ViewConfig<Props> {
 }
 
 /**
+ * Represents all default props a Nitro HybridView has.
+ */
+interface DefaultHybridViewProps<RefType> extends ViewProps {
+  /**
+   * A `ref` to the {@linkcode HybridObject} this Hybrid View is rendering.
+   *
+   * The `hybridRef` property expects a stable Ref object received from `useRef` or `createRef`.
+   * @example
+   * ```jsx
+   * function App() {
+   *   return (
+   *     <HybridScrollView
+   *       hybridRef={{ f: (ref) => {
+   *         ref.current.scrollTo(400)
+   *       }
+   *     />
+   *   )
+   * }
+   * ```
+   */
+  hybridRef?: (ref: RefType) => void
+}
+
+// Due to a React limitation, functions cannot be passed to native directly
+// because RN converts them to booleans (`true`). Nitro knows this and just
+// wraps functions as objects - the original function is stored in `f`.
+type WrapFunctionsInObjects<Props> = {
+  [K in keyof Props]: Props[K] extends Function ? { f: Props[K] } : Props[K]
+}
+
+/**
+ * Represents a React Native view, implemented as a Nitro View, with the given props and methods.
+ *
+ * @note Every React Native view has a {@linkcode DefaultHybridViewProps.hybridRef hybridRef} which can be used to gain access
+ *       to the underlying Nitro {@linkcode HybridView}.
+ * @note Every function/callback is wrapped as a `{ f: … }` object.
+ * @note Every method can be called on the Ref. Including setting properties directly.
+ */
+export type ReactNativeView<
+  Props extends HybridViewProps,
+  Methods extends HybridViewMethods,
+> = HostComponent<
+  WrapFunctionsInObjects<
+    DefaultHybridViewProps<HybridView<Props, Methods>> & Props & Methods
+  >
+>
+
+/**
  * Finds and returns a native view (aka "HostComponent") via the given {@linkcode name}.
  *
  * The view is bridged to a native Hybrid Object using Nitro Views.
@@ -26,7 +74,7 @@ export function getHostComponent<
 >(
   name: string,
   getViewConfig: () => ViewConfig<Props>
-): HybridView<Props, Methods> {
+): ReactNativeView<Props, Methods> {
   if (NativeComponentRegistry == null) {
     throw new Error(
       `NativeComponentRegistry is not available on ${Platform.OS}!`


### PR DESCRIPTION
Now the `ref` object in `hybridRef` is typed properly.