### PR TITLE
chore: Slap `[[maybe_unused]]` onto debug-only parameters to clean up build logs

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -181,8 +181,9 @@ private:
    * Get the `NativeState` of the given `value`.
    */
   template <typename THybrid>
-  static inline std::shared_ptr<THybrid> getHybridObjectNativeState(jsi::Runtime& runtime, const jsi::Value& value, FunctionKind funcKind,
-                                                                    const std::string& funcName) {
+  static inline std::shared_ptr<THybrid> getHybridObjectNativeState(jsi::Runtime& runtime, const jsi::Value& value,
+                                                                    [[maybe_unused]] FunctionKind funcKind,
+                                                                    [[maybe_unused]] const std::string& funcName) {
     // 1. Convert jsi::Value to jsi::Object
 #ifdef NITRO_DEBUG
     if (!value.isObject()) [[unlikely]] {

--- a/packages/react-native-nitro-modules/cpp/platform/NitroLogger.hpp
+++ b/packages/react-native-nitro-modules/cpp/platform/NitroLogger.hpp
@@ -22,7 +22,8 @@ private:
 
 public:
   template <typename... Args>
-  static void log(LogLevel level, const char* tag, const char* format, Args... args) {
+  static void log([[maybe_unused]] LogLevel level, [[maybe_unused]] const char* tag, [[maybe_unused]] const char* format,
+                  [[maybe_unused]] Args... args) {
 #ifdef NITRO_DEBUG
     // 1. Make sure args can be passed to sprintf(..)
     static_assert(all_are_trivially_copyable<Args...>(), "All arguments passed to Logger::log(..) must be trivially copyable! "


### PR DESCRIPTION
this was getting annoying:

![Screenshot 2025-06-11 at 18 07 55](https://github.com/user-attachments/assets/51085d20-859a-405a-8ae7-9a558e21d98b)
