### PR TITLE
fix: add special handling logic for structs `KotlinCxxBridgedType`

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinCxxBridgedType.ts
@@ -41,6 +41,15 @@ export class KotlinCxxBridgedType implements BridgedType<'kotlin', 'c++'> {
       case 'function':
         // Function needs to be converted from JFunc_... to Lambda
         return true
+      case 'struct':
+        // Structs don't need special handling - they have direct mappings
+        // Returning false prevents secondary constructor generation that causes duplicates
+        return false
+      case 'optional':
+        // Optionals need special handling if the wrapped type needs special handling
+        const optional = getTypeAs(this.type, OptionalType)
+        return new KotlinCxxBridgedType(optional.wrappingType)
+          .needsSpecialHandling
       default:
         break
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -744,7 +744,7 @@ namespace margelo::nitro::test {
     return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   void JHybridTestObjectSwiftKotlinSpec::jsStyleObjectAsParameters(const JsStyleStruct& params) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JJsStyleStruct> /* params */)>("jsStyleObjectAsParameters_cxx");
+    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JJsStyleStruct> /* params */)>("jsStyleObjectAsParameters");
     method(_javaPart, JJsStyleStruct::fromCpp(params));
   }
   std::shared_ptr<ArrayBuffer> JHybridTestObjectSwiftKotlinSpec::createArrayBuffer() {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
@@ -350,14 +350,9 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @Keep
   abstract fun getDriver(car: Car): Person?
   
-  abstract fun jsStyleObjectAsParameters(params: JsStyleStruct): Unit
-  
   @DoNotStrip
   @Keep
-  private fun jsStyleObjectAsParameters_cxx(params: JsStyleStruct): Unit {
-    val __result = jsStyleObjectAsParameters(params)
-    return __result
-  }
+  abstract fun jsStyleObjectAsParameters(params: JsStyleStruct): Unit
   
   @DoNotStrip
   @Keep


### PR DESCRIPTION
## Summary

Update logic for determining when a Kotlin type bridged to C++ requires special handling, specifically improving support for nested structs. The main changes clarify that structs do not need special handling and ensure that optionals defer to their wrapped type's requirements

fixes #795 