### PR TITLE
fix: Log proper generic `T` types when throwing exceptions

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -122,7 +122,8 @@ public:
    */
   void reject(const std::exception_ptr& exception) {
     if (exception == nullptr) [[unlikely]] {
-      throw std::runtime_error("Cannot reject Promise with a null exception_ptr!");
+      std::string typeName = TypeInfo::getFriendlyTypename<TResult>(true);
+      throw std::runtime_error("Cannot reject Promise<" + typeName + "> with a null exception_ptr!");
     }
 
     std::unique_lock lock(_mutex);
@@ -208,7 +209,8 @@ public:
    */
   inline const TResult& getResult() {
     if (!isResolved()) {
-      throw std::runtime_error("Cannot get result when Promise is not yet resolved!");
+      std::string typeName = TypeInfo::getFriendlyTypename<TResult>(true);
+      throw std::runtime_error("Cannot get result when Promise<" + typeName + "> is not yet resolved!");
     }
     return std::get<TResult>(_state);
   }
@@ -218,7 +220,8 @@ public:
    */
   inline const std::exception_ptr& getError() {
     if (!isRejected()) {
-      throw std::runtime_error("Cannot get error when Promise is not yet rejected!");
+      std::string typeName = TypeInfo::getFriendlyTypename<TResult>(true);
+      throw std::runtime_error("Cannot get error when Promise<" + typeName + "> is not yet rejected!");
     }
     return std::get<std::exception_ptr>(_state);
   }
@@ -323,7 +326,7 @@ public:
   }
   void reject(const std::exception_ptr& exception) {
     if (exception == nullptr) [[unlikely]] {
-      throw std::runtime_error("Cannot reject Promise with a null exception_ptr!");
+      throw std::runtime_error("Cannot reject Promise<void> with a null exception_ptr!");
     }
 
     std::unique_lock lock(_mutex);
@@ -383,7 +386,7 @@ public:
 public:
   inline const std::exception_ptr& getError() {
     if (!isRejected()) {
-      throw std::runtime_error("Cannot get error when Promise is not yet rejected!");
+      throw std::runtime_error("Cannot get error when Promise<void> is not yet rejected!");
     }
     return _error;
   }

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
@@ -31,7 +31,7 @@ struct JSIConverter<std::exception_ptr> final {
   }
   static inline jsi::Value toJSI(jsi::Runtime& runtime, const std::exception_ptr& exception) {
     if (exception == nullptr) [[unlikely]] {
-      throw std::runtime_error("Cannot convert an empty exception_ptr to a JS Error!");
+      throw std::runtime_error("Cannot convert a nullptr exception_ptr to a JS Error!");
     }
 
     try {

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Promise.hpp
@@ -12,7 +12,7 @@ struct JSIConverter;
 } // namespace margelo::nitro
 
 #include "JSIConverter.hpp"
-
+#include "NitroTypeInfo.hpp"
 #include "Promise.hpp"
 #include <exception>
 #include <jsi/jsi.h>
@@ -92,7 +92,8 @@ struct JSIConverter<std::shared_ptr<Promise<TResult>>> final {
       jsi::Value error = JSIConverter<std::exception_ptr>::toJSI(runtime, promise->getError());
       return createRejectedPromise.call(runtime, std::move(error));
     } else {
-      throw std::runtime_error("Promise has invalid state!");
+      std::string typeName = TypeInfo::getFriendlyTypename<TResult>(true);
+      throw std::runtime_error("Promise<" + typeName + "> has invalid state!");
     }
   }
 

--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "NitroDefines.hpp"
+#include "NitroTypeInfo.hpp"
 #include "OwningLock.hpp"
 #include "ReferenceState.hpp"
 #include "WeakReference.hpp"
@@ -161,7 +162,7 @@ public:
   inline T& operator*() const {
 #ifdef NITRO_DEBUG
     if (!hasValue()) [[unlikely]] {
-      throw std::runtime_error("Tried to dereference (*) nullptr BorrowingReference<T>!");
+      throw std::runtime_error("Tried to dereference (*) nullptr " + TypeInfo::getFriendlyTypename<BorrowingReference<T>>(true) + "!");
     }
 #endif
     return *_value;
@@ -170,7 +171,7 @@ public:
   inline T* operator->() const {
 #ifdef NITRO_DEBUG
     if (!hasValue()) [[unlikely]] {
-      throw std::runtime_error("Tried to dereference (->) nullptr BorrowingReference<T>!");
+      throw std::runtime_error("Tried to dereference (->) nullptr " + TypeInfo::getFriendlyTypename<BorrowingReference<T>>(true) + "!");
     }
 #endif
     return _value;

--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
@@ -162,7 +162,8 @@ public:
   inline T& operator*() const {
 #ifdef NITRO_DEBUG
     if (!hasValue()) [[unlikely]] {
-      throw std::runtime_error("Tried to dereference (*) nullptr " + TypeInfo::getFriendlyTypename<BorrowingReference<T>>(true) + "!");
+      std::string typeName = TypeInfo::getFriendlyTypename<T>(true);
+      throw std::runtime_error("Tried to dereference (*) nullptr BorrowingReference<" + typeName + ">!");
     }
 #endif
     return *_value;
@@ -171,7 +172,8 @@ public:
   inline T* operator->() const {
 #ifdef NITRO_DEBUG
     if (!hasValue()) [[unlikely]] {
-      throw std::runtime_error("Tried to dereference (->) nullptr " + TypeInfo::getFriendlyTypename<BorrowingReference<T>>(true) + "!");
+      std::string typeName = TypeInfo::getFriendlyTypename<T>(true);
+      throw std::runtime_error("Tried to dereference (->) nullptr BorrowingReference<" + typeName + ">!");
     }
 #endif
     return _value;

--- a/packages/react-native-nitro-modules/cpp/utils/WeakReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/WeakReference.hpp
@@ -87,7 +87,9 @@ private:
     if (_state->strongRefCount == 0 && _state->weakRefCount == 0) {
       // free the full memory if there are no more references at all
       if (!_state->isDeleted) [[unlikely]] {
-        throw std::runtime_error("WeakReference<T> encountered a stale _value - BorrowingReference<T> should've already deleted this!");
+        std::string typeName = TypeInfo::getFriendlyTypename<T>(true);
+        throw std::runtime_error("WeakReference<" + typeName + "> encountered a stale `_value` - BorrowingReference<" + typeName +
+                                 "> should've already deleted this!");
       }
       delete _state;
       _state = nullptr;

--- a/packages/react-native-nitro-modules/ios/turbomodule/NativeNitroModules+NewArch.mm
+++ b/packages/react-native-nitro-modules/ios/turbomodule/NativeNitroModules+NewArch.mm
@@ -36,7 +36,7 @@ RCT_EXPORT_MODULE(NitroModules)
   // 1. Get CallInvoker we cached statically
   std::shared_ptr<react::CallInvoker> callInvoker = _callInvoker.lock();
   if (callInvoker == nullptr) {
-    throw std::runtime_error("Cannot install global.NitroModulesProxy - CallInvoker was null!");
+    throw std::runtime_error("Cannot install `global.NitroModulesProxy` - CallInvoker was null!");
   }
 
   // 2. Wrap CallInvoker as Dispatcher

--- a/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/RuntimeError.hpp
@@ -19,7 +19,7 @@ static inline std::exception_ptr makeException(const std::string& message) {
 
 static inline std::string getExceptionMessage(const std::exception_ptr& exception) {
   if (exception == nullptr) [[unlikely]] {
-    throw std::runtime_error("Cannot get error message of an empty exception_ptr!");
+    throw std::runtime_error("Cannot get error message of a nullptr exception_ptr!");
   }
 
   try {


### PR DESCRIPTION
Logs the actual type of `BorrowingReference<T>`, `WeakReference<T>` and other generic `T` types instead of keeping it generic. 

Helps debug these issues: https://github.com/mrousavy/nitro/issues/565