### PR TITLE
fix: Properly throw errors on Android now on RN 0.80

### DIFF
--- a/example/src/Testers.ts
+++ b/example/src/Testers.ts
@@ -27,7 +27,7 @@ export class State<T> {
         `Expected test to throw an error, but no error was thrown! Instead it returned a result: ${stringify(this.result)}`
       )
     } else {
-      if (message == null || stringify(this.errorThrown) === message) {
+      if (message == null || stringify(this.errorThrown).includes(message)) {
         this.onPassed()
       } else {
         this.onFailed(

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -497,24 +497,28 @@ export function getTests(
 
     // Test errors
     createTest('funcThatThrows() throws', () =>
-      it(() => testObject.funcThatThrows()).didThrow(
-        `Error: ${testObject.name}.funcThatThrows(...): This function will only work after sacrificing seven lambs!`
-      )
+      it(() => testObject.funcThatThrows())
+        // contains the method name:
+        .didThrow(`${testObject.name}.funcThatThrows(...):`)
+        // contains the error message:
+        .didThrow(`This function will only work after sacrificing seven lambs!`)
     ),
     createTest('funcThatThrowsBeforePromise() throws', async () =>
-      (
-        await it(async () => await testObject.funcThatThrowsBeforePromise())
-      ).didThrow(
-        `Error: ${testObject.name}.funcThatThrowsBeforePromise(...): This function will only work after sacrificing eight lambs!`
-      )
+      (await it(async () => await testObject.funcThatThrowsBeforePromise()))
+        // contains the method name:
+        .didThrow(`${testObject.name}.funcThatThrowsBeforePromise(...):`)
+        // contains the error message:
+        .didThrow(`This function will only work after sacrificing eight lambs!`)
     ),
     createTest('throwError(error) throws same message from JS', () =>
       it(() => {
         const error = new Error('rethrowing a JS error from native!')
         testObject.throwError(error)
-      }).didThrow(
-        `Error: ${testObject.name}.throwError(...): Error: rethrowing a JS error from native!`
-      )
+      })
+        // contains the method name:
+        .didThrow(`${testObject.name}.throwError(...):`)
+        // contains the error message:
+        .didThrow(`Error: rethrowing a JS error from native!`)
     ),
 
     // Optional parameters
@@ -539,17 +543,21 @@ export function getTests(
           // @ts-expect-error
           'too many args!'
         )
-      ).didThrow(
-        `Error: \`${testObject.name}.tryOptionalParams(...)\` expected between 2 and 3 arguments, but received 4!`
       )
+        // thrown by HybridFunction, not by the user;
+        .didThrow(
+          `Error: \`${testObject.name}.tryOptionalParams(...)\` expected between 2 and 3 arguments, but received 4!`
+        )
     ),
     createTest('tryOptionalParams(...) one-too-few', () =>
       it(() =>
         // @ts-expect-error
         testObject.tryOptionalParams(13)
-      ).didThrow(
-        `Error: \`${testObject.name}.tryOptionalParams(...)\` expected between 2 and 3 arguments, but received 1!`
       )
+        // thrown by HybridFunction, not by the user;
+        .didThrow(
+          `Error: \`${testObject.name}.tryOptionalParams(...)\` expected between 2 and 3 arguments, but received 1!`
+        )
     ),
     createTest('tryMiddleParam(...)', () =>
       it(() => testObject.tryMiddleParam(13, undefined, 'hello!'))

--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -109,17 +109,6 @@ public:
         std::string funcName = getHybridFuncFullName<THybrid>(kind, name, hybridInstance.get());
         std::string message = exception.what();
         throw jsi::JSError(runtime, funcName + ": " + message);
-#ifdef ANDROID
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wexceptions"
-        // Workaround for https://github.com/mrousavy/nitro/issues/382
-      } catch (const std::runtime_error& exception) {
-        // Some exception was thrown - add method name information and re-throw as `JSError`.
-        std::string funcName = getHybridFuncFullName<THybrid>(kind, name, hybridInstance.get());
-        std::string message = exception.what();
-        throw jsi::JSError(runtime, funcName + ": " + message);
-#pragma clang diagnostic pop
-#endif
       } catch (...) {
         // Some unknown exception was thrown - add method name information and re-throw as `JSError`.
         std::string funcName = getHybridFuncFullName<THybrid>(kind, name, hybridInstance.get());

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Exception.hpp
@@ -39,15 +39,6 @@ struct JSIConverter<std::exception_ptr> final {
     } catch (const std::exception& e) {
       jsi::JSError error(runtime, e.what());
       return jsi::Value(runtime, error.value());
-#ifdef ANDROID
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wexceptions"
-      // Workaround for https://github.com/mrousavy/nitro/issues/382
-    } catch (const std::runtime_error& e) {
-      jsi::JSError error(runtime, e.what());
-      return jsi::Value(runtime, error.value());
-#pragma clang diagnostic pop
-#endif
     } catch (...) {
       // Some unknown exception was thrown - maybe an Objective-C error?
       std::string errorName = TypeInfo::getCurrentExceptionName();


### PR DESCRIPTION
This requires RN 0.80, but errors in Android are finally fully propagated to JS!