### PR TITLE
fix: Fix `ClassNotFoundException` for `HardwareBufferUtils`

### DIFF
--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/utils/HardwareBufferUtils.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/utils/HardwareBufferUtils.kt
@@ -1,5 +1,7 @@
 package com.margelo.nitro.utils
 
+import androidx.annotation.Keep
+import com.facebook.proguard.annotations.DoNotStrip
 import android.hardware.HardwareBuffer
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -11,6 +13,8 @@ import androidx.annotation.RequiresApi
 typealias BoxedHardwareBuffer = Any
 
 @Suppress("KotlinJniMissingFunction")
+@Keep
+@DoNotStrip
 class HardwareBufferUtils {
     companion object {
         @JvmStatic


### PR DESCRIPTION
C++/JNI didn't find that class in release because Proguard stripped it.