### PR TITLE
fix: Add required imports to Swift/Kotlin Function, Struct and Variant

### DIFF
--- a/packages/nitrogen/src/autolinking/ios/createSwiftCxxBridge.ts
+++ b/packages/nitrogen/src/autolinking/ios/createSwiftCxxBridge.ts
@@ -17,7 +17,8 @@ import { getHybridObjectName } from '../../syntax/getHybridObjectName.js'
 const SWIFT_BRIDGE_NAMESPACE = ['bridge', 'swift']
 
 export function createSwiftCxxBridge(): SourceFile[] {
-  const bridgeName = NitroConfig.current.getSwiftBridgeHeaderName()
+  const moduleName = NitroConfig.current.getIosModuleName()
+  const bridgeName = `${moduleName}-Swift-Cxx-Bridge`
 
   const types = getAllKnownTypes('swift').map((t) => new SwiftCxxBridgedType(t))
 

--- a/packages/nitrogen/src/autolinking/ios/createSwiftCxxBridge.ts
+++ b/packages/nitrogen/src/autolinking/ios/createSwiftCxxBridge.ts
@@ -17,8 +17,7 @@ import { getHybridObjectName } from '../../syntax/getHybridObjectName.js'
 const SWIFT_BRIDGE_NAMESPACE = ['bridge', 'swift']
 
 export function createSwiftCxxBridge(): SourceFile[] {
-  const moduleName = NitroConfig.current.getIosModuleName()
-  const bridgeName = `${moduleName}-Swift-Cxx-Bridge`
+  const bridgeName = NitroConfig.current.getSwiftBridgeHeaderName()
 
   const types = getAllKnownTypes('swift').map((t) => new SwiftCxxBridgedType(t))
 

--- a/packages/nitrogen/src/config/NitroConfig.ts
+++ b/packages/nitrogen/src/config/NitroConfig.ts
@@ -127,4 +127,9 @@ export class NitroConfig {
       this.getCxxNamespace('c++') !== NitroConfig.current.getCxxNamespace('c++')
     )
   }
+
+  getSwiftBridgeHeaderName(): string {
+    const moduleName = this.getIosModuleName()
+    return `${moduleName}-Swift-Cxx-Bridge`
+  }
 }

--- a/packages/nitrogen/src/config/NitroConfig.ts
+++ b/packages/nitrogen/src/config/NitroConfig.ts
@@ -127,9 +127,4 @@ export class NitroConfig {
       this.getCxxNamespace('c++') !== NitroConfig.current.getCxxNamespace('c++')
     )
   }
-
-  getSwiftBridgeHeaderName(): string {
-    const moduleName = this.getIosModuleName()
-    return `${moduleName}-Swift-Cxx-Bridge`
-  }
 }

--- a/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
@@ -20,6 +20,10 @@ export function createKotlinFunction(functionType: FunctionType): SourceFile[] {
   const kotlinParamsForward = functionType.parameters.map((p) => p.escapedName)
   const lambdaSignature = `(${kotlinParamTypes.join(', ')}) -> ${kotlinReturnType}`
 
+  const extraImports = functionType
+    .getRequiredImports('kotlin')
+    .map((i) => `import ${i.name}`)
+
   const kotlinCode = `
 ${createFileMetadataString(`${name}.kt`)}
 
@@ -30,6 +34,7 @@ import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
+${extraImports.join('\n')}
 
 /**
  * Represents the JavaScript callback \`${functionType.jsName}\`.

--- a/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
@@ -47,6 +47,10 @@ private constructor(${indent(params.join(', '), 20)})
     secondaryConstructor = `/* main constructor */`
   }
 
+  const extraImports = structType.properties
+    .flatMap((t) => t.getRequiredImports('kotlin'))
+    .map((i) => `import ${i.name}`)
+
   const code = `
 ${createFileMetadataString(`${structType.structName}.kt`)}
 
@@ -55,6 +59,7 @@ package ${packageName}
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
+${extraImports.join('\n')}
 
 /**
  * Represents the JavaScript object/struct "${structType.structName}".

--- a/packages/nitrogen/src/syntax/kotlin/KotlinVariant.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinVariant.ts
@@ -44,12 +44,18 @@ val is${innerName}: Boolean
 fun create(value: ${v.getCode('kotlin')}): ${kotlinName} = ${innerName}(value)
     `.trim()
   })
+
+  const extraImports = variant.variants
+    .flatMap((t) => t.getRequiredImports('kotlin'))
+    .map((i) => `import ${i.name}`)
+
   const code = `
 ${createFileMetadataString(`${kotlinName}.kt`)}
 
 package ${packageName}
 
 import com.facebook.proguard.annotations.DoNotStrip
+${extraImports.join('\n')}
 
 /**
  * Represents the TypeScript variant "${jsName}".

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -84,47 +84,21 @@ function createCxxHybridObjectSwiftHelper(
     createCxxUpcastHelper(base, type)
   )
 
-  const includes: SourceImport[] = []
-  if (!type.sourceConfig.isExternalConfig) {
-    // we are including our Swift helper internally. this is a private header so we can include just fine.
-    includes.push({
+  let include: SourceImport
+  if (type.sourceConfig.isExternalConfig) {
+    // import from external module
+    include = {
+      language: 'c++',
+      name: `${modulename}/${HybridTSpecSwift}.hpp`,
+      space: 'system',
+    }
+  } else {
+    include = {
       language: 'c++',
       // Hybrid Object Swift C++ class wrapper
       name: `${HybridTSpecSwift}.hpp`,
       space: 'user',
-    })
-  } else {
-    // it's an external type - we need to include the external module's bridge as the *Swift.hpp header is private.
-    const externalBridgeName = type.sourceConfig.getSwiftBridgeHeaderName()
-    const moduleName = type.sourceConfig.getIosModuleName()
-    includes.push({
-      language: 'c++',
-      name: `${moduleName}/${externalBridgeName}.hpp`,
-      space: 'system',
-    })
-  }
-
-  let getImplementation: string
-  let createImplementation: string
-  if (!type.sourceConfig.isExternalConfig) {
-    createImplementation = `
-${swiftPartType} swiftPart = ${swiftPartType}::fromUnsafe(swiftUnsafePointer);
-return std::make_shared<${swiftWrappingType}>(swiftPart);
-    `.trim()
-    getImplementation = `
-std::shared_ptr<${swiftWrappingType}> swiftWrapper = std::dynamic_pointer_cast<${swiftWrappingType}>(cppType);
-#ifdef NITRO_DEBUG
-if (swiftWrapper == nullptr) [[unlikely]] {
-  throw std::runtime_error("Class \\"${HybridTSpec}\\" is not implemented in Swift!");
-}
-#endif
-${swiftPartType}& swiftPart = swiftWrapper->getSwiftPart();
-return swiftPart.toUnsafe();
-`.trim()
-  } else {
-    const cxxNamespace = type.sourceConfig.getCxxNamespace('c++')
-    createImplementation = `return ${cxxNamespace}::create_${name}(swiftUnsafePointer);`
-    getImplementation = `return ${cxxNamespace}::get_${name}(cppType);`
+    }
   }
 
   return {
@@ -145,14 +119,22 @@ void* _Nonnull get_${name}(${name} cppType);
     cxxImplementation: {
       code: `
 ${actualType} create_${name}(void* _Nonnull swiftUnsafePointer) {
-  ${indent(createImplementation, '  ')}
+  ${swiftPartType} swiftPart = ${swiftPartType}::fromUnsafe(swiftUnsafePointer);
+  return std::make_shared<${swiftWrappingType}>(swiftPart);
 }
 void* _Nonnull get_${name}(${name} cppType) {
-  ${indent(getImplementation, '  ')}
+  std::shared_ptr<${swiftWrappingType}> swiftWrapper = std::dynamic_pointer_cast<${swiftWrappingType}>(cppType);
+#ifdef NITRO_DEBUG
+  if (swiftWrapper == nullptr) [[unlikely]] {
+    throw std::runtime_error("Class \\"${HybridTSpec}\\" is not implemented in Swift!");
+  }
+#endif
+  ${swiftPartType}& swiftPart = swiftWrapper->getSwiftPart();
+  return swiftPart.toUnsafe();
 }
     `.trim(),
       requiredIncludes: [
-        ...includes,
+        include,
         {
           language: 'c++',
           // Swift umbrella header

--- a/packages/nitrogen/src/syntax/swift/SwiftFunction.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftFunction.ts
@@ -31,10 +31,15 @@ return ${returnType.parseFromSwiftToCpp('__result', 'swift')}
     `.trim()
   }
 
+  const extraImports = functionType
+    .getRequiredImports('swift')
+    .map((i) => `import ${i.name}`)
+
   const code = `
 ${createFileMetadataString(`${swiftClassName}.swift`)}
 
 import NitroModules
+${extraImports.join('\n')}
 
 /**
  * Wraps a Swift \`${functionType.getCode('swift')}\` as a class.

--- a/packages/nitrogen/src/syntax/swift/SwiftVariant.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftVariant.ts
@@ -38,8 +38,14 @@ export function createSwiftVariant(variant: VariantType): SourceFile {
   const allPrimitives = variant.variants.every((v) => isPrimitive(v))
   const enumDeclaration = allPrimitives ? 'enum' : 'indirect enum'
 
+  const extraImports = variant.variants
+    .flatMap((t) => t.getRequiredImports('swift'))
+    .map((i) => `import ${i.name}`)
+
   const code = `
 ${createFileMetadataString(`${typename}.swift`)}
+
+${extraImports.join('\n')}
 
 /**
  * An Swift enum with associated values representing a Variant/Union type.

--- a/packages/nitrogen/src/syntax/types/HybridObjectType.ts
+++ b/packages/nitrogen/src/syntax/types/HybridObjectType.ts
@@ -82,12 +82,7 @@ export class HybridObjectType implements Type {
         }
       }
       case 'swift': {
-        if (this.sourceConfig.isExternalConfig) {
-          const moduleName = this.sourceConfig.getIosModuleName()
-          return `(any ${moduleName}.${name.HybridTSpec})`
-        } else {
-          return `(any ${name.HybridTSpec})`
-        }
+        return `(any ${name.HybridTSpec})`
       }
       case 'kotlin': {
         if (this.sourceConfig.isExternalConfig) {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Car.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Car.kt
@@ -11,6 +11,7 @@ import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 
+
 /**
  * Represents the JavaScript object/struct "Car".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_double.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_double.kt
@@ -13,6 +13,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
+
 /**
  * Represents the JavaScript callback `() => double`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_double__.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_double__.kt
@@ -13,6 +13,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
+
 /**
  * Represents the JavaScript callback `() => std::shared_ptr<Promise<double>>`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.kt
@@ -13,6 +13,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
+
 /**
  * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.kt
@@ -13,6 +13,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
+
 /**
  * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__string__.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__string__.kt
@@ -13,6 +13,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
+
 /**
  * Represents the JavaScript callback `() => std::shared_ptr<Promise<std::string>>`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void.kt
@@ -13,6 +13,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
+
 /**
  * Represents the JavaScript callback `() => void`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_double.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_double.kt
@@ -13,6 +13,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
+
 /**
  * Represents the JavaScript callback `(num: number) => void`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__optional_double_.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__optional_double_.kt
@@ -13,6 +13,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
+
 /**
  * Represents the JavaScript callback `(maybe: optional) => void`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__string.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__string.kt
@@ -13,6 +13,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
+
 /**
  * Represents the JavaScript callback `(valueFromJs: string) => void`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__vector_Powertrain_.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__vector_Powertrain_.kt
@@ -13,6 +13,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 import dalvik.annotation.optimization.FastNative
 
+
 /**
  * Represents the JavaScript callback `(array: array) => void`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
@@ -11,6 +11,7 @@ import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 
+
 /**
  * Represents the JavaScript object/struct "JsStyleStruct".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/MapWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/MapWrapper.kt
@@ -11,6 +11,7 @@ import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 
+
 /**
  * Represents the JavaScript object/struct "MapWrapper".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/NamedVariant.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/NamedVariant.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import com.facebook.proguard.annotations.DoNotStrip
 
+
 /**
  * Represents the TypeScript variant "String|Car".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Person.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Person.kt
@@ -11,6 +11,7 @@ import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.*
 
+
 /**
  * Represents the JavaScript object/struct "Person".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_Boolean_OldEnum.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_Boolean_OldEnum.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import com.facebook.proguard.annotations.DoNotStrip
 
+
 /**
  * Represents the TypeScript variant "Boolean|OldEnum".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_Boolean_WeirdNumbersEnum.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_Boolean_WeirdNumbersEnum.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import com.facebook.proguard.annotations.DoNotStrip
 
+
 /**
  * Represents the TypeScript variant "Boolean|WeirdNumbersEnum".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_Car_Person.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_Car_Person.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import com.facebook.proguard.annotations.DoNotStrip
 
+
 /**
  * Represents the TypeScript variant "Car|Person".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_Double_Boolean.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_Double_Boolean.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import com.facebook.proguard.annotations.DoNotStrip
 
+
 /**
  * Represents the TypeScript variant "Double|Boolean".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_Person_HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_Person_HybridTestObjectSwiftKotlinSpec.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import com.facebook.proguard.annotations.DoNotStrip
 
+
 /**
  * Represents the TypeScript variant "Person|HybridTestObjectSwiftKotlinSpec".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_String_Double.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_String_Double.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import com.facebook.proguard.annotations.DoNotStrip
 
+
 /**
  * Represents the TypeScript variant "String|Double".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_String_Double_Boolean_DoubleArray_Array_String_.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Variant_String_Double_Boolean_DoubleArray_Array_String_.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import com.facebook.proguard.annotations.DoNotStrip
 
+
 /**
  * Represents the TypeScript variant "String|Double|Boolean|DoubleArray|Array<String>".
  */

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.cpp
@@ -23,11 +23,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   void* _Nonnull get_std__shared_ptr_margelo__nitro__test__HybridTestObjectSwiftKotlinSpec_(std__shared_ptr_margelo__nitro__test__HybridTestObjectSwiftKotlinSpec_ cppType) {
     std::shared_ptr<margelo::nitro::test::HybridTestObjectSwiftKotlinSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridTestObjectSwiftKotlinSpecSwift>(cppType);
-    #ifdef NITRO_DEBUG
+  #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
       throw std::runtime_error("Class \"HybridTestObjectSwiftKotlinSpec\" is not implemented in Swift!");
     }
-    #endif
+  #endif
     NitroTest::HybridTestObjectSwiftKotlinSpec_cxx& swiftPart = swiftWrapper->getSwiftPart();
     return swiftPart.toUnsafe();
   }
@@ -163,11 +163,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   void* _Nonnull get_std__shared_ptr_margelo__nitro__test__HybridBaseSpec_(std__shared_ptr_margelo__nitro__test__HybridBaseSpec_ cppType) {
     std::shared_ptr<margelo::nitro::test::HybridBaseSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridBaseSpecSwift>(cppType);
-    #ifdef NITRO_DEBUG
+  #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
       throw std::runtime_error("Class \"HybridBaseSpec\" is not implemented in Swift!");
     }
-    #endif
+  #endif
     NitroTest::HybridBaseSpec_cxx& swiftPart = swiftWrapper->getSwiftPart();
     return swiftPart.toUnsafe();
   }
@@ -179,11 +179,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   void* _Nonnull get_std__shared_ptr_margelo__nitro__test__HybridChildSpec_(std__shared_ptr_margelo__nitro__test__HybridChildSpec_ cppType) {
     std::shared_ptr<margelo::nitro::test::HybridChildSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridChildSpecSwift>(cppType);
-    #ifdef NITRO_DEBUG
+  #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
       throw std::runtime_error("Class \"HybridChildSpec\" is not implemented in Swift!");
     }
-    #endif
+  #endif
     NitroTest::HybridChildSpec_cxx& swiftPart = swiftWrapper->getSwiftPart();
     return swiftPart.toUnsafe();
   }
@@ -204,11 +204,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   void* _Nonnull get_std__shared_ptr_margelo__nitro__test__HybridTestViewSpec_(std__shared_ptr_margelo__nitro__test__HybridTestViewSpec_ cppType) {
     std::shared_ptr<margelo::nitro::test::HybridTestViewSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridTestViewSpecSwift>(cppType);
-    #ifdef NITRO_DEBUG
+  #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
       throw std::runtime_error("Class \"HybridTestViewSpec\" is not implemented in Swift!");
     }
-    #endif
+  #endif
     NitroTest::HybridTestViewSpec_cxx& swiftPart = swiftWrapper->getSwiftPart();
     return swiftPart.toUnsafe();
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.cpp
@@ -23,11 +23,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   void* _Nonnull get_std__shared_ptr_margelo__nitro__test__HybridTestObjectSwiftKotlinSpec_(std__shared_ptr_margelo__nitro__test__HybridTestObjectSwiftKotlinSpec_ cppType) {
     std::shared_ptr<margelo::nitro::test::HybridTestObjectSwiftKotlinSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridTestObjectSwiftKotlinSpecSwift>(cppType);
-  #ifdef NITRO_DEBUG
+    #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
       throw std::runtime_error("Class \"HybridTestObjectSwiftKotlinSpec\" is not implemented in Swift!");
     }
-  #endif
+    #endif
     NitroTest::HybridTestObjectSwiftKotlinSpec_cxx& swiftPart = swiftWrapper->getSwiftPart();
     return swiftPart.toUnsafe();
   }
@@ -163,11 +163,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   void* _Nonnull get_std__shared_ptr_margelo__nitro__test__HybridBaseSpec_(std__shared_ptr_margelo__nitro__test__HybridBaseSpec_ cppType) {
     std::shared_ptr<margelo::nitro::test::HybridBaseSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridBaseSpecSwift>(cppType);
-  #ifdef NITRO_DEBUG
+    #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
       throw std::runtime_error("Class \"HybridBaseSpec\" is not implemented in Swift!");
     }
-  #endif
+    #endif
     NitroTest::HybridBaseSpec_cxx& swiftPart = swiftWrapper->getSwiftPart();
     return swiftPart.toUnsafe();
   }
@@ -179,11 +179,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   void* _Nonnull get_std__shared_ptr_margelo__nitro__test__HybridChildSpec_(std__shared_ptr_margelo__nitro__test__HybridChildSpec_ cppType) {
     std::shared_ptr<margelo::nitro::test::HybridChildSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridChildSpecSwift>(cppType);
-  #ifdef NITRO_DEBUG
+    #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
       throw std::runtime_error("Class \"HybridChildSpec\" is not implemented in Swift!");
     }
-  #endif
+    #endif
     NitroTest::HybridChildSpec_cxx& swiftPart = swiftWrapper->getSwiftPart();
     return swiftPart.toUnsafe();
   }
@@ -204,11 +204,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   void* _Nonnull get_std__shared_ptr_margelo__nitro__test__HybridTestViewSpec_(std__shared_ptr_margelo__nitro__test__HybridTestViewSpec_ cppType) {
     std::shared_ptr<margelo::nitro::test::HybridTestViewSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridTestViewSpecSwift>(cppType);
-  #ifdef NITRO_DEBUG
+    #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
       throw std::runtime_error("Class \"HybridTestViewSpec\" is not implemented in Swift!");
     }
-  #endif
+    #endif
     NitroTest::HybridTestViewSpec_cxx& swiftPart = swiftWrapper->getSwiftPart();
     return swiftPart.toUnsafe();
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_double.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_double.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `() -> Double` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_double__.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_double__.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `() -> Promise<Double>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `() -> Promise<Promise<Double>>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `() -> Promise<Promise<ArrayBuffer>>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__string__.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_std__shared_ptr_Promise_std__string__.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `() -> Promise<String>` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `() -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_Car.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_Car.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `(_ value: Car) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_double.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_double.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `(_ num: Double) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_int64_t.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_int64_t.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `(_ value: Int64) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__exception_ptr.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__exception_ptr.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `(_ error: Error) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__optional_double_.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__optional_double_.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `(_ maybe: Double?) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_ArrayBuffer_.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_ArrayBuffer_.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `(_ value: ArrayBuffer) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_double__.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_double__.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `(_ value: Promise<Double>) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `(_ value: Promise<ArrayBuffer>) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__string.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__string.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `(_ valueFromJs: String) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__vector_Powertrain_.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__vector_Powertrain_.swift
@@ -7,6 +7,7 @@
 
 import NitroModules
 
+
 /**
  * Wraps a Swift `(_ array: [Powertrain]) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/NamedVariant.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/NamedVariant.swift
@@ -5,6 +5,8 @@
 /// Copyright © 2025 Marc Rousavy @ Margelo
 ///
 
+
+
 /**
  * An Swift enum with associated values representing a Variant/Union type.
  * JS type: `string | struct`

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_Bool_OldEnum.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_Bool_OldEnum.swift
@@ -5,6 +5,8 @@
 /// Copyright © 2025 Marc Rousavy @ Margelo
 ///
 
+
+
 /**
  * An Swift enum with associated values representing a Variant/Union type.
  * JS type: `boolean | enum`

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_Bool_WeirdNumbersEnum.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_Bool_WeirdNumbersEnum.swift
@@ -5,6 +5,8 @@
 /// Copyright © 2025 Marc Rousavy @ Margelo
 ///
 
+
+
 /**
  * An Swift enum with associated values representing a Variant/Union type.
  * JS type: `boolean | enum`

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_Car_Person.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_Car_Person.swift
@@ -5,6 +5,8 @@
 /// Copyright © 2025 Marc Rousavy @ Margelo
 ///
 
+
+
 /**
  * An Swift enum with associated values representing a Variant/Union type.
  * JS type: `struct | struct`

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_Double_Bool.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_Double_Bool.swift
@@ -5,6 +5,8 @@
 /// Copyright © 2025 Marc Rousavy @ Margelo
 ///
 
+
+
 /**
  * An Swift enum with associated values representing a Variant/Union type.
  * JS type: `number | boolean`

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_Person__any_HybridTestObjectSwiftKotlinSpec_.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_Person__any_HybridTestObjectSwiftKotlinSpec_.swift
@@ -5,6 +5,8 @@
 /// Copyright © 2025 Marc Rousavy @ Margelo
 ///
 
+
+
 /**
  * An Swift enum with associated values representing a Variant/Union type.
  * JS type: `struct | hybrid-object`

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_String_Double.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_String_Double.swift
@@ -5,6 +5,8 @@
 /// Copyright © 2025 Marc Rousavy @ Margelo
 ///
 
+
+
 /**
  * An Swift enum with associated values representing a Variant/Union type.
  * JS type: `string | number`

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_String_Double_Bool__Double___String_.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Variant_String_Double_Bool__Double___String_.swift
@@ -5,6 +5,8 @@
 /// Copyright © 2025 Marc Rousavy @ Margelo
 ///
 
+
+
 /**
  * An Swift enum with associated values representing a Variant/Union type.
  * JS type: `string | number | boolean | array | array`


### PR DESCRIPTION
Import required/used types in Kotlin/Swift Functions, Structs and Variants. Previously it was assumed all types are internal.
Now you can create variants of external types, structs that contain external types as properties, or functions that take external types as parameters or return them.