### PR TITLE
fix: Fix undefined symbols when syncing

### DIFF
--- a/packages/react-native-nitro-test/android/build.gradle
+++ b/packages/react-native-nitro-test/android/build.gradle
@@ -145,3 +145,13 @@ if (isNewArchitectureEnabled()) {
     codegenJavaPackageName = "com.margelo.nitro.test"
   }
 }
+
+// This fixes linking errors due to undefined symbols from libNitroModules.so.
+// During Gradle Sync, Android Gradle Plugin runs Prefab and treats worklets
+// like a header-only library. During build, config files are not regenerated
+// because the cache key does not change and AGP thinks that they are up-to-date.
+// source: https://github.com/Expensify/react-native-live-markdown/blob/8323019c2811ebf81dce4e5273c8e4d3d0e3f9f3/android/build.gradle#L181C1-L188C2
+afterEvaluate {
+  prepareKotlinBuildScriptModel.dependsOn(":react-native-nitro-modules:prefabDebugPackage")
+  prepareKotlinBuildScriptModel.dependsOn(":react-native-nitro-modules:prefabReleasePackage")
+}

--- a/packages/react-native-nitro-test/android/build.gradle
+++ b/packages/react-native-nitro-test/android/build.gradle
@@ -151,6 +151,9 @@ if (isNewArchitectureEnabled()) {
 // like a header-only library. During build, config files are not regenerated
 // because the cache key does not change and AGP thinks that they are up-to-date.
 // source: https://github.com/Expensify/react-native-live-markdown/blob/8323019c2811ebf81dce4e5273c8e4d3d0e3f9f3/android/build.gradle#L181C1-L188C2
+task prepareKotlinBuildScriptModel {
+  // This task is run during Gradle Sync in Android Studio.
+}
 afterEvaluate {
   prepareKotlinBuildScriptModel.dependsOn(":react-native-nitro-modules:prefabDebugPackage")
   prepareKotlinBuildScriptModel.dependsOn(":react-native-nitro-modules:prefabReleasePackage")

--- a/packages/react-native-nitro-test/android/build.gradle
+++ b/packages/react-native-nitro-test/android/build.gradle
@@ -147,7 +147,7 @@ if (isNewArchitectureEnabled()) {
 }
 
 // This fixes linking errors due to undefined symbols from libNitroModules.so.
-// During Gradle Sync, Android Gradle Plugin runs Prefab and treats worklets
+// During Gradle Sync, Android Gradle Plugin runs Prefab and treats Nitro
 // like a header-only library. During build, config files are not regenerated
 // because the cache key does not change and AGP thinks that they are up-to-date.
 // source: https://github.com/Expensify/react-native-live-markdown/blob/8323019c2811ebf81dce4e5273c8e4d3d0e3f9f3/android/build.gradle#L181C1-L188C2

--- a/packages/template/android/build.gradle
+++ b/packages/template/android/build.gradle
@@ -139,7 +139,7 @@ dependencies {
 }
 
 // This fixes linking errors due to undefined symbols from libNitroModules.so.
-// During Gradle Sync, Android Gradle Plugin runs Prefab and treats worklets
+// During Gradle Sync, Android Gradle Plugin runs Prefab and treats Nitro
 // like a header-only library. During build, config files are not regenerated
 // because the cache key does not change and AGP thinks that they are up-to-date.
 // source: https://github.com/Expensify/react-native-live-markdown/blob/8323019c2811ebf81dce4e5273c8e4d3d0e3f9f3/android/build.gradle#L181C1-L188C2

--- a/packages/template/android/build.gradle
+++ b/packages/template/android/build.gradle
@@ -138,3 +138,15 @@ dependencies {
   implementation project(":react-native-nitro-modules")
 }
 
+// This fixes linking errors due to undefined symbols from libNitroModules.so.
+// During Gradle Sync, Android Gradle Plugin runs Prefab and treats worklets
+// like a header-only library. During build, config files are not regenerated
+// because the cache key does not change and AGP thinks that they are up-to-date.
+// source: https://github.com/Expensify/react-native-live-markdown/blob/8323019c2811ebf81dce4e5273c8e4d3d0e3f9f3/android/build.gradle#L181C1-L188C2
+task prepareKotlinBuildScriptModel {
+  // This task is run during Gradle Sync in Android Studio.
+}
+afterEvaluate {
+  prepareKotlinBuildScriptModel.dependsOn(":react-native-nitro-modules:prefabDebugPackage")
+  prepareKotlinBuildScriptModel.dependsOn(":react-native-nitro-modules:prefabReleasePackage")
+}


### PR DESCRIPTION
A super long standing issue in native dependencies of native dependencies (e.g. VisionCamera -> Worklets, or NitroImage -> Nitro) was that the second native dependency's symbols can no longer be linked after some time. E.g. after gradle syncs, or another npm install.

Apparently the guys at SWM found a fix for this (so huge shoutout to @tomekzaw!), and this needs to be applied to all third party dependencies.

- fixes https://github.com/mrousavy/nitro/issues/674