### PR TITLE
feat: Mark all callbacks as `@Sendable`

### DIFF
--- a/packages/nitrogen/src/syntax/types/FunctionType.ts
+++ b/packages/nitrogen/src/syntax/types/FunctionType.ts
@@ -120,7 +120,7 @@ export class FunctionType implements Type {
           })
           .join(', ')
         const returnType = this.returnType.getCode(language)
-        return `(${params}) -> ${returnType}`
+        return `@Sendable (${params}) -> ${returnType}`
       }
       case 'kotlin': {
         const params = this.parameters

--- a/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
@@ -33,7 +33,7 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
 
   var optionalOldEnum: OldEnum? = nil
 
-  var optionalCallback: ((Double) -> Void)? = nil
+  var optionalCallback: (@Sendable (Double) -> Void)? = nil
 
   var thisObject: any HybridTestObjectSwiftKotlinSpec {
     return self
@@ -104,7 +104,7 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     }
   }
 
-  func getComplexCallback() throws -> (Double) -> Void {
+  func getComplexCallback() throws -> @Sendable (Double) -> Void {
     return { value in print("Callback called with \(value).") }
   }
 

--- a/packages/react-native-nitro-test/ios/HybridTestView.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestView.swift
@@ -20,7 +20,7 @@ class HybridTestView : HybridTestViewSpec {
   }
   var hasBeenCalled: Bool = false
   var colorScheme: ColorScheme = .light
-  var someCallback: () -> Void = { }
+  var someCallback: @Sendable () -> Void = { }
 
   // Methods
   func someMethod() throws -> Void {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_double.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_double.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `() -> Double` as a class.
+ * Wraps a Swift `@Sendable () -> Double` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_double {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: () -> Double
+  private let closure: @Sendable () -> Double
 
-  public init(_ closure: @escaping () -> Double) {
+  public init(_ closure: @escaping @Sendable () -> Double) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_double__.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_double__.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `() -> Promise<Double>` as a class.
+ * Wraps a Swift `@Sendable () -> Promise<Double>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_std__shared_ptr_Promise_double__ {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: () -> Promise<Double>
+  private let closure: @Sendable () -> Promise<Double>
 
-  public init(_ closure: @escaping () -> Promise<Double>) {
+  public init(_ closure: @escaping @Sendable () -> Promise<Double>) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `() -> Promise<Promise<Double>>` as a class.
+ * Wraps a Swift `@Sendable () -> Promise<Promise<Double>>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: () -> Promise<Promise<Double>>
+  private let closure: @Sendable () -> Promise<Promise<Double>>
 
-  public init(_ closure: @escaping () -> Promise<Promise<Double>>) {
+  public init(_ closure: @escaping @Sendable () -> Promise<Promise<Double>>) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `() -> Promise<Promise<ArrayBufferHolder>>` as a class.
+ * Wraps a Swift `@Sendable () -> Promise<Promise<ArrayBufferHolder>>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: () -> Promise<Promise<ArrayBufferHolder>>
+  private let closure: @Sendable () -> Promise<Promise<ArrayBufferHolder>>
 
-  public init(_ closure: @escaping () -> Promise<Promise<ArrayBufferHolder>>) {
+  public init(_ closure: @escaping @Sendable () -> Promise<Promise<ArrayBufferHolder>>) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__string__.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__string__.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `() -> Promise<String>` as a class.
+ * Wraps a Swift `@Sendable () -> Promise<String>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_std__shared_ptr_Promise_std__string__ {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: () -> Promise<String>
+  private let closure: @Sendable () -> Promise<String>
 
-  public init(_ closure: @escaping () -> Promise<String>) {
+  public init(_ closure: @escaping @Sendable () -> Promise<String>) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `() -> Void` as a class.
+ * Wraps a Swift `@Sendable () -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: () -> Void
+  private let closure: @Sendable () -> Void
 
-  public init(_ closure: @escaping () -> Void) {
+  public init(_ closure: @escaping @Sendable () -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_Car.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_Car.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ value: Car) -> Void` as a class.
+ * Wraps a Swift `@Sendable (_ value: Car) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_Car {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ value: Car) -> Void
+  private let closure: @Sendable (_ value: Car) -> Void
 
-  public init(_ closure: @escaping (_ value: Car) -> Void) {
+  public init(_ closure: @escaping @Sendable (_ value: Car) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_double.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_double.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ num: Double) -> Void` as a class.
+ * Wraps a Swift `@Sendable (_ num: Double) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_double {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ num: Double) -> Void
+  private let closure: @Sendable (_ num: Double) -> Void
 
-  public init(_ closure: @escaping (_ num: Double) -> Void) {
+  public init(_ closure: @escaping @Sendable (_ num: Double) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_int64_t.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_int64_t.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ value: Int64) -> Void` as a class.
+ * Wraps a Swift `@Sendable (_ value: Int64) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_int64_t {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ value: Int64) -> Void
+  private let closure: @Sendable (_ value: Int64) -> Void
 
-  public init(_ closure: @escaping (_ value: Int64) -> Void) {
+  public init(_ closure: @escaping @Sendable (_ value: Int64) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__exception_ptr.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__exception_ptr.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ error: Error) -> Void` as a class.
+ * Wraps a Swift `@Sendable (_ error: Error) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__exception_ptr {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ error: Error) -> Void
+  private let closure: @Sendable (_ error: Error) -> Void
 
-  public init(_ closure: @escaping (_ error: Error) -> Void) {
+  public init(_ closure: @escaping @Sendable (_ error: Error) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__optional_double_.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__optional_double_.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ maybe: Double?) -> Void` as a class.
+ * Wraps a Swift `@Sendable (_ maybe: Double?) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__optional_double_ {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ maybe: Double?) -> Void
+  private let closure: @Sendable (_ maybe: Double?) -> Void
 
-  public init(_ closure: @escaping (_ maybe: Double?) -> Void) {
+  public init(_ closure: @escaping @Sendable (_ maybe: Double?) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_ArrayBuffer_.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_ArrayBuffer_.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ value: ArrayBufferHolder) -> Void` as a class.
+ * Wraps a Swift `@Sendable (_ value: ArrayBufferHolder) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__shared_ptr_ArrayBuffer_ {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ value: ArrayBufferHolder) -> Void
+  private let closure: @Sendable (_ value: ArrayBufferHolder) -> Void
 
-  public init(_ closure: @escaping (_ value: ArrayBufferHolder) -> Void) {
+  public init(_ closure: @escaping @Sendable (_ value: ArrayBufferHolder) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_double__.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_double__.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ value: Promise<Double>) -> Void` as a class.
+ * Wraps a Swift `@Sendable (_ value: Promise<Double>) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__shared_ptr_Promise_double__ {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ value: Promise<Double>) -> Void
+  private let closure: @Sendable (_ value: Promise<Double>) -> Void
 
-  public init(_ closure: @escaping (_ value: Promise<Double>) -> Void) {
+  public init(_ closure: @escaping @Sendable (_ value: Promise<Double>) -> Void) {
     self.closure = closure
   }
 
@@ -24,10 +24,10 @@ public final class Func_void_std__shared_ptr_Promise_double__ {
   public func call(value: bridge.std__shared_ptr_Promise_double__) -> Void {
     self.closure({ () -> Promise<Double> in
       let __promise = Promise<Double>()
-      let __resolver = { (__result: Double) in
+      let __resolver = { @Sendable (__result: Double) in
         __promise.resolve(withResult: __result)
       }
-      let __rejecter = { (__error: Error) in
+      let __rejecter = { @Sendable (__error: Error) in
         __promise.reject(withError: __error)
       }
       let __resolverCpp = { () -> bridge.Func_void_double in

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ value: Promise<ArrayBufferHolder>) -> Void` as a class.
+ * Wraps a Swift `@Sendable (_ value: Promise<ArrayBufferHolder>) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ value: Promise<ArrayBufferHolder>) -> Void
+  private let closure: @Sendable (_ value: Promise<ArrayBufferHolder>) -> Void
 
-  public init(_ closure: @escaping (_ value: Promise<ArrayBufferHolder>) -> Void) {
+  public init(_ closure: @escaping @Sendable (_ value: Promise<ArrayBufferHolder>) -> Void) {
     self.closure = closure
   }
 
@@ -24,10 +24,10 @@ public final class Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer
   public func call(value: bridge.std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___) -> Void {
     self.closure({ () -> Promise<ArrayBufferHolder> in
       let __promise = Promise<ArrayBufferHolder>()
-      let __resolver = { (__result: ArrayBufferHolder) in
+      let __resolver = { @Sendable (__result: ArrayBufferHolder) in
         __promise.resolve(withResult: __result)
       }
-      let __rejecter = { (__error: Error) in
+      let __rejecter = { @Sendable (__error: Error) in
         __promise.reject(withError: __error)
       }
       let __resolverCpp = { () -> bridge.Func_void_std__shared_ptr_ArrayBuffer_ in

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__string.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__string.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ valueFromJs: String) -> Void` as a class.
+ * Wraps a Swift `@Sendable (_ valueFromJs: String) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__string {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ valueFromJs: String) -> Void
+  private let closure: @Sendable (_ valueFromJs: String) -> Void
 
-  public init(_ closure: @escaping (_ valueFromJs: String) -> Void) {
+  public init(_ closure: @escaping @Sendable (_ valueFromJs: String) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__vector_Powertrain_.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__vector_Powertrain_.swift
@@ -8,15 +8,15 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ array: [Powertrain]) -> Void` as a class.
+ * Wraps a Swift `@Sendable (_ array: [Powertrain]) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__vector_Powertrain_ {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ array: [Powertrain]) -> Void
+  private let closure: @Sendable (_ array: [Powertrain]) -> Void
 
-  public init(_ closure: @escaping (_ array: [Powertrain]) -> Void) {
+  public init(_ closure: @escaping @Sendable (_ array: [Powertrain]) -> Void) {
     self.closure = closure
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -23,7 +23,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   var optionalArray: [String]? { get set }
   var optionalEnum: Powertrain? { get set }
   var optionalOldEnum: OldEnum? { get set }
-  var optionalCallback: ((_ value: Double) -> Void)? { get set }
+  var optionalCallback: (@Sendable (_ value: Double) -> Void)? { get set }
   var someVariant: Variant_String_Double { get set }
 
   // Methods
@@ -37,7 +37,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func bounceNumbers(array: [Double]) throws -> [Double]
   func bounceStructs(array: [Person]) throws -> [Person]
   func bounceEnums(array: [Powertrain]) throws -> [Powertrain]
-  func complexEnumCallback(array: [Powertrain], callback: @escaping (_ array: [Powertrain]) -> Void) throws -> Void
+  func complexEnumCallback(array: [Powertrain], callback: @escaping @Sendable (_ array: [Powertrain]) -> Void) throws -> Void
   func createMap() throws -> AnyMapHolder
   func mapRoundtrip(map: AnyMapHolder) throws -> AnyMapHolder
   func getMapKeys(map: AnyMapHolder) throws -> [String]
@@ -58,15 +58,15 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func awaitAndGetPromise(promise: Promise<Double>) throws -> Promise<Double>
   func awaitAndGetComplexPromise(promise: Promise<Car>) throws -> Promise<Car>
   func awaitPromise(promise: Promise<Void>) throws -> Promise<Void>
-  func callCallback(callback: @escaping () -> Void) throws -> Void
-  func callAll(first: @escaping () -> Void, second: @escaping () -> Void, third: @escaping () -> Void) throws -> Void
-  func callWithOptional(value: Double?, callback: @escaping (_ maybe: Double?) -> Void) throws -> Void
-  func callSumUpNTimes(callback: @escaping () -> Promise<Double>, n: Double) throws -> Promise<Double>
-  func callbackAsyncPromise(callback: @escaping () -> Promise<Promise<Double>>) throws -> Promise<Double>
-  func callbackAsyncPromiseBuffer(callback: @escaping () -> Promise<Promise<ArrayBufferHolder>>) throws -> Promise<ArrayBufferHolder>
-  func getComplexCallback() throws -> (_ value: Double) -> Void
-  func getValueFromJSCallbackAndWait(getValue: @escaping () -> Promise<Double>) throws -> Promise<Double>
-  func getValueFromJsCallback(callback: @escaping () -> Promise<String>, andThenCall: @escaping (_ valueFromJs: String) -> Void) throws -> Promise<Void>
+  func callCallback(callback: @escaping @Sendable () -> Void) throws -> Void
+  func callAll(first: @escaping @Sendable () -> Void, second: @escaping @Sendable () -> Void, third: @escaping @Sendable () -> Void) throws -> Void
+  func callWithOptional(value: Double?, callback: @escaping @Sendable (_ maybe: Double?) -> Void) throws -> Void
+  func callSumUpNTimes(callback: @escaping @Sendable () -> Promise<Double>, n: Double) throws -> Promise<Double>
+  func callbackAsyncPromise(callback: @escaping @Sendable () -> Promise<Promise<Double>>) throws -> Promise<Double>
+  func callbackAsyncPromiseBuffer(callback: @escaping @Sendable () -> Promise<Promise<ArrayBufferHolder>>) throws -> Promise<ArrayBufferHolder>
+  func getComplexCallback() throws -> @Sendable (_ value: Double) -> Void
+  func getValueFromJSCallbackAndWait(getValue: @escaping @Sendable () -> Promise<Double>) throws -> Promise<Double>
+  func getValueFromJsCallback(callback: @escaping @Sendable () -> Promise<String>, andThenCall: @escaping @Sendable (_ valueFromJs: String) -> Void) throws -> Promise<Void>
   func getCar() throws -> Car
   func isCarElectric(car: Car) throws -> Bool
   func getDriver(car: Car) throws -> Person?
@@ -88,7 +88,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func bounceBase(base: (any HybridBaseSpec)) throws -> (any HybridBaseSpec)
   func bounceChildBase(child: (any HybridChildSpec)) throws -> (any HybridBaseSpec)
   func castBase(base: (any HybridBaseSpec)) throws -> (any HybridChildSpec)
-  func callbackSync(callback: @escaping () -> Double) throws -> Double
+  func callbackSync(callback: @escaping @Sendable () -> Double) throws -> Double
   func getIsViewBlue(view: (any HybridTestViewSpec)) throws -> Bool
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -329,11 +329,11 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     }
     @inline(__always)
     set {
-      self.__implementation.optionalCallback = { () -> ((_ value: Double) -> Void)? in
+      self.__implementation.optionalCallback = { () -> (@Sendable (_ value: Double) -> Void)? in
         if let __unwrapped = newValue.value {
-          return { () -> (Double) -> Void in
+          return { () -> @Sendable (Double) -> Void in
             let __wrappedFunction = bridge.wrap_Func_void_double(__unwrapped)
-            return { (__value: Double) -> Void in
+            return { @Sendable (__value: Double) -> Void in
               __wrappedFunction.call(__value)
             }
           }()
@@ -549,9 +549,9 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func complexEnumCallback(array: bridge.std__vector_Powertrain_, callback: bridge.Func_void_std__vector_Powertrain_) -> bridge.Result_void_ {
     do {
-      try self.__implementation.complexEnumCallback(array: array.map({ __item in __item }), callback: { () -> ([Powertrain]) -> Void in
+      try self.__implementation.complexEnumCallback(array: array.map({ __item in __item }), callback: { () -> @Sendable ([Powertrain]) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_std__vector_Powertrain_(callback)
-        return { (__array: [Powertrain]) -> Void in
+        return { @Sendable (__array: [Powertrain]) -> Void in
           __wrappedFunction.call({ () -> bridge.std__vector_Powertrain_ in
             var __vector = bridge.create_std__vector_Powertrain_(__array.count)
             for __item in __array {
@@ -861,10 +861,10 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     do {
       let __result = try self.__implementation.awaitAndGetPromise(promise: { () -> Promise<Double> in
         let __promise = Promise<Double>()
-        let __resolver = { (__result: Double) in
+        let __resolver = { @Sendable (__result: Double) in
           __promise.resolve(withResult: __result)
         }
-        let __rejecter = { (__error: Error) in
+        let __rejecter = { @Sendable (__error: Error) in
           __promise.reject(withError: __error)
         }
         let __resolverCpp = { () -> bridge.Func_void_double in
@@ -900,10 +900,10 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     do {
       let __result = try self.__implementation.awaitAndGetComplexPromise(promise: { () -> Promise<Car> in
         let __promise = Promise<Car>()
-        let __resolver = { (__result: Car) in
+        let __resolver = { @Sendable (__result: Car) in
           __promise.resolve(withResult: __result)
         }
-        let __rejecter = { (__error: Error) in
+        let __rejecter = { @Sendable (__error: Error) in
           __promise.reject(withError: __error)
         }
         let __resolverCpp = { () -> bridge.Func_void_Car in
@@ -939,8 +939,10 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
     do {
       let __result = try self.__implementation.awaitPromise(promise: { () -> Promise<Void> in
         let __promise = Promise<Void>()
-        let __resolver = { __promise.resolve(withResult: ()) }
-        let __rejecter = { (__error: Error) in
+        let __resolver = { @Sendable in
+          __promise.resolve(withResult: ())
+        }
+        let __rejecter = { @Sendable (__error: Error) in
           __promise.reject(withError: __error)
         }
         let __resolverCpp = { () -> bridge.Func_void in
@@ -974,9 +976,9 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func callCallback(callback: bridge.Func_void) -> bridge.Result_void_ {
     do {
-      try self.__implementation.callCallback(callback: { () -> () -> Void in
+      try self.__implementation.callCallback(callback: { () -> @Sendable () -> Void in
         let __wrappedFunction = bridge.wrap_Func_void(callback)
-        return { () -> Void in
+        return { @Sendable () -> Void in
           __wrappedFunction.call()
         }
       }())
@@ -990,19 +992,19 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func callAll(first: bridge.Func_void, second: bridge.Func_void, third: bridge.Func_void) -> bridge.Result_void_ {
     do {
-      try self.__implementation.callAll(first: { () -> () -> Void in
+      try self.__implementation.callAll(first: { () -> @Sendable () -> Void in
         let __wrappedFunction = bridge.wrap_Func_void(first)
-        return { () -> Void in
+        return { @Sendable () -> Void in
           __wrappedFunction.call()
         }
-      }(), second: { () -> () -> Void in
+      }(), second: { () -> @Sendable () -> Void in
         let __wrappedFunction = bridge.wrap_Func_void(second)
-        return { () -> Void in
+        return { @Sendable () -> Void in
           __wrappedFunction.call()
         }
-      }(), third: { () -> () -> Void in
+      }(), third: { () -> @Sendable () -> Void in
         let __wrappedFunction = bridge.wrap_Func_void(third)
-        return { () -> Void in
+        return { @Sendable () -> Void in
           __wrappedFunction.call()
         }
       }())
@@ -1016,9 +1018,9 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func callWithOptional(value: bridge.std__optional_double_, callback: bridge.Func_void_std__optional_double_) -> bridge.Result_void_ {
     do {
-      try self.__implementation.callWithOptional(value: value.value, callback: { () -> (Double?) -> Void in
+      try self.__implementation.callWithOptional(value: value.value, callback: { () -> @Sendable (Double?) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_std__optional_double_(callback)
-        return { (__maybe: Double?) -> Void in
+        return { @Sendable (__maybe: Double?) -> Void in
           __wrappedFunction.call({ () -> bridge.std__optional_double_ in
             if let __unwrappedValue = __maybe {
               return bridge.create_std__optional_double_(__unwrappedValue)
@@ -1038,16 +1040,16 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func callSumUpNTimes(callback: bridge.Func_std__shared_ptr_Promise_double__, n: Double) -> bridge.Result_std__shared_ptr_Promise_double___ {
     do {
-      let __result = try self.__implementation.callSumUpNTimes(callback: { () -> () -> Promise<Double> in
+      let __result = try self.__implementation.callSumUpNTimes(callback: { () -> @Sendable () -> Promise<Double> in
         let __wrappedFunction = bridge.wrap_Func_std__shared_ptr_Promise_double__(callback)
-        return { () -> Promise<Double> in
+        return { @Sendable () -> Promise<Double> in
           let __result = __wrappedFunction.call()
           return { () -> Promise<Double> in
             let __promise = Promise<Double>()
-            let __resolver = { (__result: Double) in
+            let __resolver = { @Sendable (__result: Double) in
               __promise.resolve(withResult: __result)
             }
-            let __rejecter = { (__error: Error) in
+            let __rejecter = { @Sendable (__error: Error) in
               __promise.reject(withError: __error)
             }
             let __resolverCpp = { () -> bridge.Func_void_double in
@@ -1083,16 +1085,16 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func callbackAsyncPromise(callback: bridge.Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____) -> bridge.Result_std__shared_ptr_Promise_double___ {
     do {
-      let __result = try self.__implementation.callbackAsyncPromise(callback: { () -> () -> Promise<Promise<Double>> in
+      let __result = try self.__implementation.callbackAsyncPromise(callback: { () -> @Sendable () -> Promise<Promise<Double>> in
         let __wrappedFunction = bridge.wrap_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(callback)
-        return { () -> Promise<Promise<Double>> in
+        return { @Sendable () -> Promise<Promise<Double>> in
           let __result = __wrappedFunction.call()
           return { () -> Promise<Promise<Double>> in
             let __promise = Promise<Promise<Double>>()
-            let __resolver = { (__result: Promise<Double>) in
+            let __resolver = { @Sendable (__result: Promise<Double>) in
               __promise.resolve(withResult: __result)
             }
-            let __rejecter = { (__error: Error) in
+            let __rejecter = { @Sendable (__error: Error) in
               __promise.reject(withError: __error)
             }
             let __resolverCpp = { () -> bridge.Func_void_std__shared_ptr_Promise_double__ in
@@ -1128,16 +1130,16 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func callbackAsyncPromiseBuffer(callback: bridge.Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____) -> bridge.Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____ {
     do {
-      let __result = try self.__implementation.callbackAsyncPromiseBuffer(callback: { () -> () -> Promise<Promise<ArrayBufferHolder>> in
+      let __result = try self.__implementation.callbackAsyncPromiseBuffer(callback: { () -> @Sendable () -> Promise<Promise<ArrayBufferHolder>> in
         let __wrappedFunction = bridge.wrap_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(callback)
-        return { () -> Promise<Promise<ArrayBufferHolder>> in
+        return { @Sendable () -> Promise<Promise<ArrayBufferHolder>> in
           let __result = __wrappedFunction.call()
           return { () -> Promise<Promise<ArrayBufferHolder>> in
             let __promise = Promise<Promise<ArrayBufferHolder>>()
-            let __resolver = { (__result: Promise<ArrayBufferHolder>) in
+            let __resolver = { @Sendable (__result: Promise<ArrayBufferHolder>) in
               __promise.resolve(withResult: __result)
             }
-            let __rejecter = { (__error: Error) in
+            let __rejecter = { @Sendable (__error: Error) in
               __promise.reject(withError: __error)
             }
             let __resolverCpp = { () -> bridge.Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ in
@@ -1188,16 +1190,16 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func getValueFromJSCallbackAndWait(getValue: bridge.Func_std__shared_ptr_Promise_double__) -> bridge.Result_std__shared_ptr_Promise_double___ {
     do {
-      let __result = try self.__implementation.getValueFromJSCallbackAndWait(getValue: { () -> () -> Promise<Double> in
+      let __result = try self.__implementation.getValueFromJSCallbackAndWait(getValue: { () -> @Sendable () -> Promise<Double> in
         let __wrappedFunction = bridge.wrap_Func_std__shared_ptr_Promise_double__(getValue)
-        return { () -> Promise<Double> in
+        return { @Sendable () -> Promise<Double> in
           let __result = __wrappedFunction.call()
           return { () -> Promise<Double> in
             let __promise = Promise<Double>()
-            let __resolver = { (__result: Double) in
+            let __resolver = { @Sendable (__result: Double) in
               __promise.resolve(withResult: __result)
             }
-            let __rejecter = { (__error: Error) in
+            let __rejecter = { @Sendable (__error: Error) in
               __promise.reject(withError: __error)
             }
             let __resolverCpp = { () -> bridge.Func_void_double in
@@ -1233,16 +1235,16 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func getValueFromJsCallback(callback: bridge.Func_std__shared_ptr_Promise_std__string__, andThenCall: bridge.Func_void_std__string) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      let __result = try self.__implementation.getValueFromJsCallback(callback: { () -> () -> Promise<String> in
+      let __result = try self.__implementation.getValueFromJsCallback(callback: { () -> @Sendable () -> Promise<String> in
         let __wrappedFunction = bridge.wrap_Func_std__shared_ptr_Promise_std__string__(callback)
-        return { () -> Promise<String> in
+        return { @Sendable () -> Promise<String> in
           let __result = __wrappedFunction.call()
           return { () -> Promise<String> in
             let __promise = Promise<String>()
-            let __resolver = { (__result: String) in
+            let __resolver = { @Sendable (__result: String) in
               __promise.resolve(withResult: __result)
             }
-            let __rejecter = { (__error: Error) in
+            let __rejecter = { @Sendable (__error: Error) in
               __promise.reject(withError: __error)
             }
             let __resolverCpp = { () -> bridge.Func_void_std__string in
@@ -1259,9 +1261,9 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
             return __promise
           }()
         }
-      }(), andThenCall: { () -> (String) -> Void in
+      }(), andThenCall: { () -> @Sendable (String) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_std__string(andThenCall)
-        return { (__valueFromJs: String) -> Void in
+        return { @Sendable (__valueFromJs: String) -> Void in
           __wrappedFunction.call(std.string(__valueFromJs))
         }
       }())
@@ -1668,9 +1670,9 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func callbackSync(callback: bridge.Func_double) -> bridge.Result_double_ {
     do {
-      let __result = try self.__implementation.callbackSync(callback: { () -> () -> Double in
+      let __result = try self.__implementation.callbackSync(callback: { () -> @Sendable () -> Double in
         let __wrappedFunction = bridge.wrap_Func_double(callback)
-        return { () -> Double in
+        return { @Sendable () -> Double in
           let __result = __wrappedFunction.call()
           return __result
         }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
@@ -14,7 +14,7 @@ public protocol HybridTestViewSpec_protocol: HybridObject, HybridView {
   var isBlue: Bool { get set }
   var hasBeenCalled: Bool { get set }
   var colorScheme: ColorScheme { get set }
-  var someCallback: () -> Void { get set }
+  var someCallback: @Sendable () -> Void { get set }
 
   // Methods
   func someMethod() throws -> Void

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
@@ -140,9 +140,9 @@ public class HybridTestViewSpec_cxx {
     }
     @inline(__always)
     set {
-      self.__implementation.someCallback = { () -> () -> Void in
+      self.__implementation.someCallback = { () -> @Sendable () -> Void in
         let __wrappedFunction = bridge.wrap_Func_void(newValue)
-        return { () -> Void in
+        return { @Sendable () -> Void in
           __wrappedFunction.call()
         }
       }()

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/JsStyleStruct.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/JsStyleStruct.swift
@@ -18,7 +18,7 @@ public extension JsStyleStruct {
   /**
    * Create a new instance of `JsStyleStruct`.
    */
-  init(value: Double, onChanged: @escaping (_ num: Double) -> Void) {
+  init(value: Double, onChanged: @escaping @Sendable (_ num: Double) -> Void) {
     self.init(value, { () -> bridge.Func_void_double in
       let __closureWrapper = Func_void_double(onChanged)
       return bridge.create_Func_void_double(__closureWrapper.toUnsafe())
@@ -36,12 +36,12 @@ public extension JsStyleStruct {
     }
   }
   
-  var onChanged: (_ num: Double) -> Void {
+  var onChanged: @Sendable (_ num: Double) -> Void {
     @inline(__always)
     get {
-      return { () -> (Double) -> Void in
+      return { () -> @Sendable (Double) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_double(self.__onChanged)
-        return { (__num: Double) -> Void in
+        return { @Sendable (__num: Double) -> Void in
           __wrappedFunction.call(__num)
         }
       }()


### PR DESCRIPTION
In Swift 6, Swift enforces Swift concurrency even more. Which is stupid imo if you think about interop with other languages (like JS or C++, which have different concurrency modules).

So either we mark all Swift callbacks as `@Sendable`, or we mark all as `@preconcurrency`.

- `@preconcurrency` seems like it would mark an API as legacy, which I don't think makes sense.
- `@Sendable` sounds like it just marks the function as callable from any Thread, which is what it essentially is.

That's at least the way I understood those concepts - it's not very well explained in low-level terminology imo, but let's just try if this works.