### PR TITLE
fix: remove unused StateWrapperImpl import

### DIFF
--- a/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
+++ b/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
@@ -43,7 +43,6 @@ ${createFileMetadataString(`${manager}.kt`)}
 package ${javaSubNamespace}
 
 import android.view.View
-import com.facebook.react.fabric.StateWrapperImpl
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.StateWrapper

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/views/HybridTestViewManager.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/views/HybridTestViewManager.kt
@@ -8,7 +8,6 @@
 package com.margelo.nitro.image.views
 
 import android.view.View
-import com.facebook.react.fabric.StateWrapperImpl
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.StateWrapper


### PR DESCRIPTION
Leaving this in might cause build error on RN 0.80, but either way we don't need this.