### PR TITLE
fix(android): prevent crash when returning callback functions by safely capturing weak JNI references

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -718,13 +718,12 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
   if (${parameterName}->isInstanceOf(${jniType}::javaClassStatic())) [[likely]] {
     auto downcast = jni::static_ref_cast<${jniType}::javaobject>(${parameterName});
     return downcast->cthis()->getFunction();
+  } else {
+    auto ${parameterName}Ref = jni::make_global(${parameterName});
+    return [${parameterName}Ref](${params.join(', ')}) -> ${returnType} {
+      return ${parameterName}Ref->invoke(${paramsForward});
+    };
   }
-  auto ${parameterName}WeakRef = jni::make_weak(${parameterName});
-  return [${parameterName}WeakRef](${params.join(', ')}) -> ${returnType} {
-    if (auto ${parameterName}StrongRef = ${parameterName}WeakRef.lockLocal()) {
-      return ${parameterName}StrongRef->invoke(${paramsForward});
-    }
-  };
 }()
             `.trim()
           }

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -723,8 +723,8 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
   return [${parameterName}WeakRef](${params.join(', ')}) -> ${returnType} {
     if (auto ${parameterName}StrongRef = ${parameterName}WeakRef.lockLocal()) {
       return ${parameterName}StrongRef->invoke(${paramsForward});
-    };
-  }
+    }
+  };
 }()
             `.trim()
           }

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -718,9 +718,11 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
   if (${parameterName}->isInstanceOf(${jniType}::javaClassStatic())) [[likely]] {
     auto downcast = jni::static_ref_cast<${jniType}::javaobject>(${parameterName});
     return downcast->cthis()->getFunction();
-  } else {
-    return [${parameterName}](${params.join(', ')}) -> ${returnType} {
-      return ${parameterName}->invoke(${paramsForward});
+  }
+  auto ${parameterName}WeakRef = jni::make_weak(${parameterName});
+  return [${parameterName}WeakRef](${params.join(', ')}) -> ${returnType} {
+    if (auto ${parameterName}StrongRef = ${parameterName}WeakRef.lockLocal()) {
+      return ${parameterName}StrongRef->invoke(${paramsForward});
     };
   }
 }()

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -232,9 +232,11 @@ namespace margelo::nitro::image {
       if (__result->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
         auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(__result);
         return downcast->cthis()->getFunction();
-      } else {
-        return [__result](double value) -> void {
-          return __result->invoke(value);
+      }
+      auto __resultWeakRef = jni::make_weak(__result);
+      return [__resultWeakRef](double value) -> void {
+        if (auto __resultStrongRef = __resultWeakRef.lockLocal()) {
+          return __resultStrongRef->invoke(value);
         };
       }
     }()) : std::nullopt;
@@ -652,9 +654,11 @@ namespace margelo::nitro::image {
       if (__result->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
         auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(__result);
         return downcast->cthis()->getFunction();
-      } else {
-        return [__result](double value) -> void {
-          return __result->invoke(value);
+      }
+      auto __resultWeakRef = jni::make_weak(__result);
+      return [__resultWeakRef](double value) -> void {
+        if (auto __resultStrongRef = __resultWeakRef.lockLocal()) {
+          return __resultStrongRef->invoke(value);
         };
       }
     }();

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -237,8 +237,8 @@ namespace margelo::nitro::image {
       return [__resultWeakRef](double value) -> void {
         if (auto __resultStrongRef = __resultWeakRef.lockLocal()) {
           return __resultStrongRef->invoke(value);
-        };
-      }
+        }
+      };
     }()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalCallback(const std::optional<std::function<void(double /* value */)>>& optionalCallback) {
@@ -659,8 +659,8 @@ namespace margelo::nitro::image {
       return [__resultWeakRef](double value) -> void {
         if (auto __resultStrongRef = __resultWeakRef.lockLocal()) {
           return __resultStrongRef->invoke(value);
-        };
-      }
+        }
+      };
     }();
   }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -232,13 +232,12 @@ namespace margelo::nitro::image {
       if (__result->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
         auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(__result);
         return downcast->cthis()->getFunction();
+      } else {
+        auto __resultRef = jni::make_global(__result);
+        return [__resultRef](double value) -> void {
+          return __resultRef->invoke(value);
+        };
       }
-      auto __resultWeakRef = jni::make_weak(__result);
-      return [__resultWeakRef](double value) -> void {
-        if (auto __resultStrongRef = __resultWeakRef.lockLocal()) {
-          return __resultStrongRef->invoke(value);
-        }
-      };
     }()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::setOptionalCallback(const std::optional<std::function<void(double /* value */)>>& optionalCallback) {
@@ -654,13 +653,12 @@ namespace margelo::nitro::image {
       if (__result->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
         auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(__result);
         return downcast->cthis()->getFunction();
+      } else {
+        auto __resultRef = jni::make_global(__result);
+        return [__resultRef](double value) -> void {
+          return __resultRef->invoke(value);
+        };
       }
-      auto __resultWeakRef = jni::make_weak(__result);
-      return [__resultWeakRef](double value) -> void {
-        if (auto __resultStrongRef = __resultWeakRef.lockLocal()) {
-          return __resultStrongRef->invoke(value);
-        }
-      };
     }();
   }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::getValueFromJSCallbackAndWait(const std::function<std::shared_ptr<Promise<double>>()>& getValue) {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
@@ -58,9 +58,11 @@ namespace margelo::nitro::image {
       if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
         auto downcast = jni::static_ref_cast<JFunc_void_cxx::javaobject>(__result);
         return downcast->cthis()->getFunction();
-      } else {
-        return [__result]() -> void {
-          return __result->invoke();
+      }
+      auto __resultWeakRef = jni::make_weak(__result);
+      return [__resultWeakRef]() -> void {
+        if (auto __resultStrongRef = __resultWeakRef.lockLocal()) {
+          return __resultStrongRef->invoke();
         };
       }
     }();

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
@@ -63,8 +63,8 @@ namespace margelo::nitro::image {
       return [__resultWeakRef]() -> void {
         if (auto __resultStrongRef = __resultWeakRef.lockLocal()) {
           return __resultStrongRef->invoke();
-        };
-      }
+        }
+      };
     }();
   }
   void JHybridTestViewSpec::setSomeCallback(const std::function<void()>& someCallback) {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
@@ -58,13 +58,12 @@ namespace margelo::nitro::image {
       if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
         auto downcast = jni::static_ref_cast<JFunc_void_cxx::javaobject>(__result);
         return downcast->cthis()->getFunction();
+      } else {
+        auto __resultRef = jni::make_global(__result);
+        return [__resultRef]() -> void {
+          return __resultRef->invoke();
+        };
       }
-      auto __resultWeakRef = jni::make_weak(__result);
-      return [__resultWeakRef]() -> void {
-        if (auto __resultStrongRef = __resultWeakRef.lockLocal()) {
-          return __resultStrongRef->invoke();
-        }
-      };
     }();
   }
   void JHybridTestViewSpec::setSomeCallback(const std::function<void()>& someCallback) {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JJsStyleStruct.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JJsStyleStruct.hpp
@@ -42,13 +42,12 @@ namespace margelo::nitro::image {
           if (onChanged->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
             auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(onChanged);
             return downcast->cthis()->getFunction();
+          } else {
+            auto onChangedRef = jni::make_global(onChanged);
+            return [onChangedRef](double num) -> void {
+              return onChangedRef->invoke(num);
+            };
           }
-          auto onChangedWeakRef = jni::make_weak(onChanged);
-          return [onChangedWeakRef](double num) -> void {
-            if (auto onChangedStrongRef = onChangedWeakRef.lockLocal()) {
-              return onChangedStrongRef->invoke(num);
-            }
-          };
         }()
       );
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JJsStyleStruct.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JJsStyleStruct.hpp
@@ -42,9 +42,11 @@ namespace margelo::nitro::image {
           if (onChanged->isInstanceOf(JFunc_void_double_cxx::javaClassStatic())) [[likely]] {
             auto downcast = jni::static_ref_cast<JFunc_void_double_cxx::javaobject>(onChanged);
             return downcast->cthis()->getFunction();
-          } else {
-            return [onChanged](double num) -> void {
-              return onChanged->invoke(num);
+          }
+          auto onChangedWeakRef = jni::make_weak(onChanged);
+          return [onChangedWeakRef](double num) -> void {
+            if (auto onChangedStrongRef = onChangedWeakRef.lockLocal()) {
+              return onChangedStrongRef->invoke(num);
             };
           }
         }()

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JJsStyleStruct.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JJsStyleStruct.hpp
@@ -47,8 +47,8 @@ namespace margelo::nitro::image {
           return [onChangedWeakRef](double num) -> void {
             if (auto onChangedStrongRef = onChangedWeakRef.lockLocal()) {
               return onChangedStrongRef->invoke(num);
-            };
-          }
+            }
+          };
         }()
       );
     }


### PR DESCRIPTION
This commit updates the generated C++ glue code to use `jni::make_global()` to avoid invalid memory access and ensure safe interop with Java/Kotlin-managed objects.

Closes: #654