### PR TITLE
fix: Fix a case where a `nullptr` `BorrowingReference<T>` could be accessed

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/ArrayBuffer.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/ArrayBuffer.cpp
@@ -61,7 +61,7 @@ bool NativeArrayBuffer::isOwner() const noexcept {
 
 // 3. JSArrayBuffer
 
-JSArrayBuffer::JSArrayBuffer(jsi::Runtime* runtime, BorrowingReference<jsi::ArrayBuffer> jsReference)
+JSArrayBuffer::JSArrayBuffer(jsi::Runtime& runtime, BorrowingReference<jsi::ArrayBuffer> jsReference)
     : ArrayBuffer(), _runtime(runtime), _jsReference(jsReference), _initialThreadId(std::this_thread::get_id()) {}
 
 JSArrayBuffer::~JSArrayBuffer() {}

--- a/packages/react-native-nitro-modules/cpp/core/ArrayBuffer.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/ArrayBuffer.cpp
@@ -77,7 +77,7 @@ uint8_t* JSArrayBuffer::data() {
     return nullptr;
   }
   // JS Part is still alive - we can assume that the jsi::Runtime is safe to access here too.
-  return _jsReference->data(*_runtime);
+  return _jsReference->data(_runtime);
 }
 
 size_t JSArrayBuffer::size() const {
@@ -91,7 +91,7 @@ size_t JSArrayBuffer::size() const {
     return 0;
   }
   // JS Part is still alive - we can assume that the jsi::Runtime is safe to access here too.
-  return _jsReference->size(*_runtime);
+  return _jsReference->size(_runtime);
 }
 
 bool JSArrayBuffer::isOwner() const noexcept {

--- a/packages/react-native-nitro-modules/cpp/core/ArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/ArrayBuffer.hpp
@@ -122,7 +122,7 @@ private:
  */
 class JSArrayBuffer final : public ArrayBuffer {
 public:
-  explicit JSArrayBuffer(jsi::Runtime* runtime, BorrowingReference<jsi::ArrayBuffer> jsReference);
+  explicit JSArrayBuffer(jsi::Runtime& runtime, BorrowingReference<jsi::ArrayBuffer> jsReference);
   ~JSArrayBuffer();
 
 public:
@@ -140,7 +140,7 @@ public:
   bool isOwner() const noexcept override;
 
 private:
-  jsi::Runtime* _runtime;
+  jsi::Runtime& _runtime;
   BorrowingReference<jsi::ArrayBuffer> _jsReference;
   std::thread::id _initialThreadId;
 };

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+ArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+ArrayBuffer.hpp
@@ -51,7 +51,7 @@ struct JSIConverter<T, std::enable_if_t<is_shared_ptr_to_v<T, jsi::MutableBuffer
     JSICacheReference cache = JSICache::getOrCreateCache(runtime);
     auto borrowingArrayBuffer = cache.makeShared(object.getArrayBuffer(runtime));
 
-    return std::make_shared<JSArrayBuffer>(&runtime, borrowingArrayBuffer);
+    return std::make_shared<JSArrayBuffer>(runtime, borrowingArrayBuffer);
   }
   static inline jsi::Value toJSI(jsi::Runtime& runtime, const std::shared_ptr<jsi::MutableBuffer>& buffer) {
     return jsi::ArrayBuffer(runtime, buffer);

--- a/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
+++ b/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
@@ -28,6 +28,7 @@ jsi::Value HybridObjectPrototype::createPrototype(jsi::Runtime& runtime, const s
   if (cachedPrototype != prototypeCache.end()) {
     const BorrowingReference<jsi::Object>& cachedObject = cachedPrototype->second;
     if (cachedObject != nullptr) {
+      // 1.1. Found it in cache! Copy & return it.
       return jsi::Value(runtime, *cachedObject);
     }
   }

--- a/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
@@ -22,8 +22,9 @@ public:
 
 public:
   bool equals(jsi::Runtime& runtime, const jsi::Value& other) const {
-    if (!jsiValue)
+    if (jsiValue == nullptr) {
       return false;
+    }
     return jsi::Value::strictEquals(runtime, *jsiValue, other);
   }
 


### PR DESCRIPTION
There is a rare case in which a `nullptr` `BorrowingReference<T>` could actually be accessed from a `jsi::Runtime`.
This PR fixes the issue

- fixes https://github.com/mrousavy/nitro/issues/565