### PR TITLE
feat: Add `context` as a parameter to `HybridView`s

### DIFF
--- a/docs/docs/view-components.md
+++ b/docs/docs/view-components.md
@@ -81,12 +81,12 @@ Now it's time to implement the View - simply create a new Swift/Kotlin class/fil
   </TabItem>
   <TabItem value="kotlin" label="Kotlin">
     ```kotlin title="HybridCameraView.kt"
-    class HybridCameraView : HybridCameraViewSpec() {
+    class HybridCameraView(val context: ThemedReactContext) : HybridCameraViewSpec() {
       // Props
       override var enableFlash: Boolean = false
 
       // View
-      override val view: View = View(NitroModules.applicationContext)
+      override val view: View = View(context)
     }
     ```
   </TabItem>

--- a/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
+++ b/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
@@ -61,7 +61,7 @@ class ${manager}: SimpleViewManager<View>() {
   }
 
   override fun createViewInstance(reactContext: ThemedReactContext): View {
-    val hybridView = ${viewImplementation}()
+    val hybridView = ${viewImplementation}(reactContext)
     val view = hybridView.view
     views[view] = hybridView
     return view

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestView.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestView.kt
@@ -4,13 +4,13 @@ import android.graphics.Color
 import android.view.View
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
-import com.margelo.nitro.NitroModules
+import com.facebook.react.uimanager.ThemedReactContext
 
 @Keep
 @DoNotStrip
-class HybridTestView: HybridTestViewSpec() {
+class HybridTestView(val context: ThemedReactContext): HybridTestViewSpec() {
     // View
-    override val view: View = View(NitroModules.applicationContext)
+    override val view: View = View(context)
 
     // Props
     private var _isBlue = false

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/views/HybridTestViewManager.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/views/HybridTestViewManager.kt
@@ -26,7 +26,7 @@ class HybridTestViewManager: SimpleViewManager<View>() {
   }
 
   override fun createViewInstance(reactContext: ThemedReactContext): View {
-    val hybridView = HybridTestView()
+    val hybridView = HybridTestView(reactContext)
     val view = hybridView.view
     views[view] = hybridView
     return view


### PR DESCRIPTION
Technically a breaking change, but before it was broken too because views must have a `ThemedReactContext`.