### PR TITLE
fix: revert Object.freeze

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -79,17 +79,11 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
   object.setProperty(runtime, "__type", jsi::String::createFromUtf8(runtime, "NativeState<" + std::string(_name) + ">"));
 #endif
 
-#ifdef NITRO_DEBUG
-  // 8. Freeze the object to prevent accidentally setting wrong props on it that do nothing.
-  jsi::Function freeze = objectConstructor.getPropertyAsFunction(runtime, "freeze");
-  freeze.call(runtime, object);
-#endif
-
-  // 9. Throw a jsi::WeakObject pointing to our object into cache so subsequent calls can use it from cache
+  // 8. Throw a jsi::WeakObject pointing to our object into cache so subsequent calls can use it from cache
   JSICacheReference cache = JSICache::getOrCreateCache(runtime);
   _objectCache[&runtime] = cache.makeShared(jsi::WeakObject(runtime, object));
 
-  // 10. Return it!
+  // 9. Return it!
   return object;
 }
 


### PR DESCRIPTION
This PR reverts #602 as it breaks Unistyles.

Freezing objects is indeed a good approach, but it compromises Nitro's flexibility to override certain JS-only properties.  
One use case is mapping React Native `StyleSheet` properties like `compose` and `flatten` to my Hybrid.

I considered exposing some setters on my side, but that feels like overkill for such a simple case.
