### PR TITLE
fix: RN 0.80 compatibility 

### DIFF
--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
@@ -17,8 +17,17 @@ using ConcreteStateData = react::ConcreteState<HybridTestViewState>;
 
 void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                                            jni::alias_ref<JHybridTestViewSpec::javaobject> javaView,
-                                           jni::alias_ref<react::StateWrapperImpl::javaobject> stateWrapper) {
+                                           jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface) {
   JHybridTestViewSpec* view = javaView->cthis();
+  
+  // Get concrete StateWrapperImpl from passed StateWrapper interface object
+  jobject rawStateWrapper = stateWrapperInterface.get();
+  if (!stateWrapperInterface->isInstanceOf(react::StateWrapperImpl::javaClassStatic())) {
+      throw std::runtime_error("StateWrapper is not a StateWrapperImpl");
+  }
+  auto stateWrapper = jni::alias_ref<react::StateWrapperImpl::javaobject>{
+            static_cast<react::StateWrapperImpl::javaobject>(rawStateWrapper)};
+
   std::shared_ptr<const react::State> state = stateWrapper->cthis()->getState();
   auto concreteState = std::dynamic_pointer_cast<const ConcreteStateData>(state);
   const HybridTestViewState& data = concreteState->getData();

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.hpp
@@ -12,6 +12,7 @@
 #include <react/fabric/CoreComponentsRegistry.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <NitroModules/NitroDefines.hpp>
+#include <NitroModules/JStateWrapper.hpp>
 #include "JHybridTestViewSpec.hpp"
 #include "views/HybridTestViewComponent.hpp"
 
@@ -26,7 +27,7 @@ public:
 public:
   static void updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                               jni::alias_ref<JHybridTestViewSpec::javaobject> view,
-                              jni::alias_ref<react::StateWrapperImpl::javaobject> stateWrapper);
+                              jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface);
 
 public:
   static void registerNatives() {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/views/HybridTestViewManager.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/views/HybridTestViewManager.kt
@@ -38,16 +38,14 @@ class HybridTestViewManager: SimpleViewManager<View>() {
   }
 
   override fun updateState(view: View, props: ReactStylesDiffMap, stateWrapper: StateWrapper): Any? {
-    // 1. Downcast state
-    val stateWrapperImpl = stateWrapper as? StateWrapperImpl ?: throw Error("StateWrapper uses a different implementation!")
     val hybridView = views[view] ?: throw Error("Couldn't find view $view in local views table!")
 
-    // 2. Update each prop individually
+    // 1. Update each prop individually
     hybridView.beforeUpdate()
-    HybridTestViewStateUpdater.updateViewProps(hybridView, stateWrapperImpl)
+    HybridTestViewStateUpdater.updateViewProps(hybridView, stateWrapper)
     hybridView.afterUpdate()
 
-    // 3. Continue in base View props
+    // 2. Continue in base View props
     return super.updateState(view, props, stateWrapper)
   }
 }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/views/HybridTestViewStateUpdater.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/views/HybridTestViewStateUpdater.kt
@@ -7,7 +7,7 @@
 
 package com.margelo.nitro.image.views
 
-import com.facebook.react.fabric.StateWrapperImpl
+import com.facebook.react.uimanager.StateWrapper
 import com.margelo.nitro.image.*
 
 internal class HybridTestViewStateUpdater {
@@ -18,6 +18,6 @@ internal class HybridTestViewStateUpdater {
      */
     @Suppress("KotlinJniMissingFunction")
     @JvmStatic
-    external fun updateViewProps(view: HybridTestViewSpec, state: StateWrapperImpl)
+    external fun updateViewProps(view: HybridTestViewSpec, state: StateWrapper)
   }
 }

--- a/packages/react-native-nitro-modules/android/CMakeLists.txt
+++ b/packages/react-native-nitro-modules/android/CMakeLists.txt
@@ -39,6 +39,7 @@ include_directories(
   src/main/cpp/turbomodule
   src/main/cpp/platform
   src/main/cpp/utils
+  src/main/cpp/views
 )
 
 # Find required libraries

--- a/packages/react-native-nitro-modules/android/src/main/cpp/views/JStateWrapper.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/views/JStateWrapper.hpp
@@ -1,0 +1,22 @@
+//
+// Created by Hanno Gödecke on 09.05.2025.
+//
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace margelo::nitro {
+
+    using namespace facebook;
+
+    /**
+     * C++ counterpart for the StateWrapper java class which is exposed in the fabric view manager implementation.
+     * Internally fabric is using StateWrapperImpl.kt but this class is hidden.
+     * We thus pass the StateWrapper typed object to the native side and on the c++ side we can cast it to a StateWrapperImpl type.
+     */
+    struct JStateWrapper : public jni::JavaClass<JStateWrapper> {
+        static constexpr auto kJavaDescriptor = "Lcom/facebook/react/uimanager/StateWrapper;";
+    };
+
+}

--- a/packages/react-native-nitro-modules/android/src/main/cpp/views/JStateWrapper.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/views/JStateWrapper.hpp
@@ -8,15 +8,15 @@
 
 namespace margelo::nitro {
 
-    using namespace facebook;
+using namespace facebook;
 
-    /**
-     * C++ counterpart for the StateWrapper java class which is exposed in the fabric view manager implementation.
-     * Internally fabric is using StateWrapperImpl.kt but this class is hidden.
-     * We thus pass the StateWrapper typed object to the native side and on the c++ side we can cast it to a StateWrapperImpl type.
-     */
-    struct JStateWrapper : public jni::JavaClass<JStateWrapper> {
-        static constexpr auto kJavaDescriptor = "Lcom/facebook/react/uimanager/StateWrapper;";
-    };
+/**
+ * C++ counterpart for the StateWrapper java class which is exposed in the fabric view manager implementation.
+ * Internally fabric is using StateWrapperImpl.kt but this class is hidden.
+ * We thus pass the StateWrapper typed object to the native side and on the c++ side we can cast it to a StateWrapperImpl type.
+ */
+struct JStateWrapper : public jni::JavaClass<JStateWrapper> {
+  static constexpr auto kJavaDescriptor = "Lcom/facebook/react/uimanager/StateWrapper;";
+};
 
-}
+} // namespace margelo::nitro


### PR DESCRIPTION
In RN 0.80 they made the `StateWrapperImpl.java` internal, which we relied on:

- https://github.com/facebook/react-native/commit/9f941c50c970e35ac6fcfa11848d1f7f5a0a9323

This solution doesn't use `StateWrapperImpl` on the java side anywhere, but just the public `StateWrapper` class (which is just an interface, but is part of the public API).
On the C++ side we then cast the `jobject` to the concrete `StateWrapperImpl` type which we know it should be.

The good thing is, is that this change is backwards compatible as well. It doesn't break anything for users that are not yet on RN 0.80.