### PR TITLE
fix: Always generate `.gitattributes` - boolean flag controls `linguist-generated` now

### DIFF
--- a/docs/docs/configuration-nitro-json.md
+++ b/docs/docs/configuration-nitro-json.md
@@ -18,7 +18,7 @@
   },
   "autolinking": {},
   "ignorePaths": ["**/node_modules"],
-  "createGitAttributes": true
+  "gitAttributesGeneratedFlag": true
 }
 ```
 
@@ -178,6 +178,7 @@ Configures the TypeScript parser to ignore specific given paths when looking for
 
 By default, this is empty (`[]`), but it can be set to ignore paths like `["node_modules", "lib"]`.
 
-## `createGitAttributes`
+## `gitAttributesGeneratedFlag`
 
-Configures whether a `.gitattributes` file will be generated in the `nitrogen/generated/` directory to mark files as [`linguist-generated`](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) for GitHub.
+Configures whether all nitro-generated files are marked as [`linguist-generated`](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) for GitHub. This disables diffing for generated content and excludes them from language statistics.
+This is controlled via `nitrogen/generated/.gitattributes`.

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -762,9 +762,10 @@ Configures the TypeScript parser to ignore specific given paths when looking for
 
 By default, this is empty ( `[]`), but it can be set to ignore paths like `["node_modules", "lib"]`.
 
-## `createGitAttributes` [​](https://nitro.margelo.com/docs/configuration-nitro-json\#creategitattributes "Direct link to creategitattributes")
+## `gitAttributesGeneratedFlag` [​](https://nitro.margelo.com/docs/configuration-nitro-json\#gitattributesgeneratedflag "Direct link to gitattributesgeneratedflag")
 
-Configures whether a `.gitattributes` file will be generated in the `nitrogen/generated/` directory to mark files as [`linguist-generated`](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) for GitHub.
+Configures whether all nitro-generated files are marked as [`linguist-generated`](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) for GitHub. This disables diffing for generated content and excludes them from language statistics.
+This is controlled via `nitrogen/generated/.gitattributes`.
 
 - [`cxxNamespace`](https://nitro.margelo.com/docs/configuration-nitro-json#cxxnamespace)
 - [`ios`](https://nitro.margelo.com/docs/configuration-nitro-json#ios)

--- a/docs/static/nitro.schema.json
+++ b/docs/static/nitro.schema.json
@@ -95,10 +95,10 @@
       },
       "description": "A list of paths relative to the project directory that should be ignored by nitrogen. Nitrogen will not look for `.nitro.ts` files in these directories."
     },
-    "createGitAttributes": {
+    "gitAttributesGeneratedFlag": {
       "type": "boolean",
       "default": true,
-      "description": "Configures whether a `.gitattributes` file will be generated in the `nitrogen/generated/` directory to mark files as `linguist-generated` for GitHub."
+      "description": "Configures whether all nitro-generated files should be marked as `linguist-generated` for GitHub. This excludes generated files from diffing and language statistics."
     }
   }
 }

--- a/packages/nitrogen/src/config/NitroConfig.ts
+++ b/packages/nitrogen/src/config/NitroConfig.ts
@@ -118,7 +118,7 @@ export const NitroConfig = {
     return getUserConfig().ignorePaths ?? []
   },
 
-  getCreateGitAttributes(): boolean {
-    return getUserConfig().createGitAttributes ?? false
+  getGitAttributesGeneratedFlag(): boolean {
+    return getUserConfig().gitAttributesGeneratedFlag ?? false
   },
 }

--- a/packages/nitrogen/src/config/NitroUserConfig.ts
+++ b/packages/nitrogen/src/config/NitroUserConfig.ts
@@ -91,10 +91,12 @@ export const NitroUserConfigSchema = z.object({
    */
   ignorePaths: z.array(z.string()).optional(),
   /**
-   * Configures whether a `.gitattributes` file will be generated in
-   * the `nitrogen/generated/` directory to mark files as linguist-generated for GitHub.
+   * Configures whether all nitro-generated files are marked as
+   * [`linguist-generated`](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)
+   * for GitHub. This disables diffing for generated content and excludes them from language statistics.
+   * This is controlled via `nitrogen/generated/.gitattributes`.
    */
-  createGitAttributes: z.boolean().optional().default(true),
+  gitAttributesGeneratedFlag: z.boolean().optional().default(true),
 })
 
 /**

--- a/packages/nitrogen/src/createGitAttributes.ts
+++ b/packages/nitrogen/src/createGitAttributes.ts
@@ -1,13 +1,15 @@
 import fs from 'fs/promises'
 import path from 'path'
 
-const GIT_ATTRIBUTES_CONTENT = `
-* linguist-generated
-`
-
-export async function createGitAttributes(folder: string): Promise<string> {
+export async function createGitAttributes(
+  markAsGenerated: boolean,
+  folder: string
+): Promise<string> {
   const file = path.join(folder, '.gitattributes')
   // Marks all files in this current folder as "generated"
-  await fs.writeFile(file, GIT_ATTRIBUTES_CONTENT.trim() + '\n', 'utf-8')
+  const content = `
+* linguist-generated=${markAsGenerated}
+  `.trim()
+  await fs.writeFile(file, content + '\n', 'utf-8')
   return file
 }

--- a/packages/nitrogen/src/nitrogen.ts
+++ b/packages/nitrogen/src/nitrogen.ts
@@ -229,11 +229,10 @@ export async function runNitrogen({
   }
 
   try {
-    if (NitroConfig.getCreateGitAttributes()) {
-      // write a .gitattributes file
-      const file = await createGitAttributes(outputDirectory)
-      filesAfter.push(file)
-    }
+    // write a .gitattributes file
+    const markAsGenerated = NitroConfig.getGitAttributesGeneratedFlag()
+    const file = await createGitAttributes(markAsGenerated, outputDirectory)
+    filesAfter.push(file)
   } catch {
     Logger.error(`❌ Failed to write ${chalk.dim(`.gitattributes`)}!`)
   }

--- a/packages/react-native-nitro-image/nitro.json
+++ b/packages/react-native-nitro-image/nitro.json
@@ -40,5 +40,5 @@
   "ignorePaths": [
     "**/node_modules"
   ],
-  "createGitAttributes": false
+  "gitAttributesGeneratedFlag": false
 }


### PR DESCRIPTION
To keep it more deterministic, we always generate a `.gitattributes` file now.
We control the `linguist-generated` flag with a boolean now (true or false)