### PR TITLE
feat: Make Swift classes `open`

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -69,7 +69,7 @@ public protocol ${protocolName}_protocol: ${protocolBaseClasses.join(', ')} {
 }
 
 /// See \`\`${protocolName}\`\`
-public class ${protocolName}_base${classBaseClasses.length > 0 ? `: ${classBaseClasses.join(',')}` : ''} {
+open class ${protocolName}_base${classBaseClasses.length > 0 ? `: ${classBaseClasses.join(',')}` : ''} {
   ${baseMembers.length > 0 ? indent(baseMembers.join('\n'), '  ') : `/* inherited */`}
 }
 

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -133,7 +133,7 @@ ${imports.join('\n')}
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-${hasBase ? `public class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : `public class ${name.HybridTSpecCxx}`} {
+${hasBase ? `open class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : `open class ${name.HybridTSpecCxx}`} {
   /**
    * The Swift <> C++ bridge's namespace (\`${NitroConfig.current.getCxxNamespace('c++', 'bridge', 'swift')}\`)
    * from \`${moduleName}-Swift-Cxx-Bridge.hpp\`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -18,7 +18,7 @@ public protocol HybridBaseSpec_protocol: HybridObject {
 }
 
 /// See ``HybridBaseSpec``
-public class HybridBaseSpec_base {
+open class HybridBaseSpec_base {
   private weak var cxxWrapper: HybridBaseSpec_cxx? = nil
   public func getCxxWrapper() -> HybridBaseSpec_cxx {
   #if DEBUG

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
@@ -17,7 +17,7 @@ import NitroModules
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-public class HybridBaseSpec_cxx {
+open class HybridBaseSpec_cxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::test::bridge::swift`)
    * from `NitroTest-Swift-Cxx-Bridge.hpp`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -18,7 +18,7 @@ public protocol HybridChildSpec_protocol: HybridObject, HybridBaseSpec_protocol 
 }
 
 /// See ``HybridChildSpec``
-public class HybridChildSpec_base: HybridBaseSpec_base {
+open class HybridChildSpec_base: HybridBaseSpec_base {
   private weak var cxxWrapper: HybridChildSpec_cxx? = nil
   public override func getCxxWrapper() -> HybridChildSpec_cxx {
   #if DEBUG

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
@@ -17,7 +17,7 @@ import NitroModules
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-public class HybridChildSpec_cxx : HybridBaseSpec_cxx {
+open class HybridChildSpec_cxx : HybridBaseSpec_cxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::test::bridge::swift`)
    * from `NitroTest-Swift-Cxx-Bridge.hpp`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -95,7 +95,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
 }
 
 /// See ``HybridTestObjectSwiftKotlinSpec``
-public class HybridTestObjectSwiftKotlinSpec_base {
+open class HybridTestObjectSwiftKotlinSpec_base {
   private weak var cxxWrapper: HybridTestObjectSwiftKotlinSpec_cxx? = nil
   public func getCxxWrapper() -> HybridTestObjectSwiftKotlinSpec_cxx {
   #if DEBUG

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -17,7 +17,7 @@ import NitroModules
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-public class HybridTestObjectSwiftKotlinSpec_cxx {
+open class HybridTestObjectSwiftKotlinSpec_cxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::test::bridge::swift`)
    * from `NitroTest-Swift-Cxx-Bridge.hpp`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
@@ -21,7 +21,7 @@ public protocol HybridTestViewSpec_protocol: HybridObject, HybridView {
 }
 
 /// See ``HybridTestViewSpec``
-public class HybridTestViewSpec_base {
+open class HybridTestViewSpec_base {
   private weak var cxxWrapper: HybridTestViewSpec_cxx? = nil
   public func getCxxWrapper() -> HybridTestViewSpec_cxx {
   #if DEBUG

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
@@ -17,7 +17,7 @@ import NitroModules
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-public class HybridTestViewSpec_cxx {
+open class HybridTestViewSpec_cxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::test::bridge::swift`)
    * from `NitroTest-Swift-Cxx-Bridge.hpp`.


### PR DESCRIPTION
Allows implementing (or extending) them in other modules.