### PR TITLE
feat: Enable 16 KB page size on Android

### DIFF
--- a/packages/react-native-nitro-image/android/build.gradle
+++ b/packages/react-native-nitro-image/android/build.gradle
@@ -48,7 +48,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-frtti -fexceptions -Wall -Wextra -fstack-protector-all"
-        arguments "-DANDROID_STL=c++_shared"
+        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         abiFilters (*reactNativeArchitectures())
 
         buildTypes {

--- a/packages/react-native-nitro-modules/android/build.gradle
+++ b/packages/react-native-nitro-modules/android/build.gradle
@@ -51,7 +51,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-frtti -fexceptions -Wall -Wextra -fstack-protector-all"
-        arguments "-DANDROID_STL=c++_shared"
+        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         abiFilters (*reactNativeArchitectures())
 
         buildTypes {

--- a/packages/template/android/build.gradle
+++ b/packages/template/android/build.gradle
@@ -48,7 +48,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-frtti -fexceptions -Wall -Wextra -fstack-protector-all"
-        arguments "-DANDROID_STL=c++_shared"
+        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         abiFilters (*reactNativeArchitectures())
 
         buildTypes {


### PR DESCRIPTION
Enables support for 16 KB page sizes on Android.

Each Nitro Module library will need to define this for themselves too in their `build.gradle` file.

See [Support 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes) for more information.