### PR TITLE
fix: Fix boolean properties with `has` prefix generating wrong names

### DIFF
--- a/packages/nitrogen/src/syntax/Property.ts
+++ b/packages/nitrogen/src/syntax/Property.ts
@@ -6,6 +6,7 @@ import type { Type } from './types/Type.js'
 import { Method } from './Method.js'
 import { VoidType } from './types/VoidType.js'
 import { Parameter } from './Parameter.js'
+import { isBooleanPropertyPrefix } from './helpers.js'
 
 export interface PropertyBody {
   getter: string
@@ -72,8 +73,8 @@ export class Property implements CodeNode {
   }
 
   getGetterName(environment: LanguageEnvironment): string {
-    if (this.type.kind === 'boolean' && this.name.startsWith('is')) {
-      // Boolean accessors where the property starts with "is" are renamed in JVM and Swift
+    if (this.type.kind === 'boolean' && isBooleanPropertyPrefix(this.name)) {
+      // Boolean accessors where the property starts with "is" or "has" are renamed in JVM and Swift
       switch (environment) {
         case 'jvm':
         case 'swift':

--- a/packages/nitrogen/src/syntax/helpers.ts
+++ b/packages/nitrogen/src/syntax/helpers.ts
@@ -50,6 +50,10 @@ export function escapeCppName(string: string): string {
   return escapedStr
 }
 
+export function isBooleanPropertyPrefix(name: string): boolean {
+  return name.startsWith('is') || name.startsWith('has')
+}
+
 export function isNotDuplicate<T>(item: T, index: number, array: T[]): boolean {
   return array.indexOf(item) === index
 }

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestView.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestView.kt
@@ -21,11 +21,13 @@ class HybridTestView(val context: ThemedReactContext): HybridTestViewSpec() {
             val color = if (value) Color.BLUE else Color.RED
             view.setBackgroundColor(color)
         }
+    override var hasBeenCalled: Boolean = false
     override var colorScheme: ColorScheme = ColorScheme.LIGHT
     override var someCallback: () -> Unit = {}
 
     // Methods
     override fun someMethod(): Unit {
+        hasBeenCalled = true
         someCallback()
     }
 }

--- a/packages/react-native-nitro-image/ios/HybridTestView.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestView.swift
@@ -18,11 +18,13 @@ class HybridTestView : HybridTestViewSpec {
       view.backgroundColor = isBlue ? .systemBlue : .systemRed
     }
   }
+  var hasBeenCalled: Bool = false
   var colorScheme: ColorScheme = .light
   var someCallback: () -> Void = { }
 
   // Methods
   func someMethod() throws -> Void {
+    hasBeenCalled = true
     someCallback()
   }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
@@ -42,6 +42,15 @@ namespace margelo::nitro::image {
     static const auto method = javaClassStatic()->getMethod<void(jboolean /* isBlue */)>("setBlue");
     method(_javaPart, isBlue);
   }
+  bool JHybridTestViewSpec::getHasBeenCalled() {
+    static const auto method = javaClassStatic()->getMethod<jboolean()>("hasBeenCalled");
+    auto __result = method(_javaPart);
+    return static_cast<bool>(__result);
+  }
+  void JHybridTestViewSpec::setHasBeenCalled(bool hasBeenCalled) {
+    static const auto method = javaClassStatic()->getMethod<void(jboolean /* hasBeenCalled */)>("setHasBeenCalled");
+    method(_javaPart, hasBeenCalled);
+  }
   ColorScheme JHybridTestViewSpec::getColorScheme() {
     static const auto method = javaClassStatic()->getMethod<jni::local_ref<JColorScheme>()>("getColorScheme");
     auto __result = method(_javaPart);

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
@@ -49,6 +49,8 @@ namespace margelo::nitro::image {
     // Properties
     bool getIsBlue() override;
     void setIsBlue(bool isBlue) override;
+    bool getHasBeenCalled() override;
+    void setHasBeenCalled(bool hasBeenCalled) override;
     ColorScheme getColorScheme() override;
     void setColorScheme(ColorScheme colorScheme) override;
     std::function<void()> getSomeCallback() override;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
@@ -32,6 +32,10 @@ void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /*
     view->setIsBlue(props.isBlue.value);
     // TODO: Set isDirty = false
   }
+  if (props.hasBeenCalled.isDirty) {
+    view->setHasBeenCalled(props.hasBeenCalled.value);
+    // TODO: Set isDirty = false
+  }
   if (props.colorScheme.isDirty) {
     view->setColorScheme(props.colorScheme.value);
     // TODO: Set isDirty = false

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestViewSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestViewSpec.kt
@@ -48,6 +48,12 @@ abstract class HybridTestViewSpec: HybridView() {
   @get:Keep
   @set:DoNotStrip
   @set:Keep
+  abstract var hasBeenCalled: Boolean
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
   abstract var colorScheme: ColorScheme
   
   abstract var someCallback: () -> Unit

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestViewSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestViewSpecSwift.hpp
@@ -59,6 +59,12 @@ namespace margelo::nitro::image {
     inline void setIsBlue(bool isBlue) noexcept override {
       _swiftPart.setIsBlue(std::forward<decltype(isBlue)>(isBlue));
     }
+    inline bool getHasBeenCalled() noexcept override {
+      return _swiftPart.hasBeenCalled();
+    }
+    inline void setHasBeenCalled(bool hasBeenCalled) noexcept override {
+      _swiftPart.setHasBeenCalled(std::forward<decltype(hasBeenCalled)>(hasBeenCalled));
+    }
     inline ColorScheme getColorScheme() noexcept override {
       auto __result = _swiftPart.getColorScheme();
       return static_cast<ColorScheme>(__result);

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -76,6 +76,11 @@ using namespace margelo::nitro::image::views;
     swiftPart.setIsBlue(newViewProps.isBlue.value);
     newViewProps.isBlue.isDirty = false;
   }
+  // hasBeenCalled: boolean
+  if (newViewProps.hasBeenCalled.isDirty) {
+    swiftPart.setHasBeenCalled(newViewProps.hasBeenCalled.value);
+    newViewProps.hasBeenCalled.isDirty = false;
+  }
   // colorScheme: enum
   if (newViewProps.colorScheme.isDirty) {
     swiftPart.setColorScheme(static_cast<int>(newViewProps.colorScheme.value));

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
@@ -12,6 +12,7 @@ import NitroModules
 public protocol HybridTestViewSpec_protocol: HybridObject, HybridView {
   // Properties
   var isBlue: Bool { get set }
+  var hasBeenCalled: Bool { get set }
   var colorScheme: ColorScheme { get set }
   var someCallback: () -> Void { get set }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
@@ -108,6 +108,17 @@ public class HybridTestViewSpec_cxx {
     }
   }
   
+  public final var hasBeenCalled: Bool {
+    @inline(__always)
+    get {
+      return self.__implementation.hasBeenCalled
+    }
+    @inline(__always)
+    set {
+      self.__implementation.hasBeenCalled = newValue
+    }
+  }
+  
   public final var colorScheme: Int32 {
     @inline(__always)
     get {

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestViewSpec.cpp
@@ -16,6 +16,8 @@ namespace margelo::nitro::image {
     registerHybrids(this, [](Prototype& prototype) {
       prototype.registerHybridGetter("isBlue", &HybridTestViewSpec::getIsBlue);
       prototype.registerHybridSetter("isBlue", &HybridTestViewSpec::setIsBlue);
+      prototype.registerHybridGetter("hasBeenCalled", &HybridTestViewSpec::getHasBeenCalled);
+      prototype.registerHybridSetter("hasBeenCalled", &HybridTestViewSpec::setHasBeenCalled);
       prototype.registerHybridGetter("colorScheme", &HybridTestViewSpec::getColorScheme);
       prototype.registerHybridSetter("colorScheme", &HybridTestViewSpec::setColorScheme);
       prototype.registerHybridGetter("someCallback", &HybridTestViewSpec::getSomeCallback);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestViewSpec.hpp
@@ -48,6 +48,8 @@ namespace margelo::nitro::image {
       // Properties
       virtual bool getIsBlue() = 0;
       virtual void setIsBlue(bool isBlue) = 0;
+      virtual bool getHasBeenCalled() = 0;
+      virtual void setHasBeenCalled(bool hasBeenCalled) = 0;
       virtual ColorScheme getColorScheme() = 0;
       virtual void setColorScheme(ColorScheme colorScheme) = 0;
       virtual std::function<void()> getSomeCallback() = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
@@ -35,6 +35,16 @@ namespace margelo::nitro::image::views {
         throw std::runtime_error(std::string("TestView.isBlue: ") + exc.what());
       }
     }()),
+    hasBeenCalled([&]() -> CachedProp<bool> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("hasBeenCalled", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.hasBeenCalled;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<bool>::fromRawValue(*runtime, value, sourceProps.hasBeenCalled);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("TestView.hasBeenCalled: ") + exc.what());
+      }
+    }()),
     colorScheme([&]() -> CachedProp<ColorScheme> {
       try {
         const react::RawValue* rawValue = rawProps.at("colorScheme", nullptr, nullptr);
@@ -69,6 +79,7 @@ namespace margelo::nitro::image::views {
   HybridTestViewProps::HybridTestViewProps(const HybridTestViewProps& other):
     react::ViewProps(),
     isBlue(other.isBlue),
+    hasBeenCalled(other.hasBeenCalled),
     colorScheme(other.colorScheme),
     someCallback(other.someCallback),
     hybridRef(other.hybridRef) { }
@@ -76,6 +87,7 @@ namespace margelo::nitro::image::views {
   bool HybridTestViewProps::filterObjectKeys(const std::string& propName) {
     switch (hashString(propName)) {
       case hashString("isBlue"): return true;
+      case hashString("hasBeenCalled"): return true;
       case hashString("colorScheme"): return true;
       case hashString("someCallback"): return true;
       case hashString("hybridRef"): return true;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
@@ -45,6 +45,7 @@ namespace margelo::nitro::image::views {
 
   public:
     CachedProp<bool> isBlue;
+    CachedProp<bool> hasBeenCalled;
     CachedProp<ColorScheme> colorScheme;
     CachedProp<std::function<void()>> someCallback;
     CachedProp<std::optional<std::function<void(const std::shared_ptr<margelo::nitro::image::HybridTestViewSpec>& /* ref */)>>> hybridRef;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/json/TestViewConfig.json
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/json/TestViewConfig.json
@@ -5,6 +5,7 @@
   "directEventTypes": {},
   "validAttributes": {
     "isBlue": true,
+    "hasBeenCalled": true,
     "colorScheme": true,
     "someCallback": true,
     "hybridRef": true

--- a/packages/react-native-nitro-image/src/specs/TestView.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestView.nitro.ts
@@ -8,6 +8,7 @@ export type ColorScheme = 'light' | 'dark'
 
 export interface TestViewProps extends HybridViewProps {
   isBlue: boolean
+  hasBeenCalled: boolean
   colorScheme: ColorScheme
   someCallback: () => void
 }


### PR DESCRIPTION
In Kotlin and Swift, a boolean property that starts with `is` will have a getter that doesn't have the `get` prefix.

```swift
class Test {
  var isWith = false
  var without = false
}
```

This generates those getters:

```swift
bool Test::isWith();
bool Test::getWithout();
```

This worked for boolean properties that start with `is`, but I forgot to also add this to properties that are prefixed with `has`. This PR changes this, now it also works for `hasSomething`.

- fixes #648 