### PR TITLE
feat: add typed sets to supported Nitro types

### DIFF
--- a/docs/docs/types/typed-sets.md
+++ b/docs/docs/types/typed-sets.md
@@ -1,0 +1,48 @@
+---
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Typed sets (`Set<T>`)
+
+A typed set is a collection of unique items of type `T` that allows you to quickly check if a collection contains a certain item.
+
+It is useful in situation where you need to quickly check if you have 'seen' an item, or if there's a need of checking for item existence but you don't care about ordering of items.
+
+For example if your API returns a list of banned user IDs and you need to query quickly in the codebase if user is banned, you can model it like this:
+
+<Tabs>
+  <TabItem value="ts" label="TypeScript" default>
+    ```ts
+    interface Database extends HybridObject {
+      getBannedUserIDs(): Set<number>
+    }
+    ```
+  </TabItem>
+  <TabItem value="swift" label="Swift">
+    ```swift
+    class HybridDatabase: HybridDatabaseSpec {
+      func getBannedUserIDs() -> Set<Double>
+    }
+    ```
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+    ```kotlin
+    class HybridDatabase: HybridDatabaseSpec() {
+      fun getBannedUserIDs(): Set<Double>
+    }
+    ```
+  </TabItem>
+  <TabItem value="cpp" label="C++">
+    ```cpp
+    class HybridDatabase: public HybridDatabaseSpec {
+      std::unordered_set<double> getBannedUserIDs();
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+:::tip
+JavaScript `Set` objects are guaranteeing iteration over their elements in insertion order. This invariant is not upheld with the current, `std::unordered_set`-based implementation.
+:::

--- a/docs/docs/types/types.md
+++ b/docs/docs/types/types.md
@@ -15,7 +15,7 @@ For example, a JS `number` will always be a `double` on the native side:
 
 ```ts title="Math.nitro.ts"
 interface Math extends HybridObject {
-  add(a: number, b: number): number
+  add(a: number, b: number): number;
 }
 ```
 
@@ -125,6 +125,11 @@ These are all the types Nitro supports out of the box:
     <td><code>Dictionary&lt;String, T&gt;</code></td>
     <td><code>Map&lt;String, T&gt;</code></td>
   </tr>
+  <tr>
+    <td><code>Set&lt;T&gt;</code></td>
+    <td><code>std::unordered_set&lt;T&gt;</code></td>
+    <td><code>Set&lt;T&gt;</code></td>
+    <td><code>Set&lt;T&gt;</code></td>
   <tr>
     <td><code>Error</code></td>
     <td><code>std::exception_ptr</code></td>

--- a/packages/nitrogen/src/syntax/createType.ts
+++ b/packages/nitrogen/src/syntax/createType.ts
@@ -1,124 +1,130 @@
-import { ts, Type as TSMorphType, type Signature } from 'ts-morph'
-import type { Type } from './types/Type.js'
-import { NullType } from './types/NullType.js'
-import { BooleanType } from './types/BooleanType.js'
-import { NumberType } from './types/NumberType.js'
-import { StringType } from './types/StringType.js'
-import { BigIntType } from './types/BigIntType.js'
-import { VoidType } from './types/VoidType.js'
-import { ArrayType } from './types/ArrayType.js'
-import { FunctionType } from './types/FunctionType.js'
-import { PromiseType } from './types/PromiseType.js'
-import { RecordType } from './types/RecordType.js'
-import { ArrayBufferType } from './types/ArrayBufferType.js'
-import { EnumType } from './types/EnumType.js'
-import { HybridObjectType } from './types/HybridObjectType.js'
-import { StructType } from './types/StructType.js'
-import { OptionalType } from './types/OptionalType.js'
-import { NamedWrappingType } from './types/NamedWrappingType.js'
-import { getInterfaceProperties } from './getInterfaceProperties.js'
-import { VariantType } from './types/VariantType.js'
-import { MapType } from './types/MapType.js'
-import { TupleType } from './types/TupleType.js'
+import { ts, Type as TSMorphType, type Signature } from "ts-morph";
+import type { Type } from "./types/Type.js";
+import { NullType } from "./types/NullType.js";
+import { BooleanType } from "./types/BooleanType.js";
+import { NumberType } from "./types/NumberType.js";
+import { StringType } from "./types/StringType.js";
+import { BigIntType } from "./types/BigIntType.js";
+import { VoidType } from "./types/VoidType.js";
+import { ArrayType } from "./types/ArrayType.js";
+import { FunctionType } from "./types/FunctionType.js";
+import { PromiseType } from "./types/PromiseType.js";
+import { RecordType } from "./types/RecordType.js";
+import { ArrayBufferType } from "./types/ArrayBufferType.js";
+import { EnumType } from "./types/EnumType.js";
+import { HybridObjectType } from "./types/HybridObjectType.js";
+import { StructType } from "./types/StructType.js";
+import { OptionalType } from "./types/OptionalType.js";
+import { NamedWrappingType } from "./types/NamedWrappingType.js";
+import { getInterfaceProperties } from "./getInterfaceProperties.js";
+import { VariantType } from "./types/VariantType.js";
+import { MapType } from "./types/MapType.js";
+import { TupleType } from "./types/TupleType.js";
+import { SetType } from "./types/SetType.js";
+
 import {
   isAnyHybridSubclass,
   isDirectlyHybridObject,
   isHybridView,
   type Language,
-} from '../getPlatformSpecs.js'
-import { HybridObjectBaseType } from './types/HybridObjectBaseType.js'
-import { ErrorType } from './types/ErrorType.js'
-import { getBaseTypes } from '../utils.js'
-import { DateType } from './types/DateType.js'
+} from "../getPlatformSpecs.js";
+import { HybridObjectBaseType } from "./types/HybridObjectBaseType.js";
+import { ErrorType } from "./types/ErrorType.js";
+import { getBaseTypes } from "../utils.js";
+import { DateType } from "./types/DateType.js";
 
 function isSymbol(type: TSMorphType, symbolName: string): boolean {
-  const symbol = type.getSymbol()
+  const symbol = type.getSymbol();
   if (symbol?.getName() === symbolName) {
-    return true
+    return true;
   }
-  const aliasSymbol = type.getAliasSymbol()
+  const aliasSymbol = type.getAliasSymbol();
   if (aliasSymbol?.getName() === symbolName) {
-    return true
+    return true;
   }
-  return false
+  return false;
 }
 
 function isPromise(type: TSMorphType): boolean {
-  return isSymbol(type, 'Promise')
+  return isSymbol(type, "Promise");
 }
 
 function isRecord(type: TSMorphType): boolean {
-  return isSymbol(type, 'Record')
+  return isSymbol(type, "Record");
+}
+
+function isSet(type: TSMorphType): boolean {
+  return isSymbol(type, "Set");
 }
 
 function isArrayBuffer(type: TSMorphType): boolean {
-  return isSymbol(type, 'ArrayBuffer')
+  return isSymbol(type, "ArrayBuffer");
 }
 
 function isDate(type: TSMorphType): boolean {
-  return isSymbol(type, 'Date')
+  return isSymbol(type, "Date");
 }
 
 function isMap(type: TSMorphType): boolean {
-  return isSymbol(type, 'AnyMap')
+  return isSymbol(type, "AnyMap");
 }
 
 function isError(type: TSMorphType): boolean {
-  return isSymbol(type, 'Error')
+  return isSymbol(type, "Error");
 }
 
 function getHybridObjectName(type: TSMorphType): string {
-  const symbol = isHybridView(type) ? type.getAliasSymbol() : type.getSymbol()
+  const symbol = isHybridView(type) ? type.getAliasSymbol() : type.getSymbol();
   if (symbol == null) {
     throw new Error(
       `Cannot get name of \`${type.getText()}\` - symbol not found!`
-    )
+    );
   }
-  return symbol.getEscapedName()
+  return symbol.getEscapedName();
 }
 
 function getFunctionCallSignature(func: TSMorphType): Signature {
-  const callSignatures = func.getCallSignatures()
-  const callSignature = callSignatures[0]
+  const callSignatures = func.getCallSignatures();
+  const callSignature = callSignatures[0];
   if (callSignatures.length !== 1 || callSignature == null) {
     throw new Error(
       `Function overloads are not supported in Nitrogen! (in ${func.getText()})`
-    )
+    );
   }
-  return callSignature
+  return callSignature;
 }
 
 function removeDuplicates(types: Type[]): Type[] {
   return types.filter((t1, index, array) => {
     const firstIndexOfType = array.findIndex(
-      (t2) => t1.getCode('c++') === t2.getCode('c++')
-    )
-    return firstIndexOfType === index
-  })
+      (t2) => t1.getCode("c++") === t2.getCode("c++")
+    );
+    return firstIndexOfType === index;
+  });
 }
 
 type Tuple<
   T,
   N extends number,
   R extends unknown[] = [],
-> = R['length'] extends N ? R : Tuple<T, N, [T, ...R]>
+> = R["length"] extends N ? R : Tuple<T, N, [T, ...R]>;
 function getArguments<N extends number>(
   type: TSMorphType,
   typename: string,
   count: N
 ): Tuple<TSMorphType<ts.Type>, N> {
-  const typeArguments = type.getTypeArguments()
-  const aliasTypeArguments = type.getAliasTypeArguments()
+  const typeArguments = type.getTypeArguments();
+  const aliasTypeArguments = type.getAliasTypeArguments();
 
   if (typeArguments.length === count) {
-    return typeArguments as Tuple<TSMorphType<ts.Type>, N>
+    return typeArguments as Tuple<TSMorphType<ts.Type>, N>;
   }
   if (aliasTypeArguments.length === count) {
-    return aliasTypeArguments as Tuple<TSMorphType<ts.Type>, N>
+    return aliasTypeArguments as Tuple<TSMorphType<ts.Type>, N>;
   }
   throw new Error(
     `Type ${type.getText()} looks like a ${typename}, but has ${typeArguments.length} type arguments instead of ${count}!`
-  )
+  );
 }
 
 export function createNamedType(
@@ -127,25 +133,25 @@ export function createNamedType(
   type: TSMorphType,
   isOptional: boolean
 ) {
-  if (name.startsWith('__')) {
+  if (name.startsWith("__")) {
     throw new Error(
       `Name cannot start with two underscores (__) as this is reserved syntax for Nitrogen! (In ${type.getText()})`
-    )
+    );
   }
-  return new NamedWrappingType(name, createType(language, type, isOptional))
+  return new NamedWrappingType(name, createType(language, type, isOptional));
 }
 
 export function createVoidType(): Type {
-  return new VoidType()
+  return new VoidType();
 }
 
 // Caches complex types (types that have a symbol)
-type TypeId = string
+type TypeId = string;
 const knownTypes: Record<Language, Map<TypeId, Type>> = {
-  'c++': new Map<TypeId, Type>(),
-  'swift': new Map<TypeId, Type>(),
-  'kotlin': new Map<TypeId, Type>(),
-}
+  "c++": new Map<TypeId, Type>(),
+  swift: new Map<TypeId, Type>(),
+  kotlin: new Map<TypeId, Type>(),
+};
 
 /**
  * Get a list of all currently known complex types.
@@ -153,22 +159,22 @@ const knownTypes: Record<Language, Map<TypeId, Type>> = {
 export function getAllKnownTypes(language?: Language): Type[] {
   if (language != null) {
     // Get types for the given language
-    return Array.from(knownTypes[language].values())
+    return Array.from(knownTypes[language].values());
   } else {
     // Get types for all languages alltogether
-    const allMaps = Object.values(knownTypes)
-    return allMaps.flatMap((m) => Array.from(m.values()))
+    const allMaps = Object.values(knownTypes);
+    return allMaps.flatMap((m) => Array.from(m.values()));
   }
 }
 
 function getTypeId(type: TSMorphType, isOptional: boolean): string {
-  const symbol = type.getSymbol()
-  let key = type.getText()
+  const symbol = type.getSymbol();
+  let key = type.getText();
   if (symbol != null) {
-    key += '_' + symbol.getFullyQualifiedName()
+    key += "_" + symbol.getFullyQualifiedName();
   }
-  if (isOptional) key += '?'
-  return key
+  if (isOptional) key += "?";
+  return key;
 }
 
 export function addKnownType(
@@ -178,17 +184,17 @@ export function addKnownType(
 ): void {
   if (knownTypes[language].has(key)) {
     // type is already known
-    return
+    return;
   }
-  knownTypes[language].set(key, type)
+  knownTypes[language].set(key, type);
 }
 
 function isSyncFunction(type: TSMorphType): boolean {
   if (type.getCallSignatures().length < 1)
     // not a function.
-    return false
-  const syncTag = type.getProperty('__syncTag')
-  return syncTag != null
+    return false;
+  const syncTag = type.getProperty("__syncTag");
+  return syncTag != null;
 }
 
 /**
@@ -199,171 +205,186 @@ export function createType(
   type: TSMorphType,
   isOptional: boolean
 ): Type {
-  const key = getTypeId(type, isOptional)
+  const key = getTypeId(type, isOptional);
   if (key != null && knownTypes[language].has(key)) {
-    const known = knownTypes[language].get(key)!
+    const known = knownTypes[language].get(key)!;
     if (isOptional === known instanceof OptionalType) {
-      return known
+      return known;
     }
   }
 
   const get = () => {
     if (isOptional) {
-      const wrapping = createType(language, type, false)
-      return new OptionalType(wrapping)
+      const wrapping = createType(language, type, false);
+      return new OptionalType(wrapping);
     }
 
     if (type.isNull() || type.isUndefined()) {
-      return new NullType()
+      return new NullType();
     } else if (type.isBoolean() || type.isBooleanLiteral()) {
-      return new BooleanType()
+      return new BooleanType();
     } else if (type.isNumber() || type.isNumberLiteral()) {
       if (type.isEnumLiteral()) {
         // enum literals are technically just numbers - but we treat them differently in C++.
-        return createType(language, type.getBaseTypeOfLiteralType(), isOptional)
+        return createType(
+          language,
+          type.getBaseTypeOfLiteralType(),
+          isOptional
+        );
       }
-      return new NumberType()
+      return new NumberType();
     } else if (type.isString()) {
-      return new StringType()
+      return new StringType();
     } else if (type.isBigInt() || type.isBigIntLiteral()) {
-      return new BigIntType()
+      return new BigIntType();
     } else if (type.isVoid()) {
-      return new VoidType()
+      return new VoidType();
     } else if (type.isArray()) {
-      const arrayElementType = type.getArrayElementTypeOrThrow()
-      const elementType = createType(language, arrayElementType, false)
-      return new ArrayType(elementType)
+      const arrayElementType = type.getArrayElementTypeOrThrow();
+      const elementType = createType(language, arrayElementType, false);
+      return new ArrayType(elementType);
     } else if (type.isTuple()) {
       const itemTypes = type
         .getTupleElements()
-        .map((t) => createType(language, t, t.isNullable()))
-      return new TupleType(itemTypes)
+        .map((t) => createType(language, t, t.isNullable()));
+      return new TupleType(itemTypes);
     } else if (type.getCallSignatures().length > 0) {
       // It's a function!
-      const callSignature = getFunctionCallSignature(type)
-      const funcReturnType = callSignature.getReturnType()
+      const callSignature = getFunctionCallSignature(type);
+      const funcReturnType = callSignature.getReturnType();
       const returnType = createType(
         language,
         funcReturnType,
         funcReturnType.isNullable()
-      )
+      );
       const parameters = callSignature.getParameters().map((p) => {
-        const declaration = p.getValueDeclarationOrThrow()
-        const parameterType = p.getTypeAtLocation(declaration)
-        const isNullable = parameterType.isNullable() || p.isOptional()
-        return createNamedType(language, p.getName(), parameterType, isNullable)
-      })
-      const isSync = isSyncFunction(type)
-      return new FunctionType(returnType, parameters, isSync)
+        const declaration = p.getValueDeclarationOrThrow();
+        const parameterType = p.getTypeAtLocation(declaration);
+        const isNullable = parameterType.isNullable() || p.isOptional();
+        return createNamedType(
+          language,
+          p.getName(),
+          parameterType,
+          isNullable
+        );
+      });
+      const isSync = isSyncFunction(type);
+      return new FunctionType(returnType, parameters, isSync);
     } else if (isPromise(type)) {
       // It's a Promise!
-      const [promiseResolvingType] = getArguments(type, 'Promise', 1)
+      const [promiseResolvingType] = getArguments(type, "Promise", 1);
       const resolvingType = createType(
         language,
         promiseResolvingType,
         promiseResolvingType.isNullable()
-      )
-      return new PromiseType(resolvingType)
+      );
+      return new PromiseType(resolvingType);
     } else if (isRecord(type)) {
       // Record<K, V> -> unordered_map<K, V>
-      const [keyTypeT, valueTypeT] = getArguments(type, 'Record', 2)
-      const keyType = createType(language, keyTypeT, false)
-      const valueType = createType(language, valueTypeT, false)
-      return new RecordType(keyType, valueType)
+      const [keyTypeT, valueTypeT] = getArguments(type, "Record", 2);
+      const keyType = createType(language, keyTypeT, false);
+      const valueType = createType(language, valueTypeT, false);
+      return new RecordType(keyType, valueType);
+    } else if (isSet(type)) {
+      const [valueTypeT] = getArguments(type, "Set", 1);
+      const valueType = createType(language, valueTypeT, false);
+      return new SetType(valueType);
     } else if (isArrayBuffer(type)) {
       // ArrayBuffer
-      return new ArrayBufferType()
+      return new ArrayBufferType();
     } else if (isMap(type)) {
       // Map
-      return new MapType()
+      return new MapType();
     } else if (isDate(type)) {
       // Date
-      return new DateType()
+      return new DateType();
     } else if (isError(type)) {
       // Error
-      return new ErrorType()
+      return new ErrorType();
     } else if (type.isEnum()) {
       // It is an enum. We need to generate a C++ declaration for the enum
-      const typename = type.getSymbolOrThrow().getEscapedName()
-      const declaration = type.getSymbolOrThrow().getValueDeclarationOrThrow()
+      const typename = type.getSymbolOrThrow().getEscapedName();
+      const declaration = type.getSymbolOrThrow().getValueDeclarationOrThrow();
       const enumDeclaration = declaration.asKindOrThrow(
         ts.SyntaxKind.EnumDeclaration
-      )
-      return new EnumType(typename, enumDeclaration)
+      );
+      return new EnumType(typename, enumDeclaration);
     } else if (type.isUnion()) {
       // It is some kind of union;
       // - of string literals (then it's an enum)
       // - of type `T | undefined` (then it's just optional `T`)
       // - of different types (then it's a variant `A | B | C`)
-      const types = type.getUnionTypes()
+      const types = type.getUnionTypes();
       const nonNullTypes = types.filter(
         (t) => !t.isNull() && !t.isUndefined() && !t.isVoid()
-      )
-      const isEnumUnion = nonNullTypes.every((t) => t.isStringLiteral())
+      );
+      const isEnumUnion = nonNullTypes.every((t) => t.isStringLiteral());
       if (isEnumUnion) {
         // It consists only of string literaly - that means it's describing an enum!
-        const symbol = type.getNonNullableType().getAliasSymbol()
+        const symbol = type.getNonNullableType().getAliasSymbol();
         if (symbol == null) {
           // If there is no alias, it is an inline union instead of a separate type declaration!
           throw new Error(
             `Inline union types ("${type.getText()}") are not supported by Nitrogen!\n` +
               `Extract the union to a separate type, and re-run nitrogen!`
-          )
+          );
         }
-        const typename = symbol.getEscapedName()
-        return new EnumType(typename, type)
+        const typename = symbol.getEscapedName();
+        return new EnumType(typename, type);
       } else {
         // It consists of different types - that means it's a variant!
         let variants = type
           .getUnionTypes()
           // Filter out any nulls or undefineds, as those are already treated as `isOptional`.
           .filter((t) => !t.isNull() && !t.isUndefined() && !t.isVoid())
-          .map((t) => createType(language, t, false))
-        variants = removeDuplicates(variants)
+          .map((t) => createType(language, t, false));
+        variants = removeDuplicates(variants);
 
         if (variants.length === 1) {
           // It's just one type with undefined/null variant(s) - so we treat it like a simple optional.
-          return variants[0]!
+          return variants[0]!;
         }
 
-        const name = type.getAliasSymbol()?.getName()
-        return new VariantType(variants, name)
+        const name = type.getAliasSymbol()?.getName();
+        return new VariantType(variants, name);
       }
     } else if (isAnyHybridSubclass(type)) {
       // It is another HybridObject being referenced!
-      const typename = getHybridObjectName(type)
+      const typename = getHybridObjectName(type);
       const baseTypes = getBaseTypes(type)
         .filter((t) => isAnyHybridSubclass(t))
-        .map((b) => createType(language, b, false))
-      const baseHybrids = baseTypes.filter((b) => b instanceof HybridObjectType)
-      return new HybridObjectType(typename, language, baseHybrids)
+        .map((b) => createType(language, b, false));
+      const baseHybrids = baseTypes.filter(
+        (b) => b instanceof HybridObjectType
+      );
+      return new HybridObjectType(typename, language, baseHybrids);
     } else if (isDirectlyHybridObject(type)) {
       // It is a HybridObject directly/literally. Base type
-      return new HybridObjectBaseType()
+      return new HybridObjectBaseType();
     } else if (type.isInterface()) {
       // It is an `interface T { ... }`, which is a `struct`
-      const typename = type.getSymbolOrThrow().getName()
-      const properties = getInterfaceProperties(language, type)
-      return new StructType(typename, properties)
+      const typename = type.getSymbolOrThrow().getName();
+      const properties = getInterfaceProperties(language, type);
+      return new StructType(typename, properties);
     } else if (type.isObject()) {
       // It is an object. If it has a symbol/name, it is a `type T = ...` declaration, so a `struct`.
       // Otherwise, it is an anonymous/inline object, which cannot be represented in native.
-      const symbol = type.getAliasSymbol()
+      const symbol = type.getAliasSymbol();
       if (symbol != null) {
         // it has a `type T = ...` declaration
-        const typename = symbol.getName()
-        const properties = getInterfaceProperties(language, type)
-        return new StructType(typename, properties)
+        const typename = symbol.getName();
+        const properties = getInterfaceProperties(language, type);
+        return new StructType(typename, properties);
       } else {
         // It's an anonymous object (`{ ... }`)
         throw new Error(
           `Anonymous objects cannot be represented in C++! Extract "${type.getText()}" to a separate interface/type declaration.`
-        )
+        );
       }
     } else if (type.isStringLiteral()) {
       throw new Error(
         `String literal ${type.getText()} cannot be represented in C++ because it is ambiguous between a string and a discriminating union enum.`
-      )
+      );
     } else {
       if (type.getSymbol() == null) {
         // There is no declaration for it!
@@ -371,19 +392,19 @@ export function createType(
         throw new Error(
           `The TypeScript type "${type.getText()}" cannot be resolved - is it imported properly? ` +
             `Make sure to import it properly using fully specified relative or absolute imports, no aliases.`
-        )
+        );
       } else {
         // A different error
         throw new Error(
           `The TypeScript type "${type.getText()}" cannot be represented in C++!`
-        )
+        );
       }
     }
-  }
+  };
 
-  const result = get()
+  const result = get();
   if (key != null) {
-    knownTypes[language].set(key, result)
+    knownTypes[language].set(key, result);
   }
-  return result
+  return result;
 }

--- a/packages/nitrogen/src/syntax/types/SetType.ts
+++ b/packages/nitrogen/src/syntax/types/SetType.ts
@@ -1,0 +1,49 @@
+import type { Language } from "../../getPlatformSpecs.js";
+import { type SourceFile, type SourceImport } from "../SourceFile.js";
+import type { Type, TypeKind } from "./Type.js";
+
+export class SetType implements Type {
+  readonly valueType: Type;
+
+  constructor(valueType: Type) {
+    this.valueType = valueType;
+  }
+
+  get canBePassedByReference(): boolean {
+    // It's a unordered_map<..>, heavy to copy.
+    return true;
+  }
+  get kind(): TypeKind {
+    return "set";
+  }
+
+  getCode(language: Language): string {
+    const valueCode = this.valueType.getCode(language);
+
+    switch (language) {
+      case "c++":
+        return `std::unordered_set<${valueCode}>`;
+      case "swift":
+        return `Set<${valueCode}>`;
+      case "kotlin":
+        return `Set<${valueCode}>`;
+      default:
+        throw new Error(
+          `Language ${language} is not yet supported for RecordType!`
+        );
+    }
+  }
+  getExtraFiles(): SourceFile[] {
+    return [...this.valueType.getExtraFiles()];
+  }
+  getRequiredImports(): SourceImport[] {
+    return [
+      {
+        language: "c++",
+        name: "unordered_set",
+        space: "system",
+      },
+      ...this.valueType.getRequiredImports(),
+    ];
+  }
+}

--- a/packages/nitrogen/src/syntax/types/Type.ts
+++ b/packages/nitrogen/src/syntax/types/Type.ts
@@ -1,29 +1,30 @@
-import type { Language } from '../../getPlatformSpecs.js'
-import type { SourceFile, SourceImport } from '../SourceFile.js'
+import type { Language } from "../../getPlatformSpecs.js";
+import type { SourceFile, SourceImport } from "../SourceFile.js";
 
 export type TypeKind =
-  | 'array-buffer'
-  | 'array'
-  | 'bigint'
-  | 'boolean'
-  | 'enum'
-  | 'error'
-  | 'function'
-  | 'hybrid-object'
-  | 'hybrid-object-base'
-  | 'map'
-  | 'null'
-  | 'number'
-  | 'optional'
-  | 'promise'
-  | 'record'
-  | 'string'
-  | 'struct'
-  | 'tuple'
-  | 'variant'
-  | 'result-wrapper'
-  | 'date'
-  | 'void'
+  | "array-buffer"
+  | "array"
+  | "bigint"
+  | "boolean"
+  | "enum"
+  | "error"
+  | "function"
+  | "hybrid-object"
+  | "hybrid-object-base"
+  | "map"
+  | "null"
+  | "number"
+  | "optional"
+  | "promise"
+  | "record"
+  | "string"
+  | "struct"
+  | "tuple"
+  | "variant"
+  | "result-wrapper"
+  | "date"
+  | "set"
+  | "void";
 
 /**
  * Represents a TypeScript Type that can be represented in a native language (C++, Swift, Kotlin)
@@ -32,27 +33,27 @@ export interface Type {
   /**
    * Get whether this type can be passed by reference in C++ (`const T&` vs `T`)
    */
-  readonly canBePassedByReference: boolean
+  readonly canBePassedByReference: boolean;
   /**
    * Get the kind of the type.
    */
-  readonly kind: TypeKind
+  readonly kind: TypeKind;
   /**
    * Get the native code required to represent this type for the given language (C++, Swift, Kotlin).
    *
    * E.g. for a `number` type, this would return `'double'` in C++.
    */
-  getCode(language: Language): string
+  getCode(language: Language): string;
   /**
    * Get all required extra files that need to be **created** for this type to properly work.
    *
    * E.g. for `type Gender = 'male' | 'female'`, the enum `Gender` needs to be created first (as a separate file).
    */
-  getExtraFiles(): SourceFile[]
+  getExtraFiles(): SourceFile[];
   /**
    * Get all required extra imports that need to be **imported** for this type to properly work.
    */
-  getRequiredImports(): SourceImport[]
+  getRequiredImports(): SourceImport[];
 }
 
 export interface NamedType extends Type {
@@ -61,11 +62,11 @@ export interface NamedType extends Type {
    *
    * E.g. for a class member `double _something`, this returns `'_something'`.
    */
-  readonly name: string
+  readonly name: string;
   /**
    * Get the name of the value escaped as a valid C++ variable name.
    *
    * E.g. for a class member `double some-value`, this returns `'some_value'`.
    */
-  readonly escapedName: string
+  readonly escapedName: string;
 }

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+UnorderedSet.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+UnorderedSet.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+// Forward declare a few of the common types that might have cyclic includes.
+namespace margelo::nitro {
+template <typename T, typename Enable>
+struct JSIConverter;
+} // namespace margelo::nitro
+
+#include "JSIConverter.hpp"
+
+#include "JSIHelpers.hpp"
+#include <jsi/jsi.h>
+#include <unordered_set>
+
+namespace margelo::nitro {
+
+using namespace facebook;
+
+template <typename ValueType>
+struct JSIConverter<std::unordered_set<ValueType>> final {
+  static inline std::unordered_set<ValueType> fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
+    jsi::Object object = arg.asObject(runtime);
+    if (!object.hasProperty(runtime, "values")) {
+      throw std::invalid_argument("Value \"" + arg.toString(runtime).utf8(runtime) + "\" is not a Set-like object!");
+    }
+
+    jsi::Function valuesFunc = object.getPropertyAsFunction(runtime, "values");
+    auto lengthProp = object.getProperty(runtime, "length");
+    if (!lengthProp.isNumber()) {
+      throw std::invalid_argument("Value \"" + arg.toString(runtime).utf8(runtime) + "\" is not a Set-like object!");
+    }
+    auto length = (size_t)lengthProp.getNumber();
+
+    auto valuesJsVal_ = valuesFunc.callWithThis(runtime, object);
+    auto values = valuesJsVal_.asObject(runtime);
+
+    std::unordered_set<ValueType> set;
+    set.reserve(length);
+
+    auto nextFunction = values.getPropertyAsFunction(runtime, "next");
+    auto nextResult = nextFunction.callWithThis(runtime, values).asObject(runtime);
+
+    while (!nextResult.getProperty(runtime, "done").asBool()) {
+      jsi::Value value = nextResult.getProperty(runtime, "value");
+      auto cppValue = JSIConverter<ValueType>::toJSI(runtime, value);
+      set.insert(cppValue);
+    }
+
+    return set;
+  }
+
+  static inline jsi::Value toJSI(jsi::Runtime& runtime, const std::unordered_set<ValueType>& set) {
+    auto setObject = runtime.global().getPropertyAsFunction(runtime, "Set").callAsConstructor(runtime).asObject(runtime);
+    auto addMethod = setObject.getPropertyAsFunction(runtime, "add");
+
+    for (const auto& value : set) {
+      auto jsValue = JSIConverter<ValueType>::toJSI(runtime, value);
+      addMethod.callWithThis(runtime, setObject, jsValue, 1);
+    }
+
+    return setObject;
+  }
+
+  static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
+    return value.isObject() && value.asObject(runtime).instanceOf(runtime, runtime.global().getPropertyAsFunction(runtime, "Set"));
+  }
+};
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter.hpp
@@ -192,5 +192,6 @@ struct JSIConverter<std::string> final {
 #include "JSIConverter+Promise.hpp"
 #include "JSIConverter+Tuple.hpp"
 #include "JSIConverter+UnorderedMap.hpp"
+#include "JSIConverter+UnorderedSet.hpp"
 #include "JSIConverter+Variant.hpp"
 #include "JSIConverter+Vector.hpp"


### PR DESCRIPTION
This PR adds a new type recognized by Nitrogen (`Set<T>`) and provides a JSI conversion from JS sets into C++ `std::unordered_set` .

## Why

There are certain Web APIs that are returning _set-like objects_ like [`FontFaceSet`](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet) and they are [returning them from getters](https://developer.mozilla.org/en-US/docs/Web/API/Document/fonts). Since there is no equivalent `registerRawHybridGetter` (only `registerRawHybridMethod`) available, these APIs were hard (impossible?) to express with Nitro.

I'm very happy to adjust the implementation - my C++ is not great, so any tips are welcome.