### PR TITLE
fix: removes deprecated `HybridObjectRegistry` from template

### DIFF
--- a/packages/template/android/src/main/java/com/margelo/nitro/$$androidNamespace$$/$$androidCxxLibName$$Package.java
+++ b/packages/template/android/src/main/java/com/margelo/nitro/$$androidNamespace$$/$$androidCxxLibName$$Package.java
@@ -9,7 +9,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
 import com.facebook.react.TurboReactPackage;
 import com.margelo.nitro.core.HybridObject;
-import com.margelo.nitro.core.HybridObjectRegistry;
 
 import java.util.HashMap;
 import java.util.function.Supplier;


### PR DESCRIPTION
Fix Android build by removing `HybridObjectRegistry` from the template, following its removal from core in #579.