### PR TITLE
fix: Also support non-sequential enums in Kotlin

### DIFF
--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JColorScheme.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JColorScheme.hpp
@@ -29,7 +29,7 @@ namespace margelo::nitro::test {
     [[nodiscard]]
     ColorScheme toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("_ordinal");
+      static const auto fieldOrdinal = clazz->getField<int>("value");
       int ordinal = this->getFieldValue(fieldOrdinal);
       return static_cast<ColorScheme>(ordinal);
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JOldEnum.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JOldEnum.hpp
@@ -29,7 +29,7 @@ namespace margelo::nitro::test {
     [[nodiscard]]
     OldEnum toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("_ordinal");
+      static const auto fieldOrdinal = clazz->getField<int>("value");
       int ordinal = this->getFieldValue(fieldOrdinal);
       return static_cast<OldEnum>(ordinal);
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JPowertrain.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JPowertrain.hpp
@@ -29,7 +29,7 @@ namespace margelo::nitro::test {
     [[nodiscard]]
     Powertrain toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("_ordinal");
+      static const auto fieldOrdinal = clazz->getField<int>("value");
       int ordinal = this->getFieldValue(fieldOrdinal);
       return static_cast<Powertrain>(ordinal);
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JWeirdNumbersEnum.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JWeirdNumbersEnum.hpp
@@ -29,7 +29,7 @@ namespace margelo::nitro::test {
     [[nodiscard]]
     WeirdNumbersEnum toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldOrdinal = clazz->getField<int>("_ordinal");
+      static const auto fieldOrdinal = clazz->getField<int>("value");
       int ordinal = this->getFieldValue(fieldOrdinal);
       return static_cast<WeirdNumbersEnum>(ordinal);
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/ColorScheme.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/ColorScheme.kt
@@ -15,11 +15,7 @@ import com.facebook.proguard.annotations.DoNotStrip
  */
 @DoNotStrip
 @Keep
-enum class ColorScheme {
-  LIGHT,
-  DARK;
-
-  @DoNotStrip
-  @Keep
-  private val _ordinal = ordinal
+enum class ColorScheme(@DoNotStrip @Keep val value: Int) {
+  LIGHT(0),
+  DARK(1);
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OldEnum.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OldEnum.kt
@@ -15,12 +15,8 @@ import com.facebook.proguard.annotations.DoNotStrip
  */
 @DoNotStrip
 @Keep
-enum class OldEnum {
-  FIRST,
-  SECOND,
-  THIRD;
-
-  @DoNotStrip
-  @Keep
-  private val _ordinal = ordinal
+enum class OldEnum(@DoNotStrip @Keep val value: Int) {
+  FIRST(0),
+  SECOND(1),
+  THIRD(2);
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Powertrain.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Powertrain.kt
@@ -15,12 +15,8 @@ import com.facebook.proguard.annotations.DoNotStrip
  */
 @DoNotStrip
 @Keep
-enum class Powertrain {
-  ELECTRIC,
-  GAS,
-  HYBRID;
-
-  @DoNotStrip
-  @Keep
-  private val _ordinal = ordinal
+enum class Powertrain(@DoNotStrip @Keep val value: Int) {
+  ELECTRIC(0),
+  GAS(1),
+  HYBRID(2);
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WeirdNumbersEnum.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WeirdNumbersEnum.kt
@@ -15,12 +15,8 @@ import com.facebook.proguard.annotations.DoNotStrip
  */
 @DoNotStrip
 @Keep
-enum class WeirdNumbersEnum {
-  A,
-  B,
-  C;
-
-  @DoNotStrip
-  @Keep
-  private val _ordinal = ordinal
+enum class WeirdNumbersEnum(@DoNotStrip @Keep val value: Int) {
+  A(0),
+  B(32),
+  C(64);
 }


### PR DESCRIPTION
We now just pass a `value` flag and it works in Kotlin too.