### PR TITLE
fix(ios): only apply folly compiler flags on RN < 80 (fix RN 0.80 compat)

### DIFF
--- a/packages/react-native-nitro-modules/NitroModules.podspec
+++ b/packages/react-native-nitro-modules/NitroModules.podspec
@@ -1,4 +1,5 @@
 require "json"
+require "./nitro_pod_utils"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
@@ -55,16 +56,24 @@ Pod::Spec.new do |s|
     "ios/utils/SwiftClosure.hpp",
   ]
 
-  s.pod_target_xcconfig = {
+  xcconfig = {
     # Use C++ 20
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
     # Enables C++ <-> Swift interop (by default it's only C)
     "SWIFT_OBJC_INTEROP_MODE" => "objcxx",
     # Enables stricter modular headers
     "DEFINES_MODULE" => "YES",
-    # C++ compiler flags, mainly for RN version and folly.
-    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FOLLY_NO_CONFIG FOLLY_CFG_NO_COROUTINES"
   }
+
+  if has_react_native()
+    react_native_version = get_react_native_version()
+    if (react_native_version < 80)
+      # C++ compiler flags, for folly when building as static framework:
+      xcconfig["GCC_PREPROCESSOR_DEFINITIONS"] = "$(inherited) FOLLY_NO_CONFIG FOLLY_CFG_NO_COROUTINES"
+    end
+  end
+
+  s.pod_target_xcconfig = xcconfig
 
   # Nitro depends on JSI.
   s.dependency 'React-jsi'

--- a/packages/react-native-nitro-modules/nitro_pod_utils.rb
+++ b/packages/react-native-nitro-modules/nitro_pod_utils.rb
@@ -1,0 +1,27 @@
+require "json"
+
+# Gets the path of the react-native/package.json file.
+def get_react_native_package_path()
+  pod_root = Pod::Config.instance.installation_root.to_s
+  return `cd "#{pod_root}" && node --print "require.resolve('react-native/package.json')"`.strip!
+end
+
+# Finds out whether react-native is available, or not.
+# This works by checking if the react-native node package can be resolved.
+def has_react_native()
+  react_native_package_path = get_react_native_package_path()
+  return File.exist?(react_native_package_path)
+end
+
+# Gets the minor react-native version (e.g 76 for 0.76.4)
+def get_react_native_version()
+  react_native_package_path = get_react_native_package_path()
+  if !File.exist?(react_native_package_path)
+    raise "[NitroModules] Couldn't find react-native path! File '#{react_native_package_path}' doesn't exist!"
+  end
+  react_native_package = JSON.parse(File.read(react_native_package_path))
+  react_native_version = react_native_package['version']
+  react_native_minor_version = react_native_version.split('.')[1].to_i
+  Pod::UI.puts "[NitroModules] Found react-native #{react_native_version} (#{react_native_minor_version}) in #{File.dirname(react_native_package_path)}!"
+  return react_native_minor_version
+end


### PR DESCRIPTION
Helps with problems as reported here:

- https://github.com/facebook/react-native/issues/52366

On RN 0.80 we no longer need to specify folly flags, neither with or without using static frameworks