### PR TITLE
fix: Clear Promise callbacks after resolve or reject to prevent JNI dtor error

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -106,6 +106,7 @@ public:
     for (const auto& onResolved : _onResolvedListeners) {
       onResolved(std::get<TResult>(_state));
     }
+    didFinish();
   }
   void resolve(const TResult& result) {
     std::unique_lock lock(_mutex);
@@ -116,6 +117,7 @@ public:
     for (const auto& onResolved : _onResolvedListeners) {
       onResolved(std::get<TResult>(_state));
     }
+    didFinish();
   }
   /**
    * Rejects this Promise with the given error, and calls any pending listeners.
@@ -134,6 +136,7 @@ public:
     for (const auto& onRejected : _onRejectedListeners) {
       onRejected(exception);
     }
+    didFinish();
   }
 
 public:
@@ -246,6 +249,12 @@ public:
   }
 
 private:
+  void didFinish() noexcept {
+    _onResolvedListeners.clear();
+    _onRejectedListeners.clear();
+  }
+
+private:
   std::variant<std::monostate, TResult, std::exception_ptr> _state;
   std::vector<OnResolvedFunc> _onResolvedListeners;
   std::vector<OnRejectedFunc> _onRejectedListeners;
@@ -319,6 +328,7 @@ public:
     for (const auto& onResolved : _onResolvedListeners) {
       onResolved();
     }
+    didFinish();
   }
   void reject(const std::exception_ptr& exception) {
     if (exception == nullptr) [[unlikely]] {
@@ -333,6 +343,7 @@ public:
     for (const auto& onRejected : _onRejectedListeners) {
       onRejected(exception);
     }
+    didFinish();
   }
 
 public:
@@ -399,6 +410,12 @@ public:
   [[nodiscard]]
   inline bool isPending() const noexcept {
     return !isResolved() && !isRejected();
+  }
+
+private:
+  void didFinish() noexcept {
+    _onResolvedListeners.clear();
+    _onRejectedListeners.clear();
   }
 
 private:


### PR DESCRIPTION
### Problem

Fixes an error where the `~JPromise()` destructor was being called from an arbitrary Thread (hades GC), causing a runtime crash (SIGABRT) because the Thread was not attached to JNI.

The problem is that the `~Promise()` destructor: https://github.com/mrousavy/nitro/blob/2ae634c81f570a098ae0a393d970e448a339d0d2/packages/react-native-nitro-modules/cpp/core/Promise.hpp#L36-L41

Is obviously destroying it's fields: https://github.com/mrousavy/nitro/blob/2ae634c81f570a098ae0a393d970e448a339d0d2/packages/react-native-nitro-modules/cpp/core/Promise.hpp#L248-L252

And one of those fields contains a JNI value. To be more explicit, it's one of the `OnResolvedFunc` inside the `_onResolvedListeners`; https://github.com/mrousavy/nitro/blob/2ae634c81f570a098ae0a393d970e448a339d0d2/packages/react-native-nitro-modules/cpp/core/Promise.hpp#L251

Because if we take a look at the usage of `Promise` in `JFunc_std__shared_ptr_Promise_double__ `, we can see that the function passed to `addOnResolvedListener(...)` **captures** `__promise` - a JNI value: https://github.com/mrousavy/nitro/blob/2ae634c81f570a098ae0a393d970e448a339d0d2/packages/react-native-nitro-image/nitrogen/generated/android/c%2B%2B/JFunc_std__shared_ptr_Promise_double__.hpp#L65-L77

... So this call here: https://github.com/mrousavy/nitro/blob/2ae634c81f570a098ae0a393d970e448a339d0d2/packages/react-native-nitro-image/nitrogen/generated/android/c%2B%2B/JFunc_std__shared_ptr_Promise_double__.hpp#L69-L71

Captures `__promise` by value, and after it already completed, the function here is the last strong reference to `__promise`. Once the holder `Promise` gets destroyed, so does this function, and so do all of it's captured members - aka `__promise`.

Since this is happening from JS' GC on a Hades Thread, it's not really possible to keep this deterministic. By design, obviously. 

### Solution

So the solution is to clear the `_onResolvedListeners` and `_onRejectedListeners` immediately after resolving/rejecting the Promise to avoid them dangling around in memory. This ensures we kill them on the proper Thread too!

### Related Issues

- Fixes https://github.com/mrousavy/nitro/issues/672
- Closes https://github.com/mrousavy/nitro/pull/664
- Closes https://github.com/mrousavy/nitro/pull/673