### PR TITLE
feat: Freeze objects in debug

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -79,11 +79,17 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
   object.setProperty(runtime, "__type", jsi::String::createFromUtf8(runtime, "NativeState<" + std::string(_name) + ">"));
 #endif
 
-  // 8. Throw a jsi::WeakObject pointing to our object into cache so subsequent calls can use it from cache
+#ifdef NITRO_DEBUG
+  // 8. Freeze the object to prevent accidentally setting wrong props on it that do nothing.
+  jsi::Function freeze = objectConstructor.getPropertyAsFunction(runtime, "freeze");
+  freeze.call(runtime, object);
+#endif
+
+  // 9. Throw a jsi::WeakObject pointing to our object into cache so subsequent calls can use it from cache
   JSICacheReference cache = JSICache::getOrCreateCache(runtime);
   _objectCache[&runtime] = cache.makeShared(jsi::WeakObject(runtime, object));
 
-  // 9. Return it!
+  // 10. Return it!
   return object;
 }
 


### PR DESCRIPTION
In debug, all Hybrid Objects are now frozen. This prevents the following bugs:

```
object.someValeu = 5
```

As you can see, the user (who might not be using TypeScript (stupid idea btw)) mistyped `someValue` and instead set `someValeu`. This just does _nothing_ and sets the prop on the `jsi::Object`, instead of going into the native hybrid object.

With this change, the issue is now fixed, and the object can no longer be modified (in debug) as it's now frozen.