### PR TITLE
fix: Make `init` public

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -40,6 +40,11 @@ export function createSwiftHybridObject(spec: HybridObjectSpec): SourceFile[] {
   const hasBaseClass = classBaseClasses.length > 0
   const baseMembers: string[] = []
   baseMembers.push(`private weak var cxxWrapper: ${name.HybridTSpecCxx}? = nil`)
+  if (hasBaseClass) {
+    baseMembers.push(`public override init() { super.init() }`)
+  } else {
+    baseMembers.push(`public init() { }`)
+  }
   baseMembers.push(
     `
 public ${hasBaseClass ? 'override func' : 'func'} getCxxWrapper() -> ${name.HybridTSpecCxx} {
@@ -80,7 +85,7 @@ public protocol ${protocolName}_protocol: ${protocolBaseClasses.join(', ')} {
 
 /// See \`\`${protocolName}\`\`
 open class ${protocolName}_base${classBaseClasses.length > 0 ? `: ${classBaseClasses.join(',')}` : ''} {
-  ${baseMembers.length > 0 ? indent(baseMembers.join('\n'), '  ') : `/* inherited */`}
+  ${indent(baseMembers.join('\n'), '  ')}
 }
 
 /**

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridBaseSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridBaseSpec.swift
@@ -20,6 +20,7 @@ public protocol HybridBaseSpec_protocol: HybridObject {
 /// See ``HybridBaseSpec``
 open class HybridBaseSpec_base {
   private weak var cxxWrapper: HybridBaseSpec_cxx? = nil
+  public init() { }
   public func getCxxWrapper() -> HybridBaseSpec_cxx {
   #if DEBUG
     guard self is HybridBaseSpec else {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -20,6 +20,7 @@ public protocol HybridChildSpec_protocol: HybridObject, HybridBaseSpec_protocol 
 /// See ``HybridChildSpec``
 open class HybridChildSpec_base: HybridBaseSpec_base {
   private weak var cxxWrapper: HybridChildSpec_cxx? = nil
+  public override init() { super.init() }
   public override func getCxxWrapper() -> HybridChildSpec_cxx {
   #if DEBUG
     guard self is HybridChildSpec else {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -97,6 +97,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
 /// See ``HybridTestObjectSwiftKotlinSpec``
 open class HybridTestObjectSwiftKotlinSpec_base {
   private weak var cxxWrapper: HybridTestObjectSwiftKotlinSpec_cxx? = nil
+  public init() { }
   public func getCxxWrapper() -> HybridTestObjectSwiftKotlinSpec_cxx {
   #if DEBUG
     guard self is HybridTestObjectSwiftKotlinSpec else {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
@@ -23,6 +23,7 @@ public protocol HybridTestViewSpec_protocol: HybridObject, HybridView {
 /// See ``HybridTestViewSpec``
 open class HybridTestViewSpec_base {
   private weak var cxxWrapper: HybridTestViewSpec_cxx? = nil
+  public init() { }
   public func getCxxWrapper() -> HybridTestViewSpec_cxx {
   #if DEBUG
     guard self is HybridTestViewSpec else {


### PR DESCRIPTION
Makes a Swift HybridObject's `init` function public to allow it being overridden/implemented/called from code outside of this module.

E.g. when implementing a HybridObject's Spec from a different module, this was an error before.