### PR TITLE
fix: CMake not finding headers during Gradle Sync on a fresh install 

### DIFF
--- a/packages/react-native-nitro-modules/package.json
+++ b/packages/react-native-nitro-modules/package.json
@@ -16,6 +16,7 @@
     "android/gradle.properties",
     "android/CMakeLists.txt",
     "android/src/",
+    "android/build/headers",
     "ios/",
     "cpp/",
     "app.plugin.js",


### PR DESCRIPTION
Add s`android/build/headers` to the published files list in `package.json` to fix an error during Gradle Sync -> CMake.