### PR TITLE
docs: fix typo in lifecycle method names

### DIFF
--- a/docs/docs/view-components.md
+++ b/docs/docs/view-components.md
@@ -190,8 +190,8 @@ To batch prop changes, you can override `onBeforeUpdate()` and `onAfterUpdate()`
       // View
       var view: UIView = UIView()
 
-      func onBeforeUpdate() { }
-      func onAfterUpdate() { }
+      func beforeUpdate() { }
+      func afterUpdate() { }
     }
     ```
   </TabItem>
@@ -201,8 +201,8 @@ To batch prop changes, you can override `onBeforeUpdate()` and `onAfterUpdate()`
       // View
       override val view: View = View(NitroModules.applicationContext)
 
-      override fun onBeforeUpdate() { }
-      override fun onAfterUpdate() { }
+      override fun beforeUpdate() { }
+      override fun afterUpdate() { }
     }
     ```
   </TabItem>


### PR DESCRIPTION
This PR corrects a typo in the lifecycle method names beforeUpdate and afterUpdate for both Swift and Kotlin.

Renamed `onBeforeUpdate` → `beforeUpdate`
Renamed `onAfterUpdate` → `afterUpdate`