### PR TITLE
fix: Fix implicit `size_t` conversion in `jsi::Function::createFromHostFunction(…)`

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -57,7 +57,8 @@ public:
 public:
   // functions
   inline jsi::Function toJSFunction(jsi::Runtime& runtime) const {
-    return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, _name), _paramCount, _function);
+    return jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, _name), static_cast<unsigned int>(_paramCount),
+                                                 _function);
   }
 
 private:


### PR DESCRIPTION
Fixes a small warning. No idea why `jsi::Function::createFromHostFunction` takes a `unsigned int`, but `jsi::HostFunctionType` receives a `size_t`... 🤔 