### PR TITLE
feat: Add `ArrayBuffer.wrap(HardwareBuffer)` API

### DIFF
--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/HardwareBufferArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/HardwareBufferArrayBuffer.hpp
@@ -1,0 +1,92 @@
+//
+//  HardwareBufferArrayBuffer.hpp
+//  react-native-nitro
+//
+//  Created by Marc Rousavy on 14.07.24.
+//
+
+#pragma once
+
+#include "ArrayBuffer.hpp"
+#include <android/hardware_buffer.h>
+#include <android/hardware_buffer_jni.h>
+#include <fbjni/ByteBuffer.h>
+#include <fbjni/fbjni.h>
+
+namespace margelo::nitro {
+
+using namespace facebook;
+
+/**
+ * Represents an `ArrayBuffer` that holds a `HardwareBuffer`.
+ */
+class HardwareBufferArrayBuffer final : public ArrayBuffer {
+public:
+  /**
+   * Create a new `HardwareBufferArrayBuffer` instance that wraps the given `HardwareBuffer`.
+   * This constructor will add a +1 retain count on the given `hardwareBuffer` using
+   * `AHardwareBuffer_acquire(...)`, and release it again once it is destructured.
+   */
+  explicit HardwareBufferArrayBuffer(AHardwareBuffer* hardwareBuffer)
+      : _hardwareBuffer(hardwareBuffer), _dataCached(nullptr), _isLocked(false) {
+    AHardwareBuffer_acquire(hardwareBuffer);
+  }
+
+  ~HardwareBufferArrayBuffer() override {
+    // Hermes GC can destroy JS objects on a non-JNI Thread.
+    unlock();
+    jni::ThreadScope::WithClassLoader([&] { AHardwareBuffer_release(_hardwareBuffer); });
+  }
+
+public:
+  /**
+   * Unlocks the HardwareBuffer if it was locked.
+   * Subsequent calls to `data()` will have to lock the buffer again.
+   *
+   * It is a good practice to call this when the buffer is likely not being
+   * read from using this `HardwareBufferArrayBuffer` instance again anytime soon.
+   */
+  void unlock() {
+    if (_isLocked) {
+      AHardwareBuffer_unlock(_hardwareBuffer, nullptr);
+    }
+    _dataCached = nullptr;
+  }
+
+public:
+  [[nodiscard]] uint8_t* data() override {
+    if (_isLocked && _dataCached != nullptr) {
+      // We are still locked on the AHardwareBuffer* and have a valid buffer.
+      return _dataCached;
+    }
+    void* buffer;
+    int result = AHardwareBuffer_lock(_hardwareBuffer, AHARDWAREBUFFER_USAGE_CPU_READ_MASK, -1, nullptr, &buffer);
+    if (result != 0) {
+      throw std::runtime_error("Failed to read HardwareBuffer bytes!");
+    }
+    _dataCached = static_cast<uint8_t*>(buffer);
+    _isLocked = true;
+    return _dataCached;
+  }
+  [[nodiscard]] size_t size() const override {
+    AHardwareBuffer_Desc description;
+    AHardwareBuffer_describe(_hardwareBuffer, &description);
+    size_t size = description.height * description.stride;
+    return size;
+  }
+  [[nodiscard]] bool isOwner() const noexcept override {
+    return true;
+  }
+
+public:
+  [[nodiscard]] AHardwareBuffer* getBuffer() const {
+    return _hardwareBuffer;
+  }
+
+private:
+  AHardwareBuffer* _hardwareBuffer;
+  uint8_t* _dataCached;
+  bool _isLocked;
+};
+
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt
@@ -1,6 +1,7 @@
 package com.margelo.nitro.core
 
 import androidx.annotation.Keep
+import android.hardware.HardwareBuffer
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import dalvik.annotation.optimization.FastNative
@@ -77,6 +78,17 @@ class ArrayBuffer {
     }
 
     /**
+     * Create a new **owning-** `ArrayBuffer` that holds the given `HardwareBuffer`.
+     * The `HardwareBuffer` needs to remain valid for as long as the `ArrayBuffer` is alive.
+     */
+    constructor(hardwareBuffer: HardwareBuffer) {
+        if (hardwareBuffer.isClosed) {
+            throw Error("Cannot create ArrayBuffer from an already-closed HardwareBuffer!")
+        }
+        mHybridData = initHybrid(hardwareBuffer)
+    }
+
+    /**
      * Create a new **non-owning-** `ArrayBuffer` that holds foreign data, potentially coming from JS.
      */
     @Suppress("unused")
@@ -87,6 +99,7 @@ class ArrayBuffer {
     }
 
     private external fun initHybrid(buffer: ByteBuffer): HybridData
+    private external fun initHybrid(hardwareBuffer: HardwareBuffer): HybridData
     private external fun getByteBuffer(copyIfNeeded: Boolean): ByteBuffer
     @FastNative
     private external fun getIsOwner(): Boolean
@@ -129,6 +142,13 @@ class ArrayBuffer {
             // 5. Create a new `ArrayBuffer`
             return ArrayBuffer(newBuffer)
         }
+        /**
+         * Copy the given `HardwareBuffer` into a new **owning** `ArrayBuffer`.
+         */
+        fun copy(hardwareBuffer: HardwareBuffer): ArrayBuffer {
+            // TODO: Copy hardwareBuffer
+            return ArrayBuffer(hardwareBuffer)
+        }
 
         /**
          * Wrap the given `ByteBuffer` in a new **owning** `ArrayBuffer`.
@@ -136,6 +156,13 @@ class ArrayBuffer {
         fun wrap(byteBuffer: ByteBuffer): ArrayBuffer {
             byteBuffer.rewind()
             return ArrayBuffer(byteBuffer)
+        }
+
+        /**
+         * Wrap the given `HardwareBuffer` in a new **owning** `ArrayBuffer`.
+         */
+        fun wrap(hardwareBuffer: HardwareBuffer): ArrayBuffer {
+            return ArrayBuffer(hardwareBuffer)
         }
     }
 }


### PR DESCRIPTION
Adds an API to `ArrayBuffer` that support handling `HardwareBuffer`.

This is a highly efficient buffer type that can even be shared GPU memory - we will need this for VisionCamera.