### PR TITLE
perf: Speed up Nitrogen by 94x by making `filterDuplicateFiles(…)` O(n) instead of O(n²) 🤯

### DIFF
--- a/packages/nitrogen/src/getFiles.ts
+++ b/packages/nitrogen/src/getFiles.ts
@@ -1,9 +1,9 @@
 import { Dirent, promises as fs } from 'fs'
-import path from 'path'
+import { unsafeFastJoin } from './utils.js'
 
 function getFilePath(file: Dirent, rootDir: string): string {
   const dir = file.parentPath ?? file.path ?? rootDir
-  return path.join(dir, file.name)
+  return unsafeFastJoin(dir, file.name)
 }
 
 export async function getFiles(directory: string): Promise<string[]> {

--- a/packages/nitrogen/src/getFiles.ts
+++ b/packages/nitrogen/src/getFiles.ts
@@ -1,9 +1,9 @@
 import { Dirent, promises as fs } from 'fs'
-import { unsafeFastJoin } from './utils.js'
+import path from 'path'
 
 function getFilePath(file: Dirent, rootDir: string): string {
   const dir = file.parentPath ?? file.path ?? rootDir
-  return unsafeFastJoin(dir, file.name)
+  return path.join(dir, file.name)
 }
 
 export async function getFiles(directory: string): Promise<string[]> {

--- a/packages/nitrogen/src/nitrogen.ts
+++ b/packages/nitrogen/src/nitrogen.ts
@@ -11,8 +11,8 @@ import path from 'path'
 import { prettifyDirectory } from './prettifyDirectory.js'
 import {
   capitalizeName,
+  deduplicateFiles,
   errorToString,
-  filterDuplicateFiles,
   indent,
   NITROGEN_VERSION,
 } from './utils.js'
@@ -142,13 +142,13 @@ export async function runNitrogen({
         )
 
         // Create all files and throw it into a big list
-        const allFiles = platforms
-          .flatMap((p) => {
-            usedPlatforms.push(p)
-            const language = platformSpec[p]!
-            return generatePlatformFiles(declaration.getType(), language)
-          })
-          .filter(filterDuplicateFiles)
+        let allFiles = platforms.flatMap((p) => {
+          usedPlatforms.push(p)
+          const language = platformSpec[p]!
+          const r = generatePlatformFiles(declaration.getType(), language)
+          return r
+        })
+        allFiles = deduplicateFiles(allFiles)
         // Group the files by platform ({ ios: [], android: [], shared: [] })
         const filesPerPlatform = groupByPlatform(allFiles)
         // Loop through each platform one by one so that it has some kind of order (per-platform)

--- a/packages/nitrogen/src/utils.ts
+++ b/packages/nitrogen/src/utils.ts
@@ -64,7 +64,7 @@ export function toUnixPath(p: string): string {
 }
 
 const sep = path.sep
-function unsafeFastJoin(...segments: string[]): string {
+export function unsafeFastJoin(...segments: string[]): string {
   // this function should really not take any unsafe strings like `/` or `\`.
   return segments.join(sep)
 }

--- a/packages/nitrogen/src/utils.ts
+++ b/packages/nitrogen/src/utils.ts
@@ -74,7 +74,7 @@ function getFullPath(file: SourceFile): string {
     file.platform,
     file.language,
     ...file.subdirectory,
-    file.content
+    file.name
   )
 }
 export function filterDuplicateFiles(

--- a/packages/nitrogen/src/utils.ts
+++ b/packages/nitrogen/src/utils.ts
@@ -77,18 +77,21 @@ function getFullPath(file: SourceFile): string {
     file.name
   )
 }
-export function filterDuplicateFiles(
-  f: SourceFile,
-  i: number,
-  array: SourceFile[]
-): boolean {
-  const otherIndex = array.findIndex((f2) => getFullPath(f) === getFullPath(f2))
-  if (otherIndex !== i) {
-    if (array[i]?.content !== array[otherIndex]?.content) {
-      throw new Error(`File "${f.name}"'s content differs!`)
+
+/**
+ * Deduplicates all files via their full path.
+ * If content differs, you are f*cked.
+ */
+export function deduplicateFiles(files: SourceFile[]): SourceFile[] {
+  const map = new Map<string, SourceFile>()
+  for (const file of files) {
+    const filePath = getFullPath(file)
+
+    if (!map.has(filePath)) {
+      map.set(filePath, file)
     }
   }
-  return otherIndex === i
+  return [...map.values()]
 }
 
 export function filterDuplicateHelperBridges(

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JFunc_void_double.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JFunc_void_double.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * Represents the Java/Kotlin callback `(num: Double) -> Unit`.
+   * Represents the Java/Kotlin callback `(value: Double) -> Unit`.
    * This can be passed around between C++ and Java/Kotlin.
    */
   struct JFunc_void_double: public jni::JavaClass<JFunc_void_double> {
@@ -28,9 +28,9 @@ namespace margelo::nitro::test {
     /**
      * Invokes the function this `JFunc_void_double` instance holds through JNI.
      */
-    void invoke(double num) const {
-      static const auto method = javaClassStatic()->getMethod<void(double /* num */)>("invoke");
-      method(self(), num);
+    void invoke(double value) const {
+      static const auto method = javaClassStatic()->getMethod<void(double /* value */)>("invoke");
+      method(self(), value);
     }
   };
 
@@ -39,7 +39,7 @@ namespace margelo::nitro::test {
    */
   struct JFunc_void_double_cxx final: public jni::HybridClass<JFunc_void_double_cxx, JFunc_void_double> {
   public:
-    static jni::local_ref<JFunc_void_double::javaobject> fromCpp(const std::function<void(double /* num */)>& func) {
+    static jni::local_ref<JFunc_void_double::javaobject> fromCpp(const std::function<void(double /* value */)>& func) {
       return JFunc_void_double_cxx::newObjectCxxArgs(func);
     }
 
@@ -47,13 +47,13 @@ namespace margelo::nitro::test {
     /**
      * Invokes the C++ `std::function<...>` this `JFunc_void_double_cxx` instance holds.
      */
-    void invoke_cxx(double num) {
-      _func(num);
+    void invoke_cxx(double value) {
+      _func(value);
     }
 
   public:
     [[nodiscard]]
-    inline const std::function<void(double /* num */)>& getFunction() const {
+    inline const std::function<void(double /* value */)>& getFunction() const {
       return _func;
     }
 
@@ -64,11 +64,11 @@ namespace margelo::nitro::test {
     }
 
   private:
-    explicit JFunc_void_double_cxx(const std::function<void(double /* num */)>& func): _func(func) { }
+    explicit JFunc_void_double_cxx(const std::function<void(double /* value */)>& func): _func(func) { }
 
   private:
     friend HybridBase;
-    std::function<void(double /* num */)> _func;
+    std::function<void(double /* value */)> _func;
   };
 
 } // namespace margelo::nitro::test

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_double.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_double.kt
@@ -15,7 +15,7 @@ import dalvik.annotation.optimization.FastNative
 
 
 /**
- * Represents the JavaScript callback `(num: number) => void`.
+ * Represents the JavaScript callback `(value: number) => void`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),
  * or in Kotlin/Java (in which case it is a native callback).
  */
@@ -29,11 +29,11 @@ fun interface Func_void_double: (Double) -> Unit {
    */
   @DoNotStrip
   @Keep
-  override fun invoke(num: Double): Unit
+  override fun invoke(value: Double): Unit
 }
 
 /**
- * Represents the JavaScript callback `(num: number) => void`.
+ * Represents the JavaScript callback `(value: number) => void`.
  * This is implemented in C++, via a `std::function<...>`.
  * The callback might be coming from JS.
  */
@@ -57,15 +57,15 @@ class Func_void_double_cxx: Func_void_double {
 
   @DoNotStrip
   @Keep
-  override fun invoke(num: Double): Unit
-    = invoke_cxx(num)
+  override fun invoke(value: Double): Unit
+    = invoke_cxx(value)
 
   @FastNative
-  private external fun invoke_cxx(num: Double): Unit
+  private external fun invoke_cxx(value: Double): Unit
 }
 
 /**
- * Represents the JavaScript callback `(num: number) => void`.
+ * Represents the JavaScript callback `(value: number) => void`.
  * This is implemented in Java/Kotlin, via a `(Double) -> Unit`.
  * The callback is always coming from native.
  */
@@ -75,7 +75,7 @@ class Func_void_double_cxx: Func_void_double {
 class Func_void_double_java(private val function: (Double) -> Unit): Func_void_double {
   @DoNotStrip
   @Keep
-  override fun invoke(num: Double): Unit {
-    return this.function(num)
+  override fun invoke(value: Double): Unit {
+    return this.function(value)
   }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_double.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_double.swift
@@ -9,21 +9,21 @@ import NitroModules
 
 
 /**
- * Wraps a Swift `(_ num: Double) -> Void` as a class.
+ * Wraps a Swift `(_ value: Double) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_double {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ num: Double) -> Void
+  private let closure: (_ value: Double) -> Void
 
-  public init(_ closure: @escaping (_ num: Double) -> Void) {
+  public init(_ closure: @escaping (_ value: Double) -> Void) {
     self.closure = closure
   }
 
   @inline(__always)
-  public func call(num: Double) -> Void {
-    self.closure(num)
+  public func call(value: Double) -> Void {
+    self.closure(value)
   }
 
   /**

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__string.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Func_void_std__string.swift
@@ -9,21 +9,21 @@ import NitroModules
 
 
 /**
- * Wraps a Swift `(_ valueFromJs: String) -> Void` as a class.
+ * Wraps a Swift `(_ value: String) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__string {
   public typealias bridge = margelo.nitro.test.bridge.swift
 
-  private let closure: (_ valueFromJs: String) -> Void
+  private let closure: (_ value: String) -> Void
 
-  public init(_ closure: @escaping (_ valueFromJs: String) -> Void) {
+  public init(_ closure: @escaping (_ value: String) -> Void) {
     self.closure = closure
   }
 
   @inline(__always)
-  public func call(valueFromJs: std.string) -> Void {
-    self.closure(String(valueFromJs))
+  public func call(value: std.string) -> Void {
+    self.closure(String(value))
   }
 
   /**


### PR DESCRIPTION
1. I was walking the full array recursively, so it wasn't O(n) to dedupe files but rather O(n^2)!! 
2. I was comparing the `file.content`, which is an expensive string comparison (character by character) each time. Also called O(n^2) lol
3. Instead of recursive loops, I use a hash map to efficiently store files via their full paths. Makes things O(n) and fast.