### PR TITLE
chore(example): fix iOS building issues

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint-ci": "eslint \"**/*.{js,ts,tsx}\" -f @jamesacarr/github-actions",
     "bundle-install": "bundle install",
-    "pods": "cd ios && bundle exec pod install && rm -rf .xcode.env.local",
+    "pods": "cd ios && bundle exec pod install",
     "build:android": "cd android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
     "build:ios": "cd ios && xcodebuild -workspace NitroExample.xcworkspace -scheme NitroExample -configuration Debug -sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO"
   },


### PR DESCRIPTION
We need to keep the .xcode.env.local file for builds to work correctly.

Otherwise on a fresh setup we get errors like this during building:

<img width="2362" height="204" alt="CleanShot_2025-07-14_at_12 51 152x" src="https://github.com/user-attachments/assets/982e949d-019e-49a9-9e0f-9373c4c28bdf" />
