### PR TITLE
feat: Add `Date` type

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -56,6 +56,13 @@ jobs:
           bundler-cache: true
           working-directory: example/ios
 
+      - name: Restore Pods cache
+        uses: actions/cache@v4
+        with:
+          path: example/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
       - name: Install Pods
         working-directory: example/ios
         run: pod install
@@ -96,6 +103,13 @@ jobs:
           bundler-cache: true
           working-directory: example/ios
 
+      - name: Restore Pods cache
+        uses: actions/cache@v4
+        with:
+          path: example/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
       - name: Install Pods
         working-directory: example/ios
         run: pod install

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -56,13 +56,6 @@ jobs:
           bundler-cache: true
           working-directory: example/ios
 
-      - name: Restore Pods cache
-        uses: actions/cache@v4
-        with:
-          path: example/ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
       - name: Install Pods
         working-directory: example/ios
         run: pod install
@@ -103,13 +96,6 @@ jobs:
           bundler-cache: true
           working-directory: example/ios
 
-      - name: Restore Pods cache
-        uses: actions/cache@v4
-        with:
-          path: example/ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
       - name: Install Pods
         working-directory: example/ios
         run: pod install

--- a/docs/docs/types/dates.md
+++ b/docs/docs/types/dates.md
@@ -1,0 +1,41 @@
+---
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Dates (`Date`)
+
+Dates are date and time instances that can be passed between JS and native.
+Under the hood, conversions take place using milliseconds, so it's essentially a wrapper around `numbers`.
+
+<Tabs>
+  <TabItem value="ts" label="TypeScript" default>
+    ```ts
+    interface Image extends HybridObject {
+      getCreationDate(): Date
+    }
+    ```
+  </TabItem>
+  <TabItem value="swift" label="Swift">
+    ```swift
+    class HybridImage: HybridImageSpec {
+      func getCreationDate() -> Date
+    }
+    ```
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+    ```kotlin
+    class HybridImage: HybridImageSpec() {
+      fun getCreationDate(): Instant
+    }
+    ```
+  </TabItem>
+  <TabItem value="cpp" label="C++">
+    ```cpp
+    class HybridImage: public HybridImageSpec {
+      std::chrono::system_clock::time_point getCreationDate();
+    }
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/types/types.md
+++ b/docs/docs/types/types.md
@@ -150,6 +150,12 @@ These are all the types Nitro supports out of the box:
     <td><code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt">ArrayBuffer</a></code></td>
   </tr>
   <tr>
+    <td><code>Date</code></td>
+    <td><code>std::chrono::system_clock::time_point</code></td>
+    <td><code>Date</code></td>
+    <td><code>java.time.Instant</code></td>
+  </tr>
+  <tr>
     <td>..any <code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/src/HybridObject.ts">HybridObject</a></code></td>
     <td><code>std::shared_ptr&lt;<a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp">HybridObject</a>&gt;</code></td>
     <td><code><a href="https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/ios/core/HybridObject.swift">HybridObject</a></code></td>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -57,6 +57,7 @@ const sidebars: SidebarsConfig = {
         'types/variants',
         'types/promises',
         'types/callbacks',
+        'types/dates',
         'types/typed-maps',
         'types/untyped-maps',
         'types/array-buffers',

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -2471,6 +2471,7 @@ These are all the types Nitro supports out of the box:
 | `Promise<T>` | `std::shared_ptr<Promise<T>>` | `Promise<T>` | `Promise<T>` |
 | `object` | `std::shared_ptr<AnyMap>` | `AnyMapHolder` | `AnyMap` |
 | `ArrayBuffer` | `std::shared_ptr<ArrayBuffer>` | `ArrayBufferHolder` | `ArrayBuffer` |
+| `Date` | `std::chrono::system_clock::time_point` | `Date` | `java.time.Instant` |
 | ..any `HybridObject` | `std::shared_ptr<HybridObject>` | `HybridObject` | `HybridObject` |
 | ..any `interface` | `T` | `T` | `T` |
 | ..any `enum` | `T` | `T` | `T` |

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -5,9 +5,9 @@ PODS:
   - FBLazyVector (0.78.2)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.78.0):
-    - hermes-engine/Pre-built (= 0.78.0)
-  - hermes-engine/Pre-built (0.78.0)
+  - hermes-engine (0.78.2):
+    - hermes-engine/Pre-built (= 0.78.2)
+  - hermes-engine/Pre-built (0.78.2)
   - NitroImage (0.25.2):
     - DoubleConversion
     - glog
@@ -1919,73 +1919,73 @@ SPEC CHECKSUMS:
   FBLazyVector: e32d34492c519a2194ec9d7f5e7a79d11b73f91c
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
-  NitroImage: 0a5d3fe67de9cef180e98d9c1455f8a6580d2402
-  NitroModules: 795b75234792e920c5aac1c6827080e852072548
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  hermes-engine: 2771b98fb813fdc6f92edd7c9c0035ecabf9fee7
+  NitroImage: 716d4153c455baf6b0599e3d90278735c115a111
+  NitroModules: cff9d855b511f091ee4e0f30fffb8efd606b4d80
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: be794de7dc6ed8f9f7fbf525f86e7651b8b68746
   RCTRequired: a83787b092ec554c2eb6019ff3f5b8d125472b3b
   RCTTypeSafety: 48ad3c858926b1c46f46a81a58822b476e178e2c
   React: 3b5754191f1b65f1dbc52fbea7959c3d2d9e39c9
   React-callinvoker: 6beeaf4c7db11b6cc953fac45f2c76e3fb125013
-  React-Core: 88e817c42de035378cc71e009193b9a044d3f595
-  React-CoreModules: dcf764d71efb4f75d38fcae8d4513b6729f49360
-  React-cxxreact: 8cdcc937c5fbc406fe843a381102fd69440ca78a
+  React-Core: 8a10ac9de53373a3ecb5dfcbcf56df1d3dad0861
+  React-CoreModules: af6999b35c7c01b0e12b59d27f3e054e13da43b1
+  React-cxxreact: 833f00155ce8c2fda17f6d286f8eaeff2ececc69
   React-debug: 440175830c448e7e53e61ebb8d8468c3256b645e
-  React-defaultsnativemodule: 4824bcd7b96ee2d75c28b1ca21f58976867f5535
-  React-domnativemodule: a421118b475618961cf282e8ea85347cc9bb453c
-  React-Fabric: 6ac7de06009eb96b609a770b17abba6e460b5f45
-  React-FabricComponents: e3bc2680a5a9a4917ff0c8d7f390688c30ef753c
-  React-FabricImage: 8bad558dec7478077974caa96acc79692d6b71f5
+  React-defaultsnativemodule: a970effe18fe50bdbbb7115c3297f873b666d0d4
+  React-domnativemodule: 45f886342a724e61531b18fba1859bb6782e5d62
+  React-Fabric: 69f1881f2177a8512304a64157943548ab6df0cf
+  React-FabricComponents: f54111c8e2439fc273ab07483e3a7054ca1e75af
+  React-FabricImage: 9ad2619dfe8c386d79e8aaa87da6e8f018ab9592
   React-featureflags: b9cf9b35baca1c7f20c06a104ffc325a02752faa
-  React-featureflagsnativemodule: dc93d81da9f41f7132e24455ec8b4b60802fd5b0
-  React-graphics: aaa5a38bea15d7b895b210d95d554af45a07002a
-  React-hermes: 08ad9fb832d1b9faef391be17309aa6a69fad23b
-  React-idlecallbacksnativemodule: aacea33ef6c511a9781f9286cc7cdf93f39bba14
-  React-ImageManager: c596c3b658c9c14607f9183ed0f635c8dd77987c
-  React-jserrorhandler: 987609b2f16b7d79d63fcd621bf0110dd7400b35
-  React-jsi: afa286d7e0c102c2478dc420d4f8935e13c973fc
-  React-jsiexecutor: 08f5b512b4db9e2f147416d60a0a797576b9cfef
-  React-jsinspector: 5a94bcae66e3637711c4d96a00038ab9ec935bf5
-  React-jsinspectortracing: a12589a0adbb2703cbc4380dabe9a58800810923
-  React-jsitracing: 0b1a403d7757cec66b7dd8b308d04db85eef75f3
-  React-logger: 304814ae37503c8eb54359851cc55bd4f936b39c
-  React-Mapbuffer: b588d1ca18d2ce626f868f04ab12d8b1f004f12c
-  React-microtasksnativemodule: 11831d070aa47755bb5739069eb04ec621fec548
-  react-native-safe-area-context: 9b169299f9dc95f1d7fe1dd266fde53bd899cd0c
-  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
-  React-NativeModulesApple: 79a4404ac301b40bec3b367879c5e9a9ce81683c
-  React-perflogger: 0ea25c109dba33d47dec36b2634bf7ea67c1a555
-  React-performancetimeline: f74480de6efbcd8541c34317c0baedb433f27296
+  React-featureflagsnativemodule: 7f1bc76d1d2c5bede5e753b8d188dbde7c59b12f
+  React-graphics: 069e0d0b31ed1e80feb023ad4f7e97f00e84f7b9
+  React-hermes: 63df5ac5a944889c8758a6213b39ed825863adb7
+  React-idlecallbacksnativemodule: 4c700bd7c0012adf904929075a79418b828b5ffc
+  React-ImageManager: 5d1ba8a7bae44ebba43fc93da64937c713d42941
+  React-jserrorhandler: 0defd58f8bb797cdd0a820f733bf42d8bee708ce
+  React-jsi: 99d6207ec802ad73473a0dad3c9ad48cd98463f6
+  React-jsiexecutor: 8c8097b4ba7e7f480582d6e6238b01be5dcc01c0
+  React-jsinspector: ea148ec45bc7ff830e443383ea715f9780c15934
+  React-jsinspectortracing: 46bb2841982f01e7b63eaab98140fa1de5b2a1db
+  React-jsitracing: c1063fc2233960d1c8322291e74bca51d25c10d7
+  React-logger: 763728cf4eebc9c5dc9bfc3649e22295784f69f3
+  React-Mapbuffer: 63278529b5cf531a7eaf8fc71244fabb062ca90c
+  React-microtasksnativemodule: 6a39463c32ce831c4c2aa8469273114d894b6be9
+  react-native-safe-area-context: afcc2e2b3e78ae8ef90d81e658aacee34ebc27ea
+  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
+  React-NativeModulesApple: fd0545efbb7f936f78edd15a6564a72d2c34bb32
+  React-perflogger: 5f8fa36a8e168fb355efe72099efe77213bc2ac6
+  React-performancetimeline: 8c0ecfa1ae459cc5678a65f95ac3bf85644d6feb
   React-RCTActionSheet: 2ef95837e89b9b154f13cd8401f9054fc3076aff
-  React-RCTAnimation: 33d960d7f58a81779eea6dea47ad0364c67e1517
-  React-RCTAppDelegate: 85c13403fd6f6b6cc630428d52bd8bd76a670dc9
-  React-RCTBlob: 74c986a02d951931d2f6ed0e07ed5a7eb385bfc0
-  React-RCTFabric: 384a8fea4f22fc0f21299d771971862883ba630a
-  React-RCTFBReactNativeSpec: eb1c3ec5149f76133593a516ff9d5efe32ebcecd
-  React-RCTImage: 2c58b5ddeb3c65e52f942bbe13ff9c59bd649b09
-  React-RCTLinking: b6b14f8a3e62c02fc627ac4f3fb0c7bd941f907c
-  React-RCTNetwork: 1d050f2466c1541b339587d46f78d5eee218d626
-  React-RCTSettings: 8148f6be0ccc0cfe6e313417ebf8a479caaa2146
-  React-RCTText: 64114531ad1359e4e02a4a8af60df606dbbabc25
-  React-RCTVibration: f4859417a7dd859b6bf18b1aba897e52beb72ef6
+  React-RCTAnimation: 46abefd5acfda7e6629f9e153646deecc70babd2
+  React-RCTAppDelegate: 7e58e0299e304cceee3f7019fa77bc6990f66b22
+  React-RCTBlob: f68c63a801ef1d27e83c4011e3b083cc86a200d7
+  React-RCTFabric: c59f41d0c4edbaac8baa232731ca09925ae4dda7
+  React-RCTFBReactNativeSpec: 3240b9b8d792aa4be0fb85c9898fc183125ba8de
+  React-RCTImage: 34e0bba1507e55f1c614bd759eb91d9be48c8c5b
+  React-RCTLinking: a0b6c9f4871c18b0b81ea952f43e752718bd5f1d
+  React-RCTNetwork: bdafd661ac2b20d23b779e45bf7ac3e4c8bd1b60
+  React-RCTSettings: 98aa5163796f43789314787b584a84eba47787a9
+  React-RCTText: 424a274fc9015b29de89cf3cbcdf4dd85dd69f83
+  React-RCTVibration: 92d9875a955b0adb34b4b773528fdbbbc5addd6c
   React-rendererconsistency: 5ac4164ec18cfdd76ed5f864dbfdc56a5a948bc9
-  React-rendererdebug: 3dc1d97bbee0c0c13191e501a96ed9325bbd920e
+  React-rendererdebug: 710dbd7990e355852c786aa6bc7753f6028f357a
   React-rncore: 0bace3b991d8843bb5b57c5f2301ec6e9c94718b
-  React-RuntimeApple: 1e1e0a0c6086bc8c3b07e8f1a2f6ca99b50419a0
-  React-RuntimeCore: d39322c59bef2a4b343fda663d20649f29f57fcc
+  React-RuntimeApple: 701ec44a8b5d863ee9b6a2b2447b6a26bb6805a1
+  React-RuntimeCore: a82767065b9a936b05e209dc6987bc1ea9eb5d2d
   React-runtimeexecutor: 876dfc1d8daa819dfd039c40f78f277c5a3e66a6
-  React-RuntimeHermes: 44f5f2baf039f249b31ea4f3e224484fd1731e0e
-  React-runtimescheduler: 3b3c5b50743bb8743ca49b9e5a70c2c385f156e1
+  React-RuntimeHermes: e7a051fd91cab8849df56ac917022ef6064ad621
+  React-runtimescheduler: c544141f2124ee3d5f3d5bf0d69f4029a61a68b0
   React-timing: 1ee3572c398f5579c9df5bf76aacddf5683ff74e
-  React-utils: 0cfb7c7fb37d4e5f31cc18ffc7426be0ae6bf907
-  ReactAppDependencyProvider: b48473fe434569ff8f6cb6ed4421217ebcbda878
-  ReactCodegen: 5ba804f56e4f9249bb7c20a37219df2bb3e9b783
-  ReactCommon: 547db015202a80a5b3e7e041586ea54c4a087180
-  RNScreens: 0f01bbed9bd8045a8d58e4b46993c28c7f498f3c
+  React-utils: 18703928768cb37e70cf2efff09def12d74a399e
+  ReactAppDependencyProvider: 4893bde33952f997a323eb1a1ee87a72764018ff
+  ReactCodegen: 284a640cafd1e9928d84d81865be7fd80a6d0098
+  ReactCommon: 865ebe76504a95e115b6229dd00a31e56d2d4bfe
+  RNScreens: 790123c4a28783d80a342ce42e8c7381bed62db1
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 66a9a23a82dd4081b393babe509967097759b3d6
+  Yoga: e14bad835e12b6c7e2260fc320bd00e0f4b45add
 
 PODFILE CHECKSUM: 205a5dcc178bd52bc8f2d549f38ecbb697373aaf
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
-  - FBLazyVector (0.78.0)
+  - FBLazyVector (0.78.2)
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.78.0):
@@ -74,32 +74,32 @@ PODS:
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.78.0)
-  - RCTRequired (0.78.0)
-  - RCTTypeSafety (0.78.0):
-    - FBLazyVector (= 0.78.0)
-    - RCTRequired (= 0.78.0)
-    - React-Core (= 0.78.0)
-  - React (0.78.0):
-    - React-Core (= 0.78.0)
-    - React-Core/DevSupport (= 0.78.0)
-    - React-Core/RCTWebSocket (= 0.78.0)
-    - React-RCTActionSheet (= 0.78.0)
-    - React-RCTAnimation (= 0.78.0)
-    - React-RCTBlob (= 0.78.0)
-    - React-RCTImage (= 0.78.0)
-    - React-RCTLinking (= 0.78.0)
-    - React-RCTNetwork (= 0.78.0)
-    - React-RCTSettings (= 0.78.0)
-    - React-RCTText (= 0.78.0)
-    - React-RCTVibration (= 0.78.0)
-  - React-callinvoker (0.78.0)
-  - React-Core (0.78.0):
+  - RCTDeprecation (0.78.2)
+  - RCTRequired (0.78.2)
+  - RCTTypeSafety (0.78.2):
+    - FBLazyVector (= 0.78.2)
+    - RCTRequired (= 0.78.2)
+    - React-Core (= 0.78.2)
+  - React (0.78.2):
+    - React-Core (= 0.78.2)
+    - React-Core/DevSupport (= 0.78.2)
+    - React-Core/RCTWebSocket (= 0.78.2)
+    - React-RCTActionSheet (= 0.78.2)
+    - React-RCTAnimation (= 0.78.2)
+    - React-RCTBlob (= 0.78.2)
+    - React-RCTImage (= 0.78.2)
+    - React-RCTLinking (= 0.78.2)
+    - React-RCTNetwork (= 0.78.2)
+    - React-RCTSettings (= 0.78.2)
+    - React-RCTText (= 0.78.2)
+    - React-RCTVibration (= 0.78.2)
+  - React-callinvoker (0.78.2)
+  - React-Core (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.78.0)
+    - React-Core/Default (= 0.78.2)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -111,58 +111,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.78.0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/Default (0.78.0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/DevSupport (0.78.0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.78.0)
-    - React-Core/RCTWebSocket (= 0.78.0)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.78.0):
+  - React-Core/CoreModulesHeaders (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -179,7 +128,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.78.0):
+  - React-Core/Default (0.78.2):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/DevSupport (0.78.2):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.78.2)
+    - React-Core/RCTWebSocket (= 0.78.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -196,7 +179,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.78.0):
+  - React-Core/RCTAnimationHeaders (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -213,7 +196,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.78.0):
+  - React-Core/RCTBlobHeaders (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -230,7 +213,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.78.0):
+  - React-Core/RCTImageHeaders (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -247,7 +230,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.78.0):
+  - React-Core/RCTLinkingHeaders (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -264,7 +247,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.78.0):
+  - React-Core/RCTNetworkHeaders (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -281,7 +264,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.78.0):
+  - React-Core/RCTSettingsHeaders (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -298,7 +281,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.78.0):
+  - React-Core/RCTTextHeaders (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -315,12 +298,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.78.0):
+  - React-Core/RCTVibrationHeaders (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.78.0)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -332,22 +315,39 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-CoreModules (0.78.0):
+  - React-Core/RCTWebSocket (0.78.2):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.78.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-CoreModules (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
-    - RCTTypeSafety (= 0.78.0)
-    - React-Core/CoreModulesHeaders (= 0.78.0)
-    - React-jsi (= 0.78.0)
+    - RCTTypeSafety (= 0.78.2)
+    - React-Core/CoreModulesHeaders (= 0.78.2)
+    - React-jsi (= 0.78.2)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.78.0)
+    - React-RCTImage (= 0.78.2)
     - ReactCommon
     - SocketRocket (= 0.7.1)
-  - React-cxxreact (0.78.0):
+  - React-cxxreact (0.78.2):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -355,16 +355,16 @@ PODS:
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.78.0)
-    - React-debug (= 0.78.0)
-    - React-jsi (= 0.78.0)
+    - React-callinvoker (= 0.78.2)
+    - React-debug (= 0.78.2)
+    - React-jsi (= 0.78.2)
     - React-jsinspector
-    - React-logger (= 0.78.0)
-    - React-perflogger (= 0.78.0)
-    - React-runtimeexecutor (= 0.78.0)
-    - React-timing (= 0.78.0)
-  - React-debug (0.78.0)
-  - React-defaultsnativemodule (0.78.0):
+    - React-logger (= 0.78.2)
+    - React-perflogger (= 0.78.2)
+    - React-runtimeexecutor (= 0.78.2)
+    - React-timing (= 0.78.2)
+  - React-debug (0.78.2)
+  - React-defaultsnativemodule (0.78.2):
     - hermes-engine
     - RCT-Folly
     - React-domnativemodule
@@ -374,7 +374,7 @@ PODS:
     - React-jsiexecutor
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
-  - React-domnativemodule (0.78.0):
+  - React-domnativemodule (0.78.2):
     - hermes-engine
     - RCT-Folly
     - React-Fabric
@@ -385,7 +385,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.78.0):
+  - React-Fabric (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -397,22 +397,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.78.0)
-    - React-Fabric/attributedstring (= 0.78.0)
-    - React-Fabric/componentregistry (= 0.78.0)
-    - React-Fabric/componentregistrynative (= 0.78.0)
-    - React-Fabric/components (= 0.78.0)
-    - React-Fabric/consistency (= 0.78.0)
-    - React-Fabric/core (= 0.78.0)
-    - React-Fabric/dom (= 0.78.0)
-    - React-Fabric/imagemanager (= 0.78.0)
-    - React-Fabric/leakchecker (= 0.78.0)
-    - React-Fabric/mounting (= 0.78.0)
-    - React-Fabric/observers (= 0.78.0)
-    - React-Fabric/scheduler (= 0.78.0)
-    - React-Fabric/telemetry (= 0.78.0)
-    - React-Fabric/templateprocessor (= 0.78.0)
-    - React-Fabric/uimanager (= 0.78.0)
+    - React-Fabric/animations (= 0.78.2)
+    - React-Fabric/attributedstring (= 0.78.2)
+    - React-Fabric/componentregistry (= 0.78.2)
+    - React-Fabric/componentregistrynative (= 0.78.2)
+    - React-Fabric/components (= 0.78.2)
+    - React-Fabric/consistency (= 0.78.2)
+    - React-Fabric/core (= 0.78.2)
+    - React-Fabric/dom (= 0.78.2)
+    - React-Fabric/imagemanager (= 0.78.2)
+    - React-Fabric/leakchecker (= 0.78.2)
+    - React-Fabric/mounting (= 0.78.2)
+    - React-Fabric/observers (= 0.78.2)
+    - React-Fabric/scheduler (= 0.78.2)
+    - React-Fabric/telemetry (= 0.78.2)
+    - React-Fabric/templateprocessor (= 0.78.2)
+    - React-Fabric/uimanager (= 0.78.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -422,28 +422,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.78.0):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.78.0):
+  - React-Fabric/animations (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -464,7 +443,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.78.0):
+  - React-Fabric/attributedstring (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -485,7 +464,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.78.0):
+  - React-Fabric/componentregistry (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -506,31 +485,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.78.0):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.78.0)
-    - React-Fabric/components/root (= 0.78.0)
-    - React-Fabric/components/view (= 0.78.0)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.78.0):
+  - React-Fabric/componentregistrynative (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -551,7 +506,31 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.78.0):
+  - React-Fabric/components (0.78.2):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.78.2)
+    - React-Fabric/components/root (= 0.78.2)
+    - React-Fabric/components/view (= 0.78.2)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/legacyviewmanagerinterop (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -572,7 +551,28 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.78.0):
+  - React-Fabric/components/root (0.78.2):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -594,7 +594,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/consistency (0.78.0):
+  - React-Fabric/consistency (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -615,7 +615,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/core (0.78.0):
+  - React-Fabric/core (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -636,7 +636,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.78.0):
+  - React-Fabric/dom (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -657,7 +657,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.78.0):
+  - React-Fabric/imagemanager (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -678,7 +678,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.78.0):
+  - React-Fabric/leakchecker (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -699,7 +699,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.78.0):
+  - React-Fabric/mounting (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -720,7 +720,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.78.0):
+  - React-Fabric/observers (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -732,7 +732,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.78.0)
+    - React-Fabric/observers/events (= 0.78.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -742,7 +742,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.78.0):
+  - React-Fabric/observers/events (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -763,7 +763,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.78.0):
+  - React-Fabric/scheduler (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -786,7 +786,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.78.0):
+  - React-Fabric/telemetry (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -807,7 +807,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.78.0):
+  - React-Fabric/templateprocessor (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -828,7 +828,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.78.0):
+  - React-Fabric/uimanager (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -840,29 +840,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.78.0)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.78.0):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.78.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -873,7 +851,29 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.78.0):
+  - React-Fabric/uimanager/consistency (0.78.2):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -886,8 +886,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.78.0)
-    - React-FabricComponents/textlayoutmanager (= 0.78.0)
+    - React-FabricComponents/components (= 0.78.2)
+    - React-FabricComponents/textlayoutmanager (= 0.78.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -898,7 +898,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.78.0):
+  - React-FabricComponents/components (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -911,15 +911,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.78.0)
-    - React-FabricComponents/components/iostextinput (= 0.78.0)
-    - React-FabricComponents/components/modal (= 0.78.0)
-    - React-FabricComponents/components/rncore (= 0.78.0)
-    - React-FabricComponents/components/safeareaview (= 0.78.0)
-    - React-FabricComponents/components/scrollview (= 0.78.0)
-    - React-FabricComponents/components/text (= 0.78.0)
-    - React-FabricComponents/components/textinput (= 0.78.0)
-    - React-FabricComponents/components/unimplementedview (= 0.78.0)
+    - React-FabricComponents/components/inputaccessory (= 0.78.2)
+    - React-FabricComponents/components/iostextinput (= 0.78.2)
+    - React-FabricComponents/components/modal (= 0.78.2)
+    - React-FabricComponents/components/rncore (= 0.78.2)
+    - React-FabricComponents/components/safeareaview (= 0.78.2)
+    - React-FabricComponents/components/scrollview (= 0.78.2)
+    - React-FabricComponents/components/text (= 0.78.2)
+    - React-FabricComponents/components/textinput (= 0.78.2)
+    - React-FabricComponents/components/unimplementedview (= 0.78.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -930,53 +930,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.78.0):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.78.0):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.78.0):
+  - React-FabricComponents/components/inputaccessory (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -999,7 +953,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.78.0):
+  - React-FabricComponents/components/iostextinput (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1022,7 +976,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.78.0):
+  - React-FabricComponents/components/modal (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1045,7 +999,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.78.0):
+  - React-FabricComponents/components/rncore (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1068,7 +1022,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.78.0):
+  - React-FabricComponents/components/safeareaview (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1091,7 +1045,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.78.0):
+  - React-FabricComponents/components/scrollview (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1114,7 +1068,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.78.0):
+  - React-FabricComponents/components/text (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1137,7 +1091,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.78.0):
+  - React-FabricComponents/components/textinput (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1160,29 +1114,75 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.78.0):
+  - React-FabricComponents/components/unimplementedview (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired (= 0.78.0)
-    - RCTTypeSafety (= 0.78.0)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.78.2):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.78.2):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired (= 0.78.2)
+    - RCTTypeSafety (= 0.78.2)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.78.0)
+    - React-jsiexecutor (= 0.78.2)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.78.0):
+  - React-featureflags (0.78.2):
     - RCT-Folly (= 2024.11.18.00)
-  - React-featureflagsnativemodule (0.78.0):
+  - React-featureflagsnativemodule (0.78.2):
     - hermes-engine
     - RCT-Folly
     - React-featureflags
@@ -1190,7 +1190,7 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - React-graphics (0.78.0):
+  - React-graphics (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1200,20 +1200,20 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-hermes (0.78.0):
+  - React-hermes (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.78.0)
+    - React-cxxreact (= 0.78.2)
     - React-jsi
-    - React-jsiexecutor (= 0.78.0)
+    - React-jsiexecutor (= 0.78.2)
     - React-jsinspector
-    - React-perflogger (= 0.78.0)
+    - React-perflogger (= 0.78.2)
     - React-runtimeexecutor
-  - React-idlecallbacksnativemodule (0.78.0):
+  - React-idlecallbacksnativemodule (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly
@@ -1222,7 +1222,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
-  - React-ImageManager (0.78.0):
+  - React-ImageManager (0.78.2):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1231,7 +1231,7 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.78.0):
+  - React-jserrorhandler (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1240,7 +1240,7 @@ PODS:
     - React-featureflags
     - React-jsi
     - ReactCommon/turbomodule/bridging
-  - React-jsi (0.78.0):
+  - React-jsi (0.78.2):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -1248,18 +1248,18 @@ PODS:
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-  - React-jsiexecutor (0.78.0):
+  - React-jsiexecutor (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.78.0)
-    - React-jsi (= 0.78.0)
+    - React-cxxreact (= 0.78.2)
+    - React-jsi (= 0.78.2)
     - React-jsinspector
-    - React-perflogger (= 0.78.0)
-  - React-jsinspector (0.78.0):
+    - React-perflogger (= 0.78.2)
+  - React-jsinspector (0.78.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1267,25 +1267,25 @@ PODS:
     - React-featureflags
     - React-jsi
     - React-jsinspectortracing
-    - React-perflogger (= 0.78.0)
-    - React-runtimeexecutor (= 0.78.0)
-  - React-jsinspectortracing (0.78.0):
+    - React-perflogger (= 0.78.2)
+    - React-runtimeexecutor (= 0.78.2)
+  - React-jsinspectortracing (0.78.2):
     - RCT-Folly
-  - React-jsitracing (0.78.0):
+  - React-jsitracing (0.78.2):
     - React-jsi
-  - React-logger (0.78.0):
+  - React-logger (0.78.2):
     - glog
-  - React-Mapbuffer (0.78.0):
+  - React-Mapbuffer (0.78.2):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.78.0):
+  - React-microtasksnativemodule (0.78.2):
     - hermes-engine
     - RCT-Folly
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - react-native-safe-area-context (5.2.0):
+  - react-native-safe-area-context (5.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1298,8 +1298,8 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-safe-area-context/common (= 5.2.0)
-    - react-native-safe-area-context/fabric (= 5.2.0)
+    - react-native-safe-area-context/common (= 5.4.0)
+    - react-native-safe-area-context/fabric (= 5.4.0)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1308,7 +1308,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/common (5.2.0):
+  - react-native-safe-area-context/common (5.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1329,7 +1329,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/fabric (5.2.0):
+  - react-native-safe-area-context/fabric (5.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1353,7 +1353,7 @@ PODS:
     - Yoga
   - react-native-segmented-control (2.5.7):
     - React-Core
-  - React-NativeModulesApple (0.78.0):
+  - React-NativeModulesApple (0.78.2):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -1364,18 +1364,18 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.78.0):
+  - React-perflogger (0.78.2):
     - DoubleConversion
     - RCT-Folly (= 2024.11.18.00)
-  - React-performancetimeline (0.78.0):
+  - React-performancetimeline (0.78.2):
     - RCT-Folly (= 2024.11.18.00)
     - React-cxxreact
     - React-featureflags
     - React-jsinspectortracing
     - React-timing
-  - React-RCTActionSheet (0.78.0):
-    - React-Core/RCTActionSheetHeaders (= 0.78.0)
-  - React-RCTAnimation (0.78.0):
+  - React-RCTActionSheet (0.78.2):
+    - React-Core/RCTActionSheetHeaders (= 0.78.2)
+  - React-RCTAnimation (0.78.2):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -1383,7 +1383,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTAppDelegate (0.78.0):
+  - React-RCTAppDelegate (0.78.2):
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1407,7 +1407,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon
-  - React-RCTBlob (0.78.0):
+  - React-RCTBlob (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1421,7 +1421,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.78.0):
+  - React-RCTFabric (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1444,7 +1444,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTFBReactNativeSpec (0.78.0):
+  - React-RCTFBReactNativeSpec (0.78.2):
     - hermes-engine
     - RCT-Folly
     - RCTRequired
@@ -1454,7 +1454,7 @@ PODS:
     - React-jsiexecutor
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTImage (0.78.0):
+  - React-RCTImage (0.78.2):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -1463,14 +1463,14 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.78.0):
-    - React-Core/RCTLinkingHeaders (= 0.78.0)
-    - React-jsi (= 0.78.0)
+  - React-RCTLinking (0.78.2):
+    - React-Core/RCTLinkingHeaders (= 0.78.2)
+    - React-jsi (= 0.78.2)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.78.0)
-  - React-RCTNetwork (0.78.0):
+    - ReactCommon/turbomodule/core (= 0.78.2)
+  - React-RCTNetwork (0.78.2):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -1478,7 +1478,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTSettings (0.78.0):
+  - React-RCTSettings (0.78.2):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -1486,25 +1486,25 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTText (0.78.0):
-    - React-Core/RCTTextHeaders (= 0.78.0)
+  - React-RCTText (0.78.2):
+    - React-Core/RCTTextHeaders (= 0.78.2)
     - Yoga
-  - React-RCTVibration (0.78.0):
+  - React-RCTVibration (0.78.2):
     - RCT-Folly (= 2024.11.18.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-rendererconsistency (0.78.0)
-  - React-rendererdebug (0.78.0):
+  - React-rendererconsistency (0.78.2)
+  - React-rendererdebug (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
-  - React-rncore (0.78.0)
-  - React-RuntimeApple (0.78.0):
+  - React-rncore (0.78.2)
+  - React-RuntimeApple (0.78.2):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-callinvoker
@@ -1525,7 +1525,7 @@ PODS:
     - React-RuntimeHermes
     - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.78.0):
+  - React-RuntimeCore (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1540,9 +1540,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.78.0):
-    - React-jsi (= 0.78.0)
-  - React-RuntimeHermes (0.78.0):
+  - React-runtimeexecutor (0.78.2):
+    - React-jsi (= 0.78.2)
+  - React-RuntimeHermes (0.78.2):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-featureflags
@@ -1552,7 +1552,7 @@ PODS:
     - React-jsitracing
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.78.0):
+  - React-runtimescheduler (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -1567,16 +1567,16 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - React-utils
-  - React-timing (0.78.0)
-  - React-utils (0.78.0):
+  - React-timing (0.78.2)
+  - React-utils (0.78.2):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
-    - React-jsi (= 0.78.0)
-  - ReactAppDependencyProvider (0.78.0):
+    - React-jsi (= 0.78.2)
+  - ReactAppDependencyProvider (0.78.2):
     - ReactCodegen
-  - ReactCodegen (0.78.0):
+  - ReactCodegen (0.78.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1597,50 +1597,50 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.78.0):
-    - ReactCommon/turbomodule (= 0.78.0)
-  - ReactCommon/turbomodule (0.78.0):
+  - ReactCommon (0.78.2):
+    - ReactCommon/turbomodule (= 0.78.2)
+  - ReactCommon/turbomodule (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.78.0)
-    - React-cxxreact (= 0.78.0)
-    - React-jsi (= 0.78.0)
-    - React-logger (= 0.78.0)
-    - React-perflogger (= 0.78.0)
-    - ReactCommon/turbomodule/bridging (= 0.78.0)
-    - ReactCommon/turbomodule/core (= 0.78.0)
-  - ReactCommon/turbomodule/bridging (0.78.0):
+    - React-callinvoker (= 0.78.2)
+    - React-cxxreact (= 0.78.2)
+    - React-jsi (= 0.78.2)
+    - React-logger (= 0.78.2)
+    - React-perflogger (= 0.78.2)
+    - ReactCommon/turbomodule/bridging (= 0.78.2)
+    - ReactCommon/turbomodule/core (= 0.78.2)
+  - ReactCommon/turbomodule/bridging (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.78.0)
-    - React-cxxreact (= 0.78.0)
-    - React-jsi (= 0.78.0)
-    - React-logger (= 0.78.0)
-    - React-perflogger (= 0.78.0)
-  - ReactCommon/turbomodule/core (0.78.0):
+    - React-callinvoker (= 0.78.2)
+    - React-cxxreact (= 0.78.2)
+    - React-jsi (= 0.78.2)
+    - React-logger (= 0.78.2)
+    - React-perflogger (= 0.78.2)
+  - ReactCommon/turbomodule/core (0.78.2):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.78.0)
-    - React-cxxreact (= 0.78.0)
-    - React-debug (= 0.78.0)
-    - React-featureflags (= 0.78.0)
-    - React-jsi (= 0.78.0)
-    - React-logger (= 0.78.0)
-    - React-perflogger (= 0.78.0)
-    - React-utils (= 0.78.0)
-  - RNScreens (4.9.0-beta.0):
+    - React-callinvoker (= 0.78.2)
+    - React-cxxreact (= 0.78.2)
+    - React-debug (= 0.78.2)
+    - React-featureflags (= 0.78.2)
+    - React-jsi (= 0.78.2)
+    - React-logger (= 0.78.2)
+    - React-perflogger (= 0.78.2)
+    - React-utils (= 0.78.2)
+  - RNScreens (4.10.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1661,9 +1661,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.9.0-beta.0)
+    - RNScreens/common (= 4.10.0)
     - Yoga
-  - RNScreens/common (4.9.0-beta.0):
+  - RNScreens/common (4.10.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1916,75 +1916,75 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
-  FBLazyVector: 6fe148afcef2e3213e484758e3459609d40d57f5
+  FBLazyVector: e32d34492c519a2194ec9d7f5e7a79d11b73f91c
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
   NitroImage: 0a5d3fe67de9cef180e98d9c1455f8a6580d2402
   NitroModules: 6cad985fa4a6efaf567fe5c9aa464bce17e2d0cc
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
-  RCTDeprecation: b2eecf2d60216df56bc5e6be5f063826d3c1ee35
-  RCTRequired: 78522de7dc73b81f3ed7890d145fa341f5bb32ea
-  RCTTypeSafety: c135dd2bf50402d87fd12884cbad5d5e64850edd
-  React: b229c49ed5898dab46d60f61ed5a0bfa2ee2fadb
-  React-callinvoker: 2ac508e92c8bd9cf834cc7d7787d94352e4af58f
-  React-Core: 13cdd1558d0b3f6d9d5a22e14d89150280e79f02
-  React-CoreModules: b07a6744f48305405e67c845ebf481b6551b712a
-  React-cxxreact: 1055a86c66ac35b4e80bd5fb766aed5f494dfff4
-  React-debug: 0a5fcdbacc6becba0521e910c1bcfdb20f32a3f6
-  React-defaultsnativemodule: 4bb28fc97fee5be63a9ebf8f7a435cfe8ba69459
-  React-domnativemodule: b36a11c2597243d7563985028c51ece988d8ae33
-  React-Fabric: afc561718f25b2cd800b709d934101afe376a12c
-  React-FabricComponents: f4e0a4e18a27bf6d39cbf2a0b42f37a92fa4e37f
-  React-FabricImage: 37d8e8b672eda68a19d71143eb65148084efb325
-  React-featureflags: 19682e02ef5861d96b992af16a19109c3dfc1200
-  React-featureflagsnativemodule: d7cddf6d907b4e5ab84f9e744b7e88461656e48c
-  React-graphics: b0f78580cdaf5800d25437e3d41cc6c3d83b7aea
-  React-hermes: 71186f872c932e4574d5feb3ed754dda63a0b3bd
-  React-idlecallbacksnativemodule: dd2af19cdd3bc55149d17a2409ed72b694dfbe9c
-  React-ImageManager: a77dde8d5aa6a2b6962c702bf3a47695ef0aa32b
-  React-jserrorhandler: 9c14e89f12d5904257a79aaf84a70cd2e5ac07ba
-  React-jsi: 0775a66820496769ad83e629f0f5cce621a57fc7
-  React-jsiexecutor: 2cf5ba481386803f3c88b85c63fa102cba5d769e
-  React-jsinspector: 8052d532bb7a98b6e021755674659802fb140cc5
-  React-jsinspectortracing: bdd8fd0adcb4813663562e7874c5842449df6d8a
-  React-jsitracing: 2bab3bf55de3d04baf205def375fa6643c47c794
-  React-logger: 795cd5055782db394f187f9db0477d4b25b44291
-  React-Mapbuffer: 0502faf46cab8fb89cfc7bf3e6c6109b6ef9b5de
-  React-microtasksnativemodule: 663bc64e3a96c5fc91081923ae7481adc1359a78
-  react-native-safe-area-context: 9c33120e9eac7741a5364cc2d9f74665049b76b3
+  RCTDeprecation: be794de7dc6ed8f9f7fbf525f86e7651b8b68746
+  RCTRequired: a83787b092ec554c2eb6019ff3f5b8d125472b3b
+  RCTTypeSafety: 48ad3c858926b1c46f46a81a58822b476e178e2c
+  React: 3b5754191f1b65f1dbc52fbea7959c3d2d9e39c9
+  React-callinvoker: 6beeaf4c7db11b6cc953fac45f2c76e3fb125013
+  React-Core: 88e817c42de035378cc71e009193b9a044d3f595
+  React-CoreModules: dcf764d71efb4f75d38fcae8d4513b6729f49360
+  React-cxxreact: 8cdcc937c5fbc406fe843a381102fd69440ca78a
+  React-debug: 440175830c448e7e53e61ebb8d8468c3256b645e
+  React-defaultsnativemodule: 4824bcd7b96ee2d75c28b1ca21f58976867f5535
+  React-domnativemodule: a421118b475618961cf282e8ea85347cc9bb453c
+  React-Fabric: 6ac7de06009eb96b609a770b17abba6e460b5f45
+  React-FabricComponents: e3bc2680a5a9a4917ff0c8d7f390688c30ef753c
+  React-FabricImage: 8bad558dec7478077974caa96acc79692d6b71f5
+  React-featureflags: b9cf9b35baca1c7f20c06a104ffc325a02752faa
+  React-featureflagsnativemodule: dc93d81da9f41f7132e24455ec8b4b60802fd5b0
+  React-graphics: aaa5a38bea15d7b895b210d95d554af45a07002a
+  React-hermes: 08ad9fb832d1b9faef391be17309aa6a69fad23b
+  React-idlecallbacksnativemodule: aacea33ef6c511a9781f9286cc7cdf93f39bba14
+  React-ImageManager: c596c3b658c9c14607f9183ed0f635c8dd77987c
+  React-jserrorhandler: 987609b2f16b7d79d63fcd621bf0110dd7400b35
+  React-jsi: afa286d7e0c102c2478dc420d4f8935e13c973fc
+  React-jsiexecutor: 08f5b512b4db9e2f147416d60a0a797576b9cfef
+  React-jsinspector: 5a94bcae66e3637711c4d96a00038ab9ec935bf5
+  React-jsinspectortracing: a12589a0adbb2703cbc4380dabe9a58800810923
+  React-jsitracing: 0b1a403d7757cec66b7dd8b308d04db85eef75f3
+  React-logger: 304814ae37503c8eb54359851cc55bd4f936b39c
+  React-Mapbuffer: b588d1ca18d2ce626f868f04ab12d8b1f004f12c
+  React-microtasksnativemodule: 11831d070aa47755bb5739069eb04ec621fec548
+  react-native-safe-area-context: 9b169299f9dc95f1d7fe1dd266fde53bd899cd0c
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
-  React-NativeModulesApple: 16fbd5b040ff6c492dacc361d49e63cba7a6a7a1
-  React-perflogger: ab51b7592532a0ea45bf6eed7e6cae14a368b678
-  React-performancetimeline: bc2e48198ec814d578ac8401f65d78a574358203
-  React-RCTActionSheet: 592674cf61142497e0e820688f5a696e41bf16dd
-  React-RCTAnimation: 8fbb8dba757b49c78f4db403133ab6399a4ce952
-  React-RCTAppDelegate: 7f88baa8cb4e5d6c38bb4d84339925c70c9ac864
-  React-RCTBlob: f89b162d0fe6b570a18e755eb16cbe356d3c6d17
-  React-RCTFabric: 8ad6d875abe6e87312cef90e4b15ef7f6bed72e6
-  React-RCTFBReactNativeSpec: 8c29630c2f379c729300e4c1e540f3d1b78d1936
-  React-RCTImage: ccac9969940f170503857733f9a5f63578e106e1
-  React-RCTLinking: d82427bbf18415a3732105383dff119131cadd90
-  React-RCTNetwork: 12ad4d0fbde939e00251ca5ca890da2e6825cc3c
-  React-RCTSettings: e7865bf9f455abf427da349c855f8644b5c39afa
-  React-RCTText: 2cdfd88745059ec3202a0842ea75a956c7d6f27d
-  React-RCTVibration: a3a1458e6230dfd64b3768ebc0a4aac430d9d508
-  React-rendererconsistency: 64e897e00d2568fd8dfe31e2496f80e85c0aaad1
-  React-rendererdebug: a3f6d3ae7d2fa0035885026756281c07ee32479e
-  React-rncore: 58748c2aa445f56b99e5118dad0aedb51c40ce9f
-  React-RuntimeApple: f0fda7bacabd32daa099cfda8f07466c30acd149
-  React-RuntimeCore: 683ee0b6a76d4b4bf6fbf83a541895b4887cc636
-  React-runtimeexecutor: a188df372373baf5066e6e229177836488799f80
-  React-RuntimeHermes: 907c8e9bec13ea6466b94828c088c24590d4d0b6
-  React-runtimescheduler: a2e2a39125dd6426b5d8b773f689d660cd7c5f60
-  React-timing: bb220a53a795ed57976a4855c521f3de2f298fe5
-  React-utils: 300d8bbb6555dcffaca71e7a0663201b5c7edbbc
-  ReactAppDependencyProvider: f2e81d80afd71a8058589e19d8a134243fa53f17
-  ReactCodegen: 3d49e04e783325efd2ad79ce064d1adc073e3e1b
-  ReactCommon: 3d39389f8e2a2157d5c999f8fba57bd1c8f226f0
-  RNScreens: e6fdafd9b91fc790c7e4b1e01e8f1d0fdc4d89cb
+  React-NativeModulesApple: 79a4404ac301b40bec3b367879c5e9a9ce81683c
+  React-perflogger: 0ea25c109dba33d47dec36b2634bf7ea67c1a555
+  React-performancetimeline: f74480de6efbcd8541c34317c0baedb433f27296
+  React-RCTActionSheet: 2ef95837e89b9b154f13cd8401f9054fc3076aff
+  React-RCTAnimation: 33d960d7f58a81779eea6dea47ad0364c67e1517
+  React-RCTAppDelegate: 85c13403fd6f6b6cc630428d52bd8bd76a670dc9
+  React-RCTBlob: 74c986a02d951931d2f6ed0e07ed5a7eb385bfc0
+  React-RCTFabric: 384a8fea4f22fc0f21299d771971862883ba630a
+  React-RCTFBReactNativeSpec: eb1c3ec5149f76133593a516ff9d5efe32ebcecd
+  React-RCTImage: 2c58b5ddeb3c65e52f942bbe13ff9c59bd649b09
+  React-RCTLinking: b6b14f8a3e62c02fc627ac4f3fb0c7bd941f907c
+  React-RCTNetwork: 1d050f2466c1541b339587d46f78d5eee218d626
+  React-RCTSettings: 8148f6be0ccc0cfe6e313417ebf8a479caaa2146
+  React-RCTText: 64114531ad1359e4e02a4a8af60df606dbbabc25
+  React-RCTVibration: f4859417a7dd859b6bf18b1aba897e52beb72ef6
+  React-rendererconsistency: 5ac4164ec18cfdd76ed5f864dbfdc56a5a948bc9
+  React-rendererdebug: 3dc1d97bbee0c0c13191e501a96ed9325bbd920e
+  React-rncore: 0bace3b991d8843bb5b57c5f2301ec6e9c94718b
+  React-RuntimeApple: 1e1e0a0c6086bc8c3b07e8f1a2f6ca99b50419a0
+  React-RuntimeCore: d39322c59bef2a4b343fda663d20649f29f57fcc
+  React-runtimeexecutor: 876dfc1d8daa819dfd039c40f78f277c5a3e66a6
+  React-RuntimeHermes: 44f5f2baf039f249b31ea4f3e224484fd1731e0e
+  React-runtimescheduler: 3b3c5b50743bb8743ca49b9e5a70c2c385f156e1
+  React-timing: 1ee3572c398f5579c9df5bf76aacddf5683ff74e
+  React-utils: 0cfb7c7fb37d4e5f31cc18ffc7426be0ae6bf907
+  ReactAppDependencyProvider: b48473fe434569ff8f6cb6ed4421217ebcbda878
+  ReactCodegen: 5ba804f56e4f9249bb7c20a37219df2bb3e9b783
+  ReactCommon: 547db015202a80a5b3e7e041586ea54c4a087180
+  RNScreens: 0f01bbed9bd8045a8d58e4b46993c28c7f498f3c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 9b7fb56e7b08cde60e2153344fa6afbd88e5d99f
+  Yoga: 66a9a23a82dd4081b393babe509967097759b3d6
 
 PODFILE CHECKSUM: 205a5dcc178bd52bc8f2d549f38ecbb697373aaf
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1920,72 +1920,72 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: 2771b98fb813fdc6f92edd7c9c0035ecabf9fee7
-  NitroImage: 716d4153c455baf6b0599e3d90278735c115a111
-  NitroModules: cff9d855b511f091ee4e0f30fffb8efd606b4d80
+  NitroImage: 0a5d3fe67de9cef180e98d9c1455f8a6580d2402
+  NitroModules: 795b75234792e920c5aac1c6827080e852072548
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: be794de7dc6ed8f9f7fbf525f86e7651b8b68746
   RCTRequired: a83787b092ec554c2eb6019ff3f5b8d125472b3b
   RCTTypeSafety: 48ad3c858926b1c46f46a81a58822b476e178e2c
   React: 3b5754191f1b65f1dbc52fbea7959c3d2d9e39c9
   React-callinvoker: 6beeaf4c7db11b6cc953fac45f2c76e3fb125013
-  React-Core: 8a10ac9de53373a3ecb5dfcbcf56df1d3dad0861
-  React-CoreModules: af6999b35c7c01b0e12b59d27f3e054e13da43b1
-  React-cxxreact: 833f00155ce8c2fda17f6d286f8eaeff2ececc69
+  React-Core: 88e817c42de035378cc71e009193b9a044d3f595
+  React-CoreModules: dcf764d71efb4f75d38fcae8d4513b6729f49360
+  React-cxxreact: 8cdcc937c5fbc406fe843a381102fd69440ca78a
   React-debug: 440175830c448e7e53e61ebb8d8468c3256b645e
-  React-defaultsnativemodule: a970effe18fe50bdbbb7115c3297f873b666d0d4
-  React-domnativemodule: 45f886342a724e61531b18fba1859bb6782e5d62
-  React-Fabric: 69f1881f2177a8512304a64157943548ab6df0cf
-  React-FabricComponents: f54111c8e2439fc273ab07483e3a7054ca1e75af
-  React-FabricImage: 9ad2619dfe8c386d79e8aaa87da6e8f018ab9592
+  React-defaultsnativemodule: 4824bcd7b96ee2d75c28b1ca21f58976867f5535
+  React-domnativemodule: a421118b475618961cf282e8ea85347cc9bb453c
+  React-Fabric: 6ac7de06009eb96b609a770b17abba6e460b5f45
+  React-FabricComponents: e3bc2680a5a9a4917ff0c8d7f390688c30ef753c
+  React-FabricImage: 8bad558dec7478077974caa96acc79692d6b71f5
   React-featureflags: b9cf9b35baca1c7f20c06a104ffc325a02752faa
-  React-featureflagsnativemodule: 7f1bc76d1d2c5bede5e753b8d188dbde7c59b12f
-  React-graphics: 069e0d0b31ed1e80feb023ad4f7e97f00e84f7b9
-  React-hermes: 63df5ac5a944889c8758a6213b39ed825863adb7
-  React-idlecallbacksnativemodule: 4c700bd7c0012adf904929075a79418b828b5ffc
-  React-ImageManager: 5d1ba8a7bae44ebba43fc93da64937c713d42941
-  React-jserrorhandler: 0defd58f8bb797cdd0a820f733bf42d8bee708ce
-  React-jsi: 99d6207ec802ad73473a0dad3c9ad48cd98463f6
-  React-jsiexecutor: 8c8097b4ba7e7f480582d6e6238b01be5dcc01c0
-  React-jsinspector: ea148ec45bc7ff830e443383ea715f9780c15934
-  React-jsinspectortracing: 46bb2841982f01e7b63eaab98140fa1de5b2a1db
-  React-jsitracing: c1063fc2233960d1c8322291e74bca51d25c10d7
-  React-logger: 763728cf4eebc9c5dc9bfc3649e22295784f69f3
-  React-Mapbuffer: 63278529b5cf531a7eaf8fc71244fabb062ca90c
-  React-microtasksnativemodule: 6a39463c32ce831c4c2aa8469273114d894b6be9
-  react-native-safe-area-context: afcc2e2b3e78ae8ef90d81e658aacee34ebc27ea
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  React-NativeModulesApple: fd0545efbb7f936f78edd15a6564a72d2c34bb32
-  React-perflogger: 5f8fa36a8e168fb355efe72099efe77213bc2ac6
-  React-performancetimeline: 8c0ecfa1ae459cc5678a65f95ac3bf85644d6feb
+  React-featureflagsnativemodule: dc93d81da9f41f7132e24455ec8b4b60802fd5b0
+  React-graphics: aaa5a38bea15d7b895b210d95d554af45a07002a
+  React-hermes: 08ad9fb832d1b9faef391be17309aa6a69fad23b
+  React-idlecallbacksnativemodule: aacea33ef6c511a9781f9286cc7cdf93f39bba14
+  React-ImageManager: c596c3b658c9c14607f9183ed0f635c8dd77987c
+  React-jserrorhandler: 987609b2f16b7d79d63fcd621bf0110dd7400b35
+  React-jsi: afa286d7e0c102c2478dc420d4f8935e13c973fc
+  React-jsiexecutor: 08f5b512b4db9e2f147416d60a0a797576b9cfef
+  React-jsinspector: 5a94bcae66e3637711c4d96a00038ab9ec935bf5
+  React-jsinspectortracing: a12589a0adbb2703cbc4380dabe9a58800810923
+  React-jsitracing: 0b1a403d7757cec66b7dd8b308d04db85eef75f3
+  React-logger: 304814ae37503c8eb54359851cc55bd4f936b39c
+  React-Mapbuffer: b588d1ca18d2ce626f868f04ab12d8b1f004f12c
+  React-microtasksnativemodule: 11831d070aa47755bb5739069eb04ec621fec548
+  react-native-safe-area-context: 9b169299f9dc95f1d7fe1dd266fde53bd899cd0c
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  React-NativeModulesApple: 79a4404ac301b40bec3b367879c5e9a9ce81683c
+  React-perflogger: 0ea25c109dba33d47dec36b2634bf7ea67c1a555
+  React-performancetimeline: f74480de6efbcd8541c34317c0baedb433f27296
   React-RCTActionSheet: 2ef95837e89b9b154f13cd8401f9054fc3076aff
-  React-RCTAnimation: 46abefd5acfda7e6629f9e153646deecc70babd2
-  React-RCTAppDelegate: 7e58e0299e304cceee3f7019fa77bc6990f66b22
-  React-RCTBlob: f68c63a801ef1d27e83c4011e3b083cc86a200d7
-  React-RCTFabric: c59f41d0c4edbaac8baa232731ca09925ae4dda7
-  React-RCTFBReactNativeSpec: 3240b9b8d792aa4be0fb85c9898fc183125ba8de
-  React-RCTImage: 34e0bba1507e55f1c614bd759eb91d9be48c8c5b
-  React-RCTLinking: a0b6c9f4871c18b0b81ea952f43e752718bd5f1d
-  React-RCTNetwork: bdafd661ac2b20d23b779e45bf7ac3e4c8bd1b60
-  React-RCTSettings: 98aa5163796f43789314787b584a84eba47787a9
-  React-RCTText: 424a274fc9015b29de89cf3cbcdf4dd85dd69f83
-  React-RCTVibration: 92d9875a955b0adb34b4b773528fdbbbc5addd6c
+  React-RCTAnimation: 33d960d7f58a81779eea6dea47ad0364c67e1517
+  React-RCTAppDelegate: 85c13403fd6f6b6cc630428d52bd8bd76a670dc9
+  React-RCTBlob: 74c986a02d951931d2f6ed0e07ed5a7eb385bfc0
+  React-RCTFabric: 384a8fea4f22fc0f21299d771971862883ba630a
+  React-RCTFBReactNativeSpec: eb1c3ec5149f76133593a516ff9d5efe32ebcecd
+  React-RCTImage: 2c58b5ddeb3c65e52f942bbe13ff9c59bd649b09
+  React-RCTLinking: b6b14f8a3e62c02fc627ac4f3fb0c7bd941f907c
+  React-RCTNetwork: 1d050f2466c1541b339587d46f78d5eee218d626
+  React-RCTSettings: 8148f6be0ccc0cfe6e313417ebf8a479caaa2146
+  React-RCTText: 64114531ad1359e4e02a4a8af60df606dbbabc25
+  React-RCTVibration: f4859417a7dd859b6bf18b1aba897e52beb72ef6
   React-rendererconsistency: 5ac4164ec18cfdd76ed5f864dbfdc56a5a948bc9
-  React-rendererdebug: 710dbd7990e355852c786aa6bc7753f6028f357a
+  React-rendererdebug: 3dc1d97bbee0c0c13191e501a96ed9325bbd920e
   React-rncore: 0bace3b991d8843bb5b57c5f2301ec6e9c94718b
-  React-RuntimeApple: 701ec44a8b5d863ee9b6a2b2447b6a26bb6805a1
-  React-RuntimeCore: a82767065b9a936b05e209dc6987bc1ea9eb5d2d
+  React-RuntimeApple: 1e1e0a0c6086bc8c3b07e8f1a2f6ca99b50419a0
+  React-RuntimeCore: d39322c59bef2a4b343fda663d20649f29f57fcc
   React-runtimeexecutor: 876dfc1d8daa819dfd039c40f78f277c5a3e66a6
-  React-RuntimeHermes: e7a051fd91cab8849df56ac917022ef6064ad621
-  React-runtimescheduler: c544141f2124ee3d5f3d5bf0d69f4029a61a68b0
+  React-RuntimeHermes: 44f5f2baf039f249b31ea4f3e224484fd1731e0e
+  React-runtimescheduler: 3b3c5b50743bb8743ca49b9e5a70c2c385f156e1
   React-timing: 1ee3572c398f5579c9df5bf76aacddf5683ff74e
-  React-utils: 18703928768cb37e70cf2efff09def12d74a399e
-  ReactAppDependencyProvider: 4893bde33952f997a323eb1a1ee87a72764018ff
-  ReactCodegen: 284a640cafd1e9928d84d81865be7fd80a6d0098
-  ReactCommon: 865ebe76504a95e115b6229dd00a31e56d2d4bfe
-  RNScreens: 790123c4a28783d80a342ce42e8c7381bed62db1
+  React-utils: 0cfb7c7fb37d4e5f31cc18ffc7426be0ae6bf907
+  ReactAppDependencyProvider: b48473fe434569ff8f6cb6ed4421217ebcbda878
+  ReactCodegen: 5ba804f56e4f9249bb7c20a37219df2bb3e9b783
+  ReactCommon: 547db015202a80a5b3e7e041586ea54c4a087180
+  RNScreens: 0f01bbed9bd8045a8d58e4b46993c28c7f498f3c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: e14bad835e12b6c7e2260fc320bd00e0f4b45add
+  Yoga: 66a9a23a82dd4081b393babe509967097759b3d6
 
 PODFILE CHECKSUM: 205a5dcc178bd52bc8f2d549f38ecbb697373aaf
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1921,7 +1921,7 @@ SPEC CHECKSUMS:
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
   NitroImage: 0a5d3fe67de9cef180e98d9c1455f8a6580d2402
-  NitroModules: 6cad985fa4a6efaf567fe5c9aa464bce17e2d0cc
+  NitroModules: 795b75234792e920c5aac1c6827080e852072548
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: be794de7dc6ed8f9f7fbf525f86e7651b8b68746
   RCTRequired: a83787b092ec554c2eb6019ff3f5b8d125472b3b

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -403,15 +403,31 @@ export function getTests(
     ),
 
     // Test Dates
-    createTest('add1Hour(...)', () =>
-      it(() => testObject.add1Hour(BASE_DATE))
+    createTest('currentDate(...) is a Date', () =>
+      it(() => {
+        const now = testObject.currentDate()
+        return now instanceof Date
+      })
         .didNotThrow()
-        .equals(DATE_PLUS_1H)
+        .equals(true)
     ),
-    createTest('currentDate(...)', () =>
-      it(() => testObject.currentDate())
+    createTest('add1Hour(...)', () =>
+      it(() => {
+        const added = testObject.add1Hour(BASE_DATE)
+        return added.getTime()
+      })
         .didNotThrow()
-        .toContain('getTime')
+        .equals(DATE_PLUS_1H.getTime())
+    ),
+    createTest('currentDate(...) is roughly same JS value', () =>
+      it(() => {
+        const nativeNow = testObject.currentDate()
+        const jsNow = new Date()
+        const msDiff = Math.abs(jsNow.getTime() - nativeNow.getTime())
+        return msDiff < 10
+      })
+        .didNotThrow()
+        .equals(true)
     ),
 
     // Test Maps

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -55,6 +55,13 @@ const TEST_MAP_2: Record<string, string> = {
   'third-key': 'thirdValue',
 }
 
+const BASE_DATE = new Date()
+const DATE_PLUS_1H = (() => {
+  const current = BASE_DATE.getTime()
+  const oneHourInMilliseconds = 1000 * 60 * 60
+  return new Date(current + oneHourInMilliseconds)
+})()
+
 function createTest<T>(
   name: string,
   run: () => State<T> | Promise<State<T>>
@@ -393,6 +400,18 @@ export function getTests(
       )
         .didNotThrow()
         .equals(['gas', 'electric'])
+    ),
+
+    // Test Dates
+    createTest('add1Hour(...)', () =>
+      it(() => testObject.add1Hour(BASE_DATE))
+        .didNotThrow()
+        .equals(DATE_PLUS_1H)
+    ),
+    createTest('currentDate(...)', () =>
+      it(() => testObject.currentDate())
+        .didNotThrow()
+        .toContain('getTime')
     ),
 
     // Test Maps

--- a/packages/nitrogen/src/autolinking/ios/createSwiftUmbrellaHeader.ts
+++ b/packages/nitrogen/src/autolinking/ios/createSwiftUmbrellaHeader.ts
@@ -56,6 +56,7 @@ ${includes.sort().join('\n')}
 #include <NitroModules/ArrayBufferHolder.hpp>
 #include <NitroModules/AnyMapHolder.hpp>
 #include <NitroModules/RuntimeError.hpp>
+#include <NitroModules/DateToChronoDate.hpp>
 
 // Forward declarations of Swift defined types
 ${swiftForwardDeclares.sort().join('\n')}

--- a/packages/nitrogen/src/syntax/createType.ts
+++ b/packages/nitrogen/src/syntax/createType.ts
@@ -29,6 +29,7 @@ import {
 import { HybridObjectBaseType } from './types/HybridObjectBaseType.js'
 import { ErrorType } from './types/ErrorType.js'
 import { getBaseTypes } from '../utils.js'
+import { DateType } from './types/DateType.js'
 
 function isSymbol(type: TSMorphType, symbolName: string): boolean {
   const symbol = type.getSymbol()
@@ -52,6 +53,10 @@ function isRecord(type: TSMorphType): boolean {
 
 function isArrayBuffer(type: TSMorphType): boolean {
   return isSymbol(type, 'ArrayBuffer')
+}
+
+function isDate(type: TSMorphType): boolean {
+  return isSymbol(type, 'Date')
 }
 
 function isMap(type: TSMorphType): boolean {
@@ -271,6 +276,9 @@ export function createType(
     } else if (isMap(type)) {
       // Map
       return new MapType()
+    } else if (isDate(type)) {
+      // Date
+      return new DateType()
     } else if (isError(type)) {
       // Error
       return new ErrorType()

--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -104,6 +104,13 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
           space: 'system',
         })
         break
+      case 'date':
+        imports.push({
+          language: 'c++',
+          name: 'NitroModules/JInstant.hpp',
+          space: 'system',
+        })
+        break
       case 'map':
         imports.push({
           language: 'c++',
@@ -303,6 +310,13 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
           default:
             return this.type.getCode(language)
         }
+      case 'date':
+        switch (language) {
+          case 'c++':
+            return `JInstant`
+          default:
+            return this.type.getCode(language)
+        }
       case 'variant': {
         const variant = getTypeAs(this.type, VariantType)
         const name = variant.getAliasName('kotlin')
@@ -423,6 +437,14 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
             const variant = getTypeAs(this.type, VariantType)
             const name = variant.getAliasName('kotlin')
             return `J${name}::fromCpp(${parameterName})`
+          default:
+            return parameterName
+        }
+      }
+      case 'date': {
+        switch (language) {
+          case 'c++':
+            return `JInstant::fromChrono(${parameterName})`
           default:
             return parameterName
         }
@@ -666,6 +688,14 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
         switch (language) {
           case 'c++':
             return `${parameterName}->toCpp()`
+          default:
+            return parameterName
+        }
+      }
+      case 'date': {
+        switch (language) {
+          case 'c++':
+            return `${parameterName}->toChrono()`
           default:
             return parameterName
         }

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -457,6 +457,22 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
             return cppParameterName
         }
       }
+      case 'date': {
+        switch (language) {
+          case 'c++':
+            return `
+[&]() -> double {
+  using std::chrono;
+  auto __ms = duration_cast<milliseconds>(${cppParameterName}.time_since_epoch()).count();
+  double __msSinceEpoch = static_cast<double>(__ms);
+}()
+            `.trim()
+          case 'swift':
+            return `Date(timeIntervalSince1970: ${cppParameterName} / 1_000)`.trim()
+          default:
+            return cppParameterName
+        }
+      }
       case 'array': {
         const array = getTypeAs(this.type, ArrayType)
         const wrapping = new SwiftCxxBridgedType(array.itemType, true)

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -95,6 +95,9 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
           return false
         }
         return true
+      case 'date':
+        // Date <> double
+        return true
       case 'promise':
         // Promise<T> <> std::shared_ptr<Promise<T>>
         return true

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -462,7 +462,7 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
           case 'c++':
             return `
 [&]() -> double {
-  using std::chrono;
+  using namespace std::chrono;
   auto __ms = duration_cast<milliseconds>(${cppParameterName}.time_since_epoch()).count();
   double __msSinceEpoch = static_cast<double>(__ms);
 }()

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -256,20 +256,6 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
             return this.type.getCode(language)
         }
       }
-      case 'date':
-        if (this.isBridgingToDirectCppTarget) {
-          return this.type.getCode(language)
-        } else {
-          // milliseconds
-          switch (language) {
-            case 'swift':
-              return 'Double'
-            case 'c++':
-              return 'double'
-            default:
-              return this.type.getCode(language)
-          }
-        }
       case 'array-buffer':
         if (this.isBridgingToDirectCppTarget) {
           return this.type.getCode(language)
@@ -286,6 +272,13 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
             throw new Error(`Invalid language! ${language}`)
         }
       }
+      case 'date':
+        switch (language) {
+          case 'swift':
+            return `margelo.nitro.chrono_time`
+          default:
+            return this.type.getCode(language)
+        }
       case 'error':
         switch (language) {
           case 'c++':
@@ -476,16 +469,8 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
       }
       case 'date': {
         switch (language) {
-          case 'c++':
-            return `
-[&]() -> double {
-  using namespace std::chrono;
-  auto __ms = duration_cast<milliseconds>(${cppParameterName}.time_since_epoch()).count();
-  double __msSinceEpoch = static_cast<double>(__ms);
-}()
-            `.trim()
           case 'swift':
-            return `Date(timeIntervalSince1970: ${cppParameterName} / 1_000)`.trim()
+            return `Date(fromChrono: ${cppParameterName})`.trim()
           default:
             return cppParameterName
         }
@@ -685,13 +670,14 @@ case ${i}:
             return swiftParameterName
         }
       }
-      case 'date':
+      case 'date': {
         switch (language) {
           case 'swift':
-            return `margelo.nitro.chronoDateFromMillisecondsSinceEpoch(${swiftParameterName}.timeIntervalSince1970)`
+            return `${swiftParameterName}.toCpp()`
           default:
             return swiftParameterName
         }
+      }
       case 'array-buffer': {
         switch (language) {
           case 'swift':

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -256,6 +256,20 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
             return this.type.getCode(language)
         }
       }
+      case 'date':
+        if (this.isBridgingToDirectCppTarget) {
+          return this.type.getCode(language)
+        } else {
+          // milliseconds
+          switch (language) {
+            case 'swift':
+              return 'Double'
+            case 'c++':
+              return 'double'
+            default:
+              return this.type.getCode(language)
+          }
+        }
       case 'array-buffer':
         if (this.isBridgingToDirectCppTarget) {
           return this.type.getCode(language)
@@ -671,6 +685,13 @@ case ${i}:
             return swiftParameterName
         }
       }
+      case 'date':
+        switch (language) {
+          case 'swift':
+            return `margelo.nitro.chronoDateFromMillisecondsSinceEpoch(${swiftParameterName}.timeIntervalSince1970)`
+          default:
+            return swiftParameterName
+        }
       case 'array-buffer': {
         switch (language) {
           case 'swift':

--- a/packages/nitrogen/src/syntax/types/DateType.ts
+++ b/packages/nitrogen/src/syntax/types/DateType.ts
@@ -1,0 +1,41 @@
+import type { Language } from '../../getPlatformSpecs.js'
+import type { SourceFile, SourceImport } from '../SourceFile.js'
+import type { Type, TypeKind } from './Type.js'
+
+export class DateType implements Type {
+  get canBePassedByReference(): boolean {
+    // simple chrono value type
+    return false
+  }
+
+  get kind(): TypeKind {
+    return 'date'
+  }
+
+  getCode(language: Language): string {
+    switch (language) {
+      case 'c++':
+        return 'std::chrono::system_clock::time_point'
+      case 'swift':
+        return 'Date'
+      case 'kotlin':
+        return 'Instant'
+      default:
+        throw new Error(
+          `Language ${language} is not yet supported for DateType!`
+        )
+    }
+  }
+  getExtraFiles(): SourceFile[] {
+    return []
+  }
+  getRequiredImports(): SourceImport[] {
+    return [
+      {
+        name: 'chrono',
+        language: 'c++',
+        space: 'system',
+      },
+    ]
+  }
+}

--- a/packages/nitrogen/src/syntax/types/DateType.ts
+++ b/packages/nitrogen/src/syntax/types/DateType.ts
@@ -19,7 +19,7 @@ export class DateType implements Type {
       case 'swift':
         return 'Date'
       case 'kotlin':
-        return 'Instant'
+        return 'java.time.Instant'
       default:
         throw new Error(
           `Language ${language} is not yet supported for DateType!`

--- a/packages/nitrogen/src/syntax/types/Type.ts
+++ b/packages/nitrogen/src/syntax/types/Type.ts
@@ -22,6 +22,7 @@ export type TypeKind =
   | 'tuple'
   | 'variant'
   | 'result-wrapper'
+  | 'date'
   | 'void'
 
 /**

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridTestObjectKotlin.kt
@@ -8,6 +8,7 @@ import com.margelo.nitro.core.AnyValue
 import com.margelo.nitro.core.ArrayBuffer
 import com.margelo.nitro.core.Promise
 import kotlinx.coroutines.delay
+import java.time.Instant
 
 @Keep
 @DoNotStrip
@@ -64,6 +65,15 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
 
     override fun complexEnumCallback(array: Array<Powertrain>, callback: (array: Array<Powertrain>) -> Unit) {
         callback(array)
+    }
+
+    override fun currentDate(): java.time.Instant {
+        return Instant.now()
+    }
+
+    override fun add1Hour(date: Instant): Instant {
+        val oneHourInSeconds = 1L * 60 * 60
+        return date.plusSeconds(oneHourInSeconds)
     }
 
     override fun createMap(): AnyMap {

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.cpp
@@ -222,6 +222,13 @@ std::optional<Powertrain> HybridTestObjectCpp::tryOptionalEnum(std::optional<Pow
   return value;
 }
 
+std::chrono::system_clock::time_point HybridTestObjectCpp::add1Hour(std::chrono::system_clock::time_point date) {
+  return date + std::chrono::hours(1);
+}
+std::chrono::system_clock::time_point HybridTestObjectCpp::currentDate() {
+  return std::chrono::system_clock::now();
+}
+
 std::variant<std::string, double>
 HybridTestObjectCpp::passVariant(const std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>& either) {
   if (std::holds_alternative<std::string>(either)) {

--- a/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-image/cpp/HybridTestObjectCpp.hpp
@@ -89,6 +89,8 @@ public:
   std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) override;
   std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) override;
   std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) override;
+  std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) override;
+  std::chrono::system_clock::time_point currentDate() override;
   std::variant<std::string, double>
   passVariant(const std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>& either) override;
 

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -185,7 +185,7 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
   }
 
   func add1Hour(date: Date) throws -> Date {
-    let oneHourInSeconds = 1 * 60 * 60
+    let oneHourInSeconds = 1.0 * 60 * 60
     return date + oneHourInSeconds
   }
   func currentDate() throws -> Date {

--- a/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-image/ios/HybridTestObjectSwift.swift
@@ -184,6 +184,14 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     return value
   }
 
+  func add1Hour(date: Date) throws -> Date {
+    let oneHourInSeconds = 1 * 60 * 60
+    return date + oneHourInSeconds
+  }
+  func currentDate() throws -> Date {
+    return .now
+  }
+
   func bounceMap(map: Dictionary<String, Variant_Double_Bool>) throws -> Dictionary<String, Variant_Double_Bool> {
     return map
   }
@@ -191,11 +199,11 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
   func extractMap(mapWrapper: MapWrapper) throws -> Dictionary<String, String> {
     return mapWrapper.map
   }
-  
+
   func getVariantHybrid(variant: Variant_Person__any_HybridTestObjectSwiftKotlinSpec_) throws -> Variant_Person__any_HybridTestObjectSwiftKotlinSpec_ {
     return variant
   }
-  
+
   func passVariant(either: Variant_String_Double_Bool__Double___String_) throws -> Variant_String_Double {
     switch either {
     case let .first(string):
@@ -206,15 +214,15 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
       return .first("holds something else!")
     }
   }
-  
+
   func getVariantEnum(variant: Variant_Bool_OldEnum) throws -> Variant_Bool_OldEnum {
     return variant
   }
-  
+
   func getVariantObjects(variant: Variant_Car_Person) throws -> Variant_Car_Person {
     return variant
   }
-  
+
   func passNamedVariant(variant: NamedVariant) throws -> NamedVariant {
     return variant
   }

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -57,6 +57,7 @@ namespace margelo::nitro::image { class HybridTestViewSpec; }
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/JPromise.hpp>
 #include <chrono>
+#include <NitroModules/JInstant.hpp>
 #include "Car.hpp"
 #include "JCar.hpp"
 #include <NitroModules/ArrayBuffer.hpp>
@@ -457,14 +458,14 @@ namespace margelo::nitro::image {
     return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   std::chrono::system_clock::time_point JHybridTestObjectSwiftKotlinSpec::add1Hour(std::chrono::system_clock::time_point date) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<std::chrono::system_clock::time_point>(jni::alias_ref<std::chrono::system_clock::time_point> /* date */)>("add1Hour");
-    auto __result = method(_javaPart, date);
-    return __result;
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JInstant>(jni::alias_ref<JInstant> /* date */)>("add1Hour");
+    auto __result = method(_javaPart, JInstant::fromChrono(date));
+    return __result->toChrono();
   }
   std::chrono::system_clock::time_point JHybridTestObjectSwiftKotlinSpec::currentDate() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<std::chrono::system_clock::time_point>()>("currentDate");
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JInstant>()>("currentDate");
     auto __result = method(_javaPart);
-    return __result;
+    return __result->toChrono();
   }
   int64_t JHybridTestObjectSwiftKotlinSpec::calculateFibonacciSync(double value) {
     static const auto method = javaClassStatic()->getMethod<int64_t(double /* value */)>("calculateFibonacciSync");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -56,6 +56,7 @@ namespace margelo::nitro::image { class HybridTestViewSpec; }
 #include "JVariant_Double_Boolean.hpp"
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/JPromise.hpp>
+#include <chrono>
 #include "Car.hpp"
 #include "JCar.hpp"
 #include <NitroModules/ArrayBuffer.hpp>
@@ -454,6 +455,16 @@ namespace margelo::nitro::image {
     static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPowertrain>(jni::alias_ref<JPowertrain> /* value */)>("tryOptionalEnum");
     auto __result = method(_javaPart, value.has_value() ? JPowertrain::fromCpp(value.value()) : nullptr);
     return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
+  }
+  std::chrono::system_clock::time_point JHybridTestObjectSwiftKotlinSpec::add1Hour(std::chrono::system_clock::time_point date) {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<std::chrono::system_clock::time_point>(jni::alias_ref<std::chrono::system_clock::time_point> /* date */)>("add1Hour");
+    auto __result = method(_javaPart, date);
+    return __result;
+  }
+  std::chrono::system_clock::time_point JHybridTestObjectSwiftKotlinSpec::currentDate() {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<std::chrono::system_clock::time_point>()>("currentDate");
+    auto __result = method(_javaPart);
+    return __result;
   }
   int64_t JHybridTestObjectSwiftKotlinSpec::calculateFibonacciSync(double value) {
     static const auto method = javaClassStatic()->getMethod<int64_t(double /* value */)>("calculateFibonacciSync");

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -98,6 +98,8 @@ namespace margelo::nitro::image {
     std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) override;
     std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) override;
     std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) override;
+    std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) override;
+    std::chrono::system_clock::time_point currentDate() override;
     int64_t calculateFibonacciSync(double value) override;
     std::shared_ptr<Promise<int64_t>> calculateFibonacciAsync(double value) override;
     std::shared_ptr<Promise<void>> wait(double seconds) override;

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -219,6 +219,14 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun add1Hour(date: Instant): Instant
+  
+  @DoNotStrip
+  @Keep
+  abstract fun currentDate(): Instant
+  
+  @DoNotStrip
+  @Keep
   abstract fun calculateFibonacciSync(value: Double): Long
   
   @DoNotStrip

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridTestObjectSwiftKotlinSpec.kt
@@ -219,11 +219,11 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun add1Hour(date: Instant): Instant
+  abstract fun add1Hour(date: java.time.Instant): java.time.Instant
   
   @DoNotStrip
   @Keep
-  abstract fun currentDate(): Instant
+  abstract fun currentDate(): java.time.Instant
   
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -66,6 +66,7 @@ namespace NitroImage { class HybridTestViewSpec_cxx; }
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/PromiseHolder.hpp>
 #include <NitroModules/Result.hpp>
+#include <chrono>
 #include <exception>
 #include <functional>
 #include <memory>
@@ -1132,6 +1133,15 @@ namespace margelo::nitro::image::bridge::swift {
   }
   inline Result_std__optional_Powertrain__ create_Result_std__optional_Powertrain__(const std::exception_ptr& error) {
     return Result<std::optional<Powertrain>>::withError(error);
+  }
+  
+  // pragma MARK: Result<std::chrono::system_clock::time_point>
+  using Result_std__chrono__system_clock__time_point_ = Result<std::chrono::system_clock::time_point>;
+  inline Result_std__chrono__system_clock__time_point_ create_Result_std__chrono__system_clock__time_point_(std::chrono::system_clock::time_point value) {
+    return Result<std::chrono::system_clock::time_point>::withValue(std::move(value));
+  }
+  inline Result_std__chrono__system_clock__time_point_ create_Result_std__chrono__system_clock__time_point_(const std::exception_ptr& error) {
+    return Result<std::chrono::system_clock::time_point>::withError(error);
   }
   
   // pragma MARK: Result<int64_t>

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Umbrella.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Umbrella.hpp
@@ -83,6 +83,7 @@ namespace margelo::nitro::image { enum class Powertrain; }
 #include <NitroModules/ArrayBufferHolder.hpp>
 #include <NitroModules/AnyMapHolder.hpp>
 #include <NitroModules/RuntimeError.hpp>
+#include <NitroModules/DateToChronoDate.hpp>
 
 // Forward declarations of Swift defined types
 // Forward declaration of `HybridBaseSpec_cxx` to properly resolve imports.

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Umbrella.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Umbrella.hpp
@@ -66,6 +66,7 @@ namespace margelo::nitro::image { enum class Powertrain; }
 #include <NitroModules/ArrayBuffer.hpp>
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/Result.hpp>
+#include <chrono>
 #include <exception>
 #include <functional>
 #include <memory>

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -54,6 +54,7 @@ namespace margelo::nitro::image { class HybridTestViewSpec; }
 #include "MapWrapper.hpp"
 #include <NitroModules/Promise.hpp>
 #include <exception>
+#include <chrono>
 #include "Car.hpp"
 #include <NitroModules/ArrayBuffer.hpp>
 #include <NitroModules/ArrayBufferHolder.hpp>
@@ -346,6 +347,22 @@ namespace margelo::nitro::image {
     }
     inline std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) override {
       auto __result = _swiftPart.tryOptionalEnum(value);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) override {
+      auto __result = _swiftPart.add1Hour(std::forward<decltype(date)>(date));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::chrono::system_clock::time_point currentDate() override {
+      auto __result = _swiftPart.currentDate();
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -354,7 +354,11 @@ namespace margelo::nitro::image {
       return __value;
     }
     inline std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) override {
-      auto __result = _swiftPart.add1Hour(std::forward<decltype(date)>(date));
+      auto __result = _swiftPart.add1Hour([&]() -> double {
+        using namespace std::chrono;
+        auto __ms = duration_cast<milliseconds>(date.time_since_epoch()).count();
+        double __msSinceEpoch = static_cast<double>(__ms);
+      }());
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -354,11 +354,7 @@ namespace margelo::nitro::image {
       return __value;
     }
     inline std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) override {
-      auto __result = _swiftPart.add1Hour([&]() -> double {
-        using namespace std::chrono;
-        auto __ms = duration_cast<milliseconds>(date.time_since_epoch()).count();
-        double __msSinceEpoch = static_cast<double>(__ms);
-      }());
+      auto __result = _swiftPart.add1Hour(date);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -48,6 +48,8 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func tryOptionalParams(num: Double, boo: Bool, str: String?) throws -> String
   func tryMiddleParam(num: Double, boo: Bool?, str: String) throws -> String
   func tryOptionalEnum(value: Powertrain?) throws -> Powertrain?
+  func add1Hour(date: Date) throws -> Date
+  func currentDate() throws -> Date
   func calculateFibonacciSync(value: Double) throws -> Int64
   func calculateFibonacciAsync(value: Double) throws -> Promise<Int64>
   func wait(seconds: Double) throws -> Promise<Void>

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -746,6 +746,30 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   }
   
   @inline(__always)
+  public final func add1Hour(date: Date) -> bridge.Result_std__chrono__system_clock__time_point_ {
+    do {
+      let __result = try self.__implementation.add1Hour(date: Date(timeIntervalSince1970: date / 1_000))
+      let __resultCpp = __result
+      return bridge.create_Result_std__chrono__system_clock__time_point_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__chrono__system_clock__time_point_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func currentDate() -> bridge.Result_std__chrono__system_clock__time_point_ {
+    do {
+      let __result = try self.__implementation.currentDate()
+      let __resultCpp = __result
+      return bridge.create_Result_std__chrono__system_clock__time_point_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__chrono__system_clock__time_point_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func calculateFibonacciSync(value: Double) -> bridge.Result_int64_t_ {
     do {
       let __result = try self.__implementation.calculateFibonacciSync(value: value)

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -746,10 +746,10 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   }
   
   @inline(__always)
-  public final func add1Hour(date: Date) -> bridge.Result_std__chrono__system_clock__time_point_ {
+  public final func add1Hour(date: Double) -> bridge.Result_std__chrono__system_clock__time_point_ {
     do {
       let __result = try self.__implementation.add1Hour(date: Date(timeIntervalSince1970: date / 1_000))
-      let __resultCpp = __result
+      let __resultCpp = margelo.nitro.chronoDateFromMillisecondsSinceEpoch(__result.timeIntervalSince1970)
       return bridge.create_Result_std__chrono__system_clock__time_point_(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
@@ -761,7 +761,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   public final func currentDate() -> bridge.Result_std__chrono__system_clock__time_point_ {
     do {
       let __result = try self.__implementation.currentDate()
-      let __resultCpp = __result
+      let __resultCpp = margelo.nitro.chronoDateFromMillisecondsSinceEpoch(__result.timeIntervalSince1970)
       return bridge.create_Result_std__chrono__system_clock__time_point_(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -746,10 +746,10 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   }
   
   @inline(__always)
-  public final func add1Hour(date: Double) -> bridge.Result_std__chrono__system_clock__time_point_ {
+  public final func add1Hour(date: margelo.nitro.chrono_time) -> bridge.Result_std__chrono__system_clock__time_point_ {
     do {
-      let __result = try self.__implementation.add1Hour(date: Date(timeIntervalSince1970: date / 1_000))
-      let __resultCpp = margelo.nitro.chronoDateFromMillisecondsSinceEpoch(__result.timeIntervalSince1970)
+      let __result = try self.__implementation.add1Hour(date: Date(fromChrono: date))
+      let __resultCpp = __result.toCpp()
       return bridge.create_Result_std__chrono__system_clock__time_point_(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
@@ -761,7 +761,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   public final func currentDate() -> bridge.Result_std__chrono__system_clock__time_point_ {
     do {
       let __result = try self.__implementation.currentDate()
-      let __resultCpp = margelo.nitro.chronoDateFromMillisecondsSinceEpoch(__result.timeIntervalSince1970)
+      let __resultCpp = __result.toCpp()
       return bridge.create_Result_std__chrono__system_clock__time_point_(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -67,6 +67,8 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("tryOptionalParams", &HybridTestObjectCppSpec::tryOptionalParams);
       prototype.registerHybridMethod("tryMiddleParam", &HybridTestObjectCppSpec::tryMiddleParam);
       prototype.registerHybridMethod("tryOptionalEnum", &HybridTestObjectCppSpec::tryOptionalEnum);
+      prototype.registerHybridMethod("add1Hour", &HybridTestObjectCppSpec::add1Hour);
+      prototype.registerHybridMethod("currentDate", &HybridTestObjectCppSpec::currentDate);
       prototype.registerHybridMethod("calculateFibonacciSync", &HybridTestObjectCppSpec::calculateFibonacciSync);
       prototype.registerHybridMethod("calculateFibonacciAsync", &HybridTestObjectCppSpec::calculateFibonacciAsync);
       prototype.registerHybridMethod("wait", &HybridTestObjectCppSpec::wait);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -54,6 +54,7 @@ namespace margelo::nitro::image { class HybridTestViewSpec; }
 #include "MapWrapper.hpp"
 #include <NitroModules/Promise.hpp>
 #include <exception>
+#include <chrono>
 #include "Car.hpp"
 #include <NitroModules/ArrayBuffer.hpp>
 #include "JsStyleStruct.hpp"
@@ -144,6 +145,8 @@ namespace margelo::nitro::image {
       virtual std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) = 0;
       virtual std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) = 0;
       virtual std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) = 0;
+      virtual std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) = 0;
+      virtual std::chrono::system_clock::time_point currentDate() = 0;
       virtual int64_t calculateFibonacciSync(double value) = 0;
       virtual std::shared_ptr<Promise<int64_t>> calculateFibonacciAsync(double value) = 0;
       virtual std::shared_ptr<Promise<void>> wait(double seconds) = 0;

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -62,6 +62,8 @@ namespace margelo::nitro::image {
       prototype.registerHybridMethod("tryOptionalParams", &HybridTestObjectSwiftKotlinSpec::tryOptionalParams);
       prototype.registerHybridMethod("tryMiddleParam", &HybridTestObjectSwiftKotlinSpec::tryMiddleParam);
       prototype.registerHybridMethod("tryOptionalEnum", &HybridTestObjectSwiftKotlinSpec::tryOptionalEnum);
+      prototype.registerHybridMethod("add1Hour", &HybridTestObjectSwiftKotlinSpec::add1Hour);
+      prototype.registerHybridMethod("currentDate", &HybridTestObjectSwiftKotlinSpec::currentDate);
       prototype.registerHybridMethod("calculateFibonacciSync", &HybridTestObjectSwiftKotlinSpec::calculateFibonacciSync);
       prototype.registerHybridMethod("calculateFibonacciAsync", &HybridTestObjectSwiftKotlinSpec::calculateFibonacciAsync);
       prototype.registerHybridMethod("wait", &HybridTestObjectSwiftKotlinSpec::wait);

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -53,6 +53,7 @@ namespace margelo::nitro::image { class HybridTestViewSpec; }
 #include "MapWrapper.hpp"
 #include <NitroModules/Promise.hpp>
 #include <exception>
+#include <chrono>
 #include "Car.hpp"
 #include <NitroModules/ArrayBuffer.hpp>
 #include "JsStyleStruct.hpp"
@@ -138,6 +139,8 @@ namespace margelo::nitro::image {
       virtual std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) = 0;
       virtual std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) = 0;
       virtual std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) = 0;
+      virtual std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) = 0;
+      virtual std::chrono::system_clock::time_point currentDate() = 0;
       virtual int64_t calculateFibonacciSync(double value) = 0;
       virtual std::shared_ptr<Promise<int64_t>> calculateFibonacciAsync(double value) = 0;
       virtual std::shared_ptr<Promise<void>> wait(double seconds) = 0;

--- a/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/TestObject.nitro.ts
@@ -109,6 +109,10 @@ interface SharedTestObjectProps {
   // Variants
   someVariant: number | string
 
+  // Dates
+  add1Hour(date: Date): Date
+  currentDate(): Date
+
   // Promises
   calculateFibonacciSync(value: number): bigint
   calculateFibonacciAsync(value: number): Promise<bigint>

--- a/packages/react-native-nitro-modules/NitroModules.podspec
+++ b/packages/react-native-nitro-modules/NitroModules.podspec
@@ -50,6 +50,7 @@ Pod::Spec.new do |s|
     "ios/core/AnyMapHolder.hpp",
     "ios/core/PromiseHolder.hpp",
     "ios/utils/Result.hpp",
+    "ios/utils/DateToChronoDate.hpp",
     "ios/utils/RuntimeError.hpp",
     "ios/utils/SwiftClosure.hpp",
   ]

--- a/packages/react-native-nitro-modules/README.md
+++ b/packages/react-native-nitro-modules/README.md
@@ -212,6 +212,12 @@ The following C++ / JS types are supported out of the box:
     <td><code><a href="./android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt">ArrayBuffer</a></code></td>
   </tr>
   <tr>
+    <td><code>Date</code></td>
+    <td><code>std::chrono::system_clock::time_point</code></td>
+    <td><code>Date</code></td>
+    <td><code>java.time.Instant</code></td>
+  </tr>
+  <tr>
     <td>..any <code><a href="./src/HybridObject.ts">HybridObject</a></code></td>
     <td><code>std::shared_ptr&lt;<a href="./cpp/core/HybridObject.hpp">HybridObject</a>&gt;</code></td>
     <td><code><a href="./ios/core/HybridObject.swift">HybridObject</a></code></td>

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JInstant.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JInstant.hpp
@@ -1,0 +1,53 @@
+//
+//  JInstant.hpp
+//  react-native-nitro
+//
+//  Created by Marc Rousavy on 19.11.24.
+//
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <chrono>
+
+namespace margelo::nitro {
+
+using namespace facebook;
+
+/**
+ * Represents an `Instant` from Kotlin.
+ */
+class JInstant final {
+private:
+  static constexpr auto kJavaDescriptor = "Ljava/time/Instant;";
+  using namespace std;
+
+public:
+
+  static jni::local_ref<JInstant> ofEpochMilliseconds(jlong millisecondsSinceEpoch) {
+    static const auto clazz = javaClassStatic();
+    static const auto method = clazz->getStaticMethod<jni::local_ref<JInstant>(jlong)>("ofEpochMilliseconds");
+    return method(clazz, millisecondsSinceEpoch);
+  }
+
+  static jni::local_ref<JInstant> fromChrono(chrono::system_clock::time_point date) {
+    long milliseconds = chrono::duration_cast<chrono::millis>(date).count();
+    return JInstant::ofEpochMilliseconds(static_cast<jlong>(milliseconds));
+  }
+
+public:
+  jlong toEpochMilliseconds() {
+    static const auto clazz = javaClassStatic();
+    const auto method = clazz->getMethod<jlong()>("toEpochMilliseconds");
+    return method(self());
+  }
+
+  chrono::system_clock::time_point toChrono() {
+    jlong millisecondsSinceEpoch = toEpochMilliseconds();
+    auto duration = chrono::duration<long, std::milli>(static_cast<long>(millisecondsSinceEpoch));
+    auto date = chrono::system_clock::time_point(chrono::duration_cast<system_clock::duration>(duration));
+    return date;
+  }
+};
+
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JInstant.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JInstant.hpp
@@ -8,19 +8,20 @@
 #pragma once
 
 #include <fbjni/fbjni.h>
+#include <jni.h>
 #include <chrono>
 
 namespace margelo::nitro {
 
 using namespace facebook;
+using namespace std;
 
 /**
  * Represents an `Instant` from Kotlin.
  */
-class JInstant final {
+struct JInstant final: jni::JavaClass<JInstant> {
 private:
   static constexpr auto kJavaDescriptor = "Ljava/time/Instant;";
-  using namespace std;
 
 public:
 
@@ -31,7 +32,8 @@ public:
   }
 
   static jni::local_ref<JInstant> fromChrono(chrono::system_clock::time_point date) {
-    long milliseconds = chrono::duration_cast<chrono::millis>(date).count();
+    auto timeSinceEpoch = date.time_since_epoch();
+    long long milliseconds = chrono::duration_cast<chrono::milliseconds>(timeSinceEpoch).count();
     return JInstant::ofEpochMilliseconds(static_cast<jlong>(milliseconds));
   }
 
@@ -45,7 +47,7 @@ public:
   chrono::system_clock::time_point toChrono() {
     jlong millisecondsSinceEpoch = toEpochMilliseconds();
     auto duration = chrono::duration<long, std::milli>(static_cast<long>(millisecondsSinceEpoch));
-    auto date = chrono::system_clock::time_point(chrono::duration_cast<system_clock::duration>(duration));
+    auto date = chrono::system_clock::time_point(chrono::duration_cast<chrono::system_clock::duration>(duration));
     return date;
   }
 };

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JInstant.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JInstant.hpp
@@ -19,12 +19,11 @@ using namespace std;
 /**
  * Represents an `Instant` from Kotlin.
  */
-struct JInstant final: jni::JavaClass<JInstant> {
-private:
+struct JInstant final: public jni::JavaClass<JInstant> {
+public:
   static constexpr auto kJavaDescriptor = "Ljava/time/Instant;";
 
 public:
-
   static jni::local_ref<JInstant> ofEpochMilliseconds(jlong millisecondsSinceEpoch) {
     static const auto clazz = javaClassStatic();
     static const auto method = clazz->getStaticMethod<jni::local_ref<JInstant>(jlong)>("ofEpochMilliseconds");

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JInstant.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JInstant.hpp
@@ -26,7 +26,7 @@ public:
 public:
   static jni::local_ref<JInstant> ofEpochMilliseconds(jlong millisecondsSinceEpoch) {
     static const auto clazz = javaClassStatic();
-    static const auto method = clazz->getStaticMethod<jni::local_ref<JInstant>(jlong)>("ofEpochMilliseconds");
+    static const auto method = clazz->getStaticMethod<jni::local_ref<JInstant>(jlong)>("ofEpochMilli");
     return method(clazz, millisecondsSinceEpoch);
   }
 
@@ -39,7 +39,7 @@ public:
 public:
   jlong toEpochMilliseconds() {
     static const auto clazz = javaClassStatic();
-    const auto method = clazz->getMethod<jlong()>("toEpochMilliseconds");
+    const auto method = clazz->getMethod<jlong()>("toEpochMilli");
     return method(self());
   }
 

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JInstant.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JInstant.hpp
@@ -7,9 +7,9 @@
 
 #pragma once
 
+#include <chrono>
 #include <fbjni/fbjni.h>
 #include <jni.h>
-#include <chrono>
 
 namespace margelo::nitro {
 
@@ -19,7 +19,7 @@ using namespace std;
 /**
  * Represents an `Instant` from Kotlin.
  */
-struct JInstant final: public jni::JavaClass<JInstant> {
+struct JInstant final : public jni::JavaClass<JInstant> {
 public:
   static constexpr auto kJavaDescriptor = "Ljava/time/Instant;";
 

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
@@ -69,7 +69,7 @@ struct JSIConverter<std::chrono::system_clock::time_point> final {
     jsi::Object global = runtime.global();
     jsi::Function dateCtor = global.getPropertyAsFunction(runtime, "Date");
 
-    jsi::Value jsDate = dateCtor.callAsConstructor(runtime, { jsi::Value(msSinceEpoch) });
+    jsi::Value jsDate = dateCtor.callAsConstructor(runtime, {jsi::Value(msSinceEpoch)});
     return jsDate;
   }
 

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
@@ -49,7 +49,7 @@ struct JSIConverter<std::chrono::system_clock::time_point> final {
 
     // TODO: Cache this
     jsi::Function valueOfFunc = object.getPropertyAsFunction(runtime, "valueOf");
-    double msSinceEpoch = valueOfFunc.call(runtime, object).getNumber();
+    double msSinceEpoch = valueOfFunc.callWithThis(runtime, object).getNumber();
 
     // ms -> std::chrono::system_clock::time_point
     auto duration = chrono::duration<double, std::milli>(msSinceEpoch);

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
@@ -1,0 +1,83 @@
+//
+// Created by Marc Rousavy on 04.06.25.
+//
+
+#pragma once
+
+// Forward declare a few of the common types that might have cyclic includes.
+namespace margelo::nitro {
+class JSICache;
+
+template <typename T, typename Enable>
+struct JSIConverter;
+} // namespace margelo::nitro
+
+#include "JSIConverter.hpp"
+
+#include <chrono>
+#include <jsi/jsi.h>
+#include <memory>
+#include <type_traits>
+
+namespace margelo::nitro {
+
+using namespace facebook;
+
+// Date <> chrono::system_clock::time_point
+struct JSIConverter<std::chrono::system_clock::time_point> final {
+  static inline std::chrono::system_clock::time_point fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
+    using namespace std::chrono;
+
+#ifdef NITRO_DEBUG
+    if (!arg.isObject()) [[unlikely]] {
+      throw std::invalid_argument("Value \"" + arg.toString(runtime).utf8(runtime) +
+                                  "\" is not a Date - in fact, "
+                                  "it's not even an object!");
+    }
+#endif
+
+    jsi::Object object = arg.asObject(runtime);
+#ifdef NITRO_DEBUG
+    if (!object.hasProperty(runtime, "valueOf")) {
+      throw std::invalid_argument("Object \"" + arg.toString(runtime).utf8(runtime) +
+                                  "\" does not have a .valueOf() function! "
+                                  "It's not a valid Date object.");
+    }
+#endif
+
+    // TODO: Cache this
+    jsi::Function valueOfFunc = object.getPropertyAsFunction(runtime, "valueOf");
+    double msSinceEpoch = valueOfFunc.call(runtime, object).getNumber();
+
+    // ms -> std::chrono::system_clock::time_point
+    auto duration = duration<double, std::milli>(msSinceEpoch);
+    auto timePoint = system_clock::time_point(duration_cast<system_clock::duration>(duration));
+
+    return timePoint;
+  }
+
+  static inline jsi::Value toJSI(jsi::Runtime& runtime, const std::chrono::system_clock::time_point& date) {
+    using namespace std::chrono;
+
+    // 1. Get milliseconds since epoch as a double
+    auto ms = duration_cast<milliseconds>(date.time_since_epoch()).count();
+    double msSinceEpoch = static_cast<double>(ms);
+
+    // TODO: Cache this
+    jsi::Object global = runtime.global();
+    jsi::Function dateCtor = global.getPropertyAsFunction(runtime, "Date");
+
+    jsi::Value jsDate = dateCtor.callAsConstructor(runtime, { jsi::Value(msSinceEpoch) });
+    return jsDate;
+  }
+
+  static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
+    if (value.isObject()) {
+      jsi::Object object = value.getObject(runtime);
+      return object.hasProperty(runtime, "valueOf");
+    }
+    return false;
+  }
+};
+
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
@@ -27,9 +27,7 @@ using namespace std;
 // Date <> chrono::system_clock::time_point
 template <>
 struct JSIConverter<std::chrono::system_clock::time_point> final {
-  static inline std::chrono::system_clock::time_point fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
-    using namespace std::chrono;
-
+  static inline chrono::system_clock::time_point fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
 #ifdef NITRO_DEBUG
     if (!arg.isObject()) [[unlikely]] {
       throw std::invalid_argument("Value \"" + arg.toString(runtime).utf8(runtime) +
@@ -52,18 +50,17 @@ struct JSIConverter<std::chrono::system_clock::time_point> final {
     double msSinceEpoch = valueOfFunc.callWithThis(runtime, object).getNumber();
 
     // ms -> std::chrono::system_clock::time_point
-    auto duration = chrono::duration<double, std::milli>(msSinceEpoch);
-    auto timePoint = chrono::system_clock::time_point(chrono::duration_cast<chrono::system_clock::duration>(duration));
+    auto durationMs = chrono::duration<double, std::milli>(msSinceEpoch);
+    auto duration = chrono::duration_cast<chrono::system_clock::duration>(durationMs);
+    auto timePoint = chrono::system_clock::time_point(duration);
 
     return timePoint;
   }
 
-  static inline jsi::Value toJSI(jsi::Runtime& runtime, const std::chrono::system_clock::time_point& date) {
-    using namespace std::chrono;
-
+  static inline jsi::Value toJSI(jsi::Runtime& runtime, const chrono::system_clock::time_point& date) {
     // 1. Get milliseconds since epoch as a double
-    auto ms = duration_cast<milliseconds>(date.time_since_epoch()).count();
-    double msSinceEpoch = static_cast<double>(ms);
+    auto ms = chrono::duration_cast<chrono::milliseconds>(date.time_since_epoch()).count();
+    auto msSinceEpoch = static_cast<double>(ms);
 
     // TODO: Cache this
     jsi::Object global = runtime.global();

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
@@ -38,16 +38,16 @@ struct JSIConverter<std::chrono::system_clock::time_point> final {
 
     jsi::Object object = arg.asObject(runtime);
 #ifdef NITRO_DEBUG
-    if (!object.hasProperty(runtime, "valueOf")) {
+    if (!object.hasProperty(runtime, "getTime")) {
       throw std::invalid_argument("Object \"" + arg.toString(runtime).utf8(runtime) +
-                                  "\" does not have a .valueOf() function! "
+                                  "\" does not have a .getTime() function! "
                                   "It's not a valid Date object.");
     }
 #endif
 
     // TODO: Cache this
-    jsi::Function valueOfFunc = object.getPropertyAsFunction(runtime, "valueOf");
-    double msSinceEpoch = valueOfFunc.callWithThis(runtime, object).getNumber();
+    jsi::Function getTimeFunc = object.getPropertyAsFunction(runtime, "getTime");
+    double msSinceEpoch = getTimeFunc.callWithThis(runtime, object).getNumber();
 
     // ms -> std::chrono::system_clock::time_point
     auto durationMs = chrono::duration<double, std::milli>(msSinceEpoch);

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Date.hpp
@@ -22,8 +22,10 @@ struct JSIConverter;
 namespace margelo::nitro {
 
 using namespace facebook;
+using namespace std;
 
 // Date <> chrono::system_clock::time_point
+template <>
 struct JSIConverter<std::chrono::system_clock::time_point> final {
   static inline std::chrono::system_clock::time_point fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
     using namespace std::chrono;
@@ -50,8 +52,8 @@ struct JSIConverter<std::chrono::system_clock::time_point> final {
     double msSinceEpoch = valueOfFunc.call(runtime, object).getNumber();
 
     // ms -> std::chrono::system_clock::time_point
-    auto duration = duration<double, std::milli>(msSinceEpoch);
-    auto timePoint = system_clock::time_point(duration_cast<system_clock::duration>(duration));
+    auto duration = chrono::duration<double, std::milli>(msSinceEpoch);
+    auto timePoint = chrono::system_clock::time_point(chrono::duration_cast<chrono::system_clock::duration>(duration));
 
     return timePoint;
   }

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter.hpp
@@ -183,6 +183,7 @@ struct JSIConverter<std::string> final {
 
 #include "JSIConverter+AnyMap.hpp"
 #include "JSIConverter+ArrayBuffer.hpp"
+#include "JSIConverter+Date.hpp"
 #include "JSIConverter+Exception.hpp"
 #include "JSIConverter+Function.hpp"
 #include "JSIConverter+HostObject.hpp"

--- a/packages/react-native-nitro-modules/ios/utils/Date+fromChrono.swift
+++ b/packages/react-native-nitro-modules/ios/utils/Date+fromChrono.swift
@@ -1,0 +1,27 @@
+//
+//  Date+fromChrono.swift
+//  Nitro
+//
+//  Created by Marc Rousavy on 04.06.25.
+//
+
+import Foundation
+
+public extension Date {
+  /**
+   * Create a new `Date` object from the given `std::chrono::system_clock::time_point` value.
+   */
+  public init(fromChrono date: margelo.nitro.chrono_time) {
+    let millisecondsSinceEpoch = margelo.nitro.millisecondsSinceEpochFromChronoDate(date)
+    self = .init(timeIntervalSince1970: millisecondsSinceEpoch / 1_000)
+  }
+  
+  /**
+   * Converts this `Date` object to a `std::chrono::system_clock::time_point` value.
+   */
+  public func toCpp() -> margelo.nitro.chrono_time {
+    let secondsSinceEpoch = self.timeIntervalSince1970
+    let millisecondsSinceEpoch = secondsSinceEpoch * 1_000
+    return margelo.nitro.chronoDateFromMillisecondsSinceEpoch(millisecondsSinceEpoch)
+  }
+}

--- a/packages/react-native-nitro-modules/ios/utils/DateToChronoDate.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/DateToChronoDate.hpp
@@ -1,0 +1,33 @@
+//
+//  DateToChronoDate.hpp
+//  NitroModules
+//
+//  Created by Marc Rousavy on 04.06.25.
+//
+
+#pragma once
+
+#include "NitroTypeInfo.hpp"
+#include <chrono>
+
+namespace margelo::nitro {
+
+struct ChronoHelper {
+public:
+  static bool doooo() {
+    return false;
+  }
+};
+
+static inline void dummyFonc() {
+  return;
+}
+
+static inline std::chrono::system_clock::time_point chronoDateFromMillisecondsSinceEpoch(double msSinceEpoch) {
+  auto durationMs = chrono::duration<double, std::milli>(msSinceEpoch);
+  auto duration = chrono::duration_cast<chrono::system_clock::duration>(durationMs);
+  auto date = chrono::system_clock::time_point(duration);
+  return date;
+}
+
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/ios/utils/DateToChronoDate.hpp
+++ b/packages/react-native-nitro-modules/ios/utils/DateToChronoDate.hpp
@@ -12,22 +12,24 @@
 
 namespace margelo::nitro {
 
-struct ChronoHelper {
-public:
-  static bool doooo() {
-    return false;
-  }
-};
+using namespace std;
 
-static inline void dummyFonc() {
-  return;
-}
+/**
+ * Represents `std::chrono::system_clock::time_point`.
+ */
+using chrono_time = std::chrono::system_clock::time_point;
 
-static inline std::chrono::system_clock::time_point chronoDateFromMillisecondsSinceEpoch(double msSinceEpoch) {
+static inline chrono::system_clock::time_point chronoDateFromMillisecondsSinceEpoch(double msSinceEpoch) {
   auto durationMs = chrono::duration<double, std::milli>(msSinceEpoch);
   auto duration = chrono::duration_cast<chrono::system_clock::duration>(durationMs);
   auto date = chrono::system_clock::time_point(duration);
   return date;
+}
+
+static inline double millisecondsSinceEpochFromChronoDate(chrono::system_clock::time_point date) {
+  auto duration = date.time_since_epoch();
+  auto milliseconds = chrono::duration_cast<chrono::milliseconds>(duration).count();
+  return static_cast<double>(milliseconds);
 }
 
 } // namespace margelo::nitro


### PR DESCRIPTION
A JS `Date` can now be converted from and to native.

- C++: `std::chrono::system_clock::time_point`
- Swift: `Date`
- Kotlin: `java.time.Instant`