### PR TITLE
perf: Make nitrogen 4x faster by using unsafe fast path join

### DIFF
--- a/packages/nitrogen/src/utils.ts
+++ b/packages/nitrogen/src/utils.ts
@@ -60,8 +60,14 @@ export function toUnixPath(p: string): string {
   return p.replaceAll('\\', '/')
 }
 
+const sep = path.sep
+function unsafeFastJoin(...segments: string[]): string {
+  // this function should really not take any unsafe strings like `/` or `\`.
+  return segments.join(sep)
+}
+
 function getFullPath(file: SourceFile): string {
-  return path.join(
+  return unsafeFastJoin(
     file.platform,
     file.language,
     ...file.subdirectory,


### PR DESCRIPTION
Makes nitrogen 4x faster (shaves off 3.8 seconds on nitrogen) by using a faster path.join implementation.

### Before

```
🎉  Generated 5/5 HybridObjects in 4.0s!
```

### After

```
🎉  Generated 5/5 HybridObjects in 1.1s!
```