### PR TITLE
fix: Fix Xcode build error by making variants of enums `indirect`

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftVariant.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftVariant.ts
@@ -13,7 +13,6 @@ function isPrimitive(type: Type): boolean {
     case 'number':
     case 'string':
     case 'void':
-    case 'enum':
     case 'result-wrapper':
     case 'null':
     case 'error':

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Variant_Bool_OldEnum.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/Variant_Bool_OldEnum.swift
@@ -10,7 +10,7 @@
  * JS type: `boolean | enum`
  */
 @frozen
-public enum Variant_Bool_OldEnum {
+public indirect enum Variant_Bool_OldEnum {
   case first(Bool)
   case second(OldEnum)
 }


### PR DESCRIPTION
Apparently variants that contain `enum`s cannot be `direct enum`s (implicit), so they have to be `indirect enum`s. Aka not inlined but heap allocated. 