### PR TITLE
feat: Create `Callback<R(Args...)>` for more powerful callbacks

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1921,7 +1921,7 @@ SPEC CHECKSUMS:
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
   NitroImage: e6ea33d1f353925aac506ace6552e3a8a39a078a
-  NitroModules: 63a0be80b244c1bffbc2d22761671ced35664d79
+  NitroModules: c67a3685429aa915f27df4b351bc619b96e8d64b
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: b2eecf2d60216df56bc5e6be5f063826d3c1ee35
   RCTRequired: 78522de7dc73b81f3ed7890d145fa341f5bb32ea

--- a/packages/react-native-nitro-modules/NitroModules.podspec
+++ b/packages/react-native-nitro-modules/NitroModules.podspec
@@ -33,6 +33,7 @@ Pod::Spec.new do |s|
     # Public C++ headers will be exposed in modulemap (for Swift)
     "cpp/core/AnyMap.hpp",
     "cpp/core/ArrayBuffer.hpp",
+    "cpp/core/Callback.hpp",
     "cpp/core/HybridObject.hpp",
     "cpp/core/Promise.hpp",
     "cpp/entrypoint/HybridNitroModulesProxy.hpp",

--- a/packages/react-native-nitro-modules/android/src/main/cpp/platform/ThreadUtils.cpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/platform/ThreadUtils.cpp
@@ -27,10 +27,7 @@ std::string ThreadUtils::getThreadName() {
 #endif
 
   // Fall back to this_thread ID
-  std::stringstream stream;
-  stream << std::this_thread::get_id();
-  std::string threadId = stream.str();
-  return "Thread #" + threadId;
+  return idToString(std::this_thread::get_id());
 }
 
 void ThreadUtils::setThreadName(const std::string& name) {

--- a/packages/react-native-nitro-modules/cpp/core/Callback.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Callback.hpp
@@ -1,0 +1,136 @@
+//
+// Created by Marc Rousavy on 22.02.25.
+//
+
+#pragma once
+
+#include "NitroDefines.hpp"
+#include "NitroTypeInfo.hpp"
+#include "ThreadPool.hpp"
+#include "Promise.hpp"
+#include "BorrowingReference.hpp"
+#include "Dispatcher.hpp"
+#include <jsi/jsi.h>
+#include <memory>
+#include <functional>
+#include <type_traits>
+#include <thread>
+#include "ThreadUtils.hpp"
+
+namespace margelo::nitro {
+
+using namespace facebook;
+
+// ----- Callback base -----
+
+template <typename Signature>
+class Callback;
+
+template <typename R, typename... Args>
+class Callback<R(Args...)> {
+private:
+  using DefaultReturn = std::conditional_t<std::is_void_v<R>, void, Promise<R>>;
+  
+public:
+  virtual R callSync(Args... args) const = 0;
+  virtual Promise<R> callAsync(Args... args) const = 0;
+  virtual void callAsyncShootAndForget(Args... args) const = 0;
+
+public:
+  auto operator()(Args... args) const final {
+    if constexpr (std::is_void_v<R>) {
+      // Return void. Not need for Promise<T>
+      return callAsyncShootAndForget(std::forward<Args>(args)...);
+    } else {
+      // Return an awaitable Promise<T>
+      return callAsync(std::forward<Args>(args)...);
+    }
+  }
+};
+
+
+// ----- NativeCallback (std::function) -----
+
+template <typename Signature>
+class NativeCallback;
+
+template <typename R, typename... Args>
+class NativeCallback<R(Args...)> final: public Callback<R(Args...)> {
+public:
+  template <typename Func>
+  explicit NativeCallback(Func&& function): _func(std::forward<Func>(function)) { }
+
+public:
+  inline R callSync(Args... args) const override {
+    return _func(std::forward<Args>(args)...);
+  }
+  inline Promise<R> callAync(Args... args) const override {
+    return Promise<R>::resolved(_func(std::forward<Args>(args)...));
+  }
+  inline void callAsyncShootAndForget(Args... args) const override {
+    _func(std::forward<Args>(args)...);
+  }
+
+private:
+  std::function<R(Args...)> _func;
+};
+
+
+// ----- JSCallback (jsi::Function) -----
+
+template <typename Signature>
+class JSCallback;
+
+template <typename R, typename... Args>
+class JSCallback<R(Args...)> final: public Callback<R(Args...)> {
+public:
+#ifdef NITRO_DEBUG
+  explicit JSCallback(jsi::Runtime& runtime,
+                      const BorrowingReference<jsi::Function>& function,
+                      const std::shared_ptr<Dispatcher>& dispatcher):
+  _runtime(runtime), _func(function), _dispatcher(dispatcher), _threadId(std::this_thread::get_id()), _threadName(ThreadUtils::getThreadName()) { }
+#else
+  explicit JSCallback(jsi::Runtime& runtime,
+                      const BorrowingReference<jsi::Function>& function,
+                      const std::shared_ptr<Dispatcher>& dispatcher):
+  _runtime(runtime), _func(function), _dispatcher(dispatcher) { }
+#endif
+
+public:
+  inline R callSync(Args&&... args) const override {
+#ifdef NITRO_DEBUG
+    if (_threadId != std::this_thread::get_id()) [[unlikely]] {
+      std::string typeName = TypeInfo::getFriendlyTypename<JSCallback<R(Args...)>>();
+      throw std::runtime_error("Cannot call " + typeName + " on Thread " + ThreadUtils::getThreadName() + " - expected to run on Thread " + _threadName + "! If you want to call this JSCallback on a different Thread, use `callAsync(...)` instead.");
+    }
+#endif
+    if (!_func) [[unlikely]] {
+      std::string typeName = TypeInfo::getFriendlyTypename<JSCallback<R(Args...)>>();
+      throw std::runtime_error("Cannot call " + typeName + " - the jsi::Function has already been deleted!");
+    }
+    
+    jsi::Value result = _func->call(_runtime, JSIConverter<Args>::toJSI(std::forward<Args>(args))...);
+    return JSIConverter<R>::fromJSI(_runtime, result);
+  }
+  inline Promise<R> callAync(Args... args) const override {
+    return _dispatcher->runAsyncAwaitable([this, args = std::move(args) ...]() {
+      return this->callSync(args...);
+    });
+  }
+  inline void callAsyncShootAndForget(Args... args) const override {
+    _dispatcher->runAsync([this, args = std::move(args) ...]() {
+      this->callSync(args...);
+    });
+  }
+
+private:
+  jsi::Runtime& _runtime;
+  BorrowingReference<jsi::Function> _func;
+  std::shared_ptr<Dispatcher> _dispatcher;
+#ifdef NITRO_DEBUG
+  std::thread::id _threadId;
+  std::string _threadName;
+#endif
+};
+
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Callback.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Callback.hpp
@@ -1,0 +1,62 @@
+//
+// Created by Marc Rousavy on 22.02.25.
+//
+
+#pragma once
+
+// Forward declare a few of the common types that might have cyclic includes.
+namespace margelo::nitro {
+template <typename Signature>
+class Callback;
+template <typename Signature>
+class NativeCallback;
+template <typename Signature>
+class JSCallback;
+
+template <typename T, typename Enable>
+struct JSIConverter;
+} // namespace margelo::nitro
+
+#include "JSIConverter.hpp"
+
+#include "Callback.hpp"
+#include "JSICache.hpp"
+#include <jsi/jsi.h>
+#include <memory>
+
+namespace margelo::nitro {
+
+using namespace facebook;
+
+// Callback<R(A...)> <> jsi::Function
+template <typename ReturnType, typename... Args>
+struct JSIConverter<Callback<ReturnType(Args...)>> final {
+  static inline AnyValue fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
+    // 1. Convert arg to jsi::Function
+    jsi::Function function = arg.asObject(runtime).asFunction(runtime);
+    // 2. Make it a BorrowingReference
+    auto cache = JSICache::getOrCreateCache(runtime);
+    auto reference = cache.makeShared(std::move(function));
+    // 3. Get the Dispatcher
+    auto dispatcher = Dispatcher::getRuntimeGlobalDispatcher(runtime);
+    // 4. Create the callback
+    return Callback<ReturnType(Args...)>(runtime, reference, dispatcher);
+  }
+
+  static inline jsi::Value toJSI(jsi::Runtime& runtime, const Callback<ReturnType(Args...)>& callback) {
+    jsi::HostFunctionType func = [callback](jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* args,
+                                            size_t count) -> jsi::Value { throw std::runtime_error("Not yet implemented!"); };
+
+    return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forAscii(runtime, "nativeFunction"), sizeof...(Args),
+                                                 std::move(func));
+  }
+
+  static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
+    if (!value.isObject())
+      return false;
+    jsi::Object object = value.getObject(runtime);
+    return object.isFunction(runtime);
+  }
+};
+
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter.hpp
@@ -183,6 +183,7 @@ struct JSIConverter<std::string> final {
 
 #include "JSIConverter+AnyMap.hpp"
 #include "JSIConverter+ArrayBuffer.hpp"
+#include "JSIConverter+Callback.hpp"
 #include "JSIConverter+Exception.hpp"
 #include "JSIConverter+Function.hpp"
 #include "JSIConverter+Future.hpp"

--- a/packages/react-native-nitro-modules/cpp/platform/ThreadUtils.hpp
+++ b/packages/react-native-nitro-modules/cpp/platform/ThreadUtils.hpp
@@ -7,9 +7,9 @@
 
 #pragma once
 
+#include <sstream>
 #include <string>
 #include <thread>
-#include <sstream>
 
 namespace margelo::nitro {
 
@@ -22,7 +22,7 @@ public:
    * This is implemented differently on iOS and Android.
    */
   static std::string getThreadName();
-  
+
   /**
    * Converts the given `std::thread::id` to a string.
    */

--- a/packages/react-native-nitro-modules/cpp/platform/ThreadUtils.hpp
+++ b/packages/react-native-nitro-modules/cpp/platform/ThreadUtils.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <string>
+#include <thread>
+#include <sstream>
 
 namespace margelo::nitro {
 
@@ -20,6 +22,16 @@ public:
    * This is implemented differently on iOS and Android.
    */
   static std::string getThreadName();
+  
+  /**
+   * Converts the given `std::thread::id` to a string.
+   */
+  static std::string idToString(const std::thread::id& id) {
+    std::stringstream stream;
+    stream << id;
+    std::string threadId = stream.str();
+    return "#" + threadId;
+  }
 
   /**
    * Set the current Thread's name.

--- a/packages/react-native-nitro-modules/ios/platform/ThreadUtils.cpp
+++ b/packages/react-native-nitro-modules/ios/platform/ThreadUtils.cpp
@@ -20,10 +20,7 @@ std::string ThreadUtils::getThreadName() {
   }
 
   // Fall back to this_thread ID
-  std::stringstream stream;
-  stream << std::this_thread::get_id();
-  std::string threadId = stream.str();
-  return "Thread #" + threadId;
+  return idToString(std::this_thread::get_id());
 }
 
 void ThreadUtils::setThreadName(const std::string& name) {


### PR DESCRIPTION
This should be faster for JS Callbacks, and will allow sync callbacks.

Before:

```cpp
void doSomething(std::function<void(double)> callback, std::function<double(double)> callbackAndReturn) {
  // ...
  callback(55.3); // <-- returns void

  callbackAndReturn(55.3); // returns Promise<double>
}
```

After:

```cpp
void doSomething(Callback<void(double)> callback, Callback<double(double)> callbackAndReturn) {
  // ...
  callback(55.3); // <-- returns void as before
  callback.callAsync(55.3); // <-- return Promise<void> to allow awaiting
  callback.callSync(55.3); // <-- returns void as before, BUT is called synchronously/blocking.

  callbackAndReturn(55.3); // <-- returns Promise<double> as before
  callbackAndReturn.callAsync(55.3); // <-- return Promise<double> as before
  callbackAndReturn.callSync(55.3); // <-- returns double because it's called synchronously/blocking
}
```

So the key differences are;

- Callbacks that return `void` can now also be awaited
- Callbacks that return any value or `void` can be called synchronously to avoid any Thread hops or delays. (must be on the same thread)


## Why is this not merged

It works pretty well in C++ because of the power of C++ templates, but there is no good way to represent these callbacks in Swift yet. There are no variadic type parameters, and Swift Lambdas cannot be subclassed. Any ideas welcome, but I don't think this can be represented in Swift unless I generate hardcoded classes for each type specialization (e.g. `Callback<void(double)>` -> `Callback_void_double`) - but this is ugly syntax for the user.