### PR TITLE
fix: Fix the second callback argument compiler bug

### DIFF
--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -493,18 +493,18 @@ namespace margelo::nitro::test::bridge::swift {
   /**
    * Specialized version of `std::function<void(const Car&)>`.
    */
-  using Func_void_Car = std::function<void(const Car& /* result */)>;
+  using Func_void_Car = std::function<void(Car /* result */)>;
   /**
    * Wrapper class for a `std::function<void(const Car& / * result * /)>`, this can be used from Swift.
    */
   class Func_void_Car_Wrapper final {
   public:
-    explicit Func_void_Car_Wrapper(std::function<void(const Car& /* result */)>&& func): _function(std::make_unique<std::function<void(const Car& /* result */)>>(std::move(func))) {}
+    explicit Func_void_Car_Wrapper(std::function<void(Car /* result */)>&& func): _function(std::make_unique<std::function<void(Car /* result */)>>(std::move(func))) {}
     inline void call(Car result) const {
       _function->operator()(result);
     }
   private:
-    std::unique_ptr<std::function<void(const Car& /* result */)>> _function;
+    std::unique_ptr<std::function<void(Car /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
   Func_void_Car create_Func_void_Car(void* _Nonnull swiftClosureWrapper);
   inline Func_void_Car_Wrapper wrap_Func_void_Car(Func_void_Car value) {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -915,7 +915,7 @@ public class HybridTestObjectSwiftKotlinSpec_cxx {
           return bridge.create_Func_void_std__exception_ptr(__closureWrapper.toUnsafe())
         }()
         let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_Car__(promise)
-        __promiseHolder.addOnResolvedListener(__resolverCpp)
+        __promiseHolder.addOnResolvedListenerCopy(__resolverCpp)
         __promiseHolder.addOnRejectedListener(__rejecterCpp)
         return __promise
       }())


### PR DESCRIPTION
Fixes https://github.com/mrousavy/nitro/issues/746 (locally, patched) by applying the workaround mentioned in https://github.com/swiftlang/swift/issues/83097