### PR TITLE
fix: Fix Kotlin structs not holding the Cxx types

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
@@ -36,11 +36,11 @@ val ${p.escapedName}: ${bridged.getTypeCode('kotlin', false)}
       }
     })
     secondaryConstructor = `
-@DoNotStrip
-@Keep
-@Suppress("unused")
-private constructor(${indent(params.join(', '), 20)})
-             : this(${indent(paramsForward.join(', '), 20)})
+/**
+ * Initialize a new instance of \`${structType.structName}\` from Kotlin.
+ */
+constructor(${indent(params.join(', '), 12)})
+     : this(${indent(paramsForward.join(', '), 12)})
     `.trim()
   } else {
     secondaryConstructor = `/* main constructor */`

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Car.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Car.kt
@@ -21,12 +21,26 @@ data class Car
   @DoNotStrip
   @Keep
   constructor(
+    @DoNotStrip
+    @Keep
     val year: Double,
+    @DoNotStrip
+    @Keep
     val make: String,
+    @DoNotStrip
+    @Keep
     val model: String,
+    @DoNotStrip
+    @Keep
     val power: Double,
+    @DoNotStrip
+    @Keep
     val powertrain: Powertrain,
+    @DoNotStrip
+    @Keep
     val driver: Person?,
+    @DoNotStrip
+    @Keep
     val isFast: Boolean?
   ) {
   /* main constructor */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
@@ -21,12 +21,16 @@ data class JsStyleStruct
   @DoNotStrip
   @Keep
   constructor(
+    @DoNotStrip
+    @Keep
     val value: Double,
-    val onChanged: (num: Double) -> Unit
+    @DoNotStrip
+    @Keep
+    val onChanged: Func_void_double
   ) {
   @DoNotStrip
   @Keep
   @Suppress("unused")
-  private constructor(value: Double, onChanged: Func_void_double)
-               : this(value, onChanged as (num: Double) -> Unit)
+  private constructor(value: Double, onChanged: (num: Double) -> Unit)
+               : this(value, Func_void_double_java(onChanged))
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
@@ -28,9 +28,9 @@ data class JsStyleStruct
     @Keep
     val onChanged: Func_void_double
   ) {
-  @DoNotStrip
-  @Keep
-  @Suppress("unused")
-  private constructor(value: Double, onChanged: (num: Double) -> Unit)
-               : this(value, Func_void_double_java(onChanged))
+  /**
+   * Initialize a new instance of `JsStyleStruct` from Kotlin.
+   */
+  constructor(value: Double, onChanged: (num: Double) -> Unit)
+       : this(value, Func_void_double_java(onChanged))
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/MapWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/MapWrapper.kt
@@ -21,6 +21,8 @@ data class MapWrapper
   @DoNotStrip
   @Keep
   constructor(
+    @DoNotStrip
+    @Keep
     val map: Map<String, String>
   ) {
   /* main constructor */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Person.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Person.kt
@@ -21,7 +21,11 @@ data class Person
   @DoNotStrip
   @Keep
   constructor(
+    @DoNotStrip
+    @Keep
     val name: String,
+    @DoNotStrip
+    @Keep
     val age: Double
   ) {
   /* main constructor */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WrappedJsStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WrappedJsStruct.kt
@@ -21,6 +21,8 @@ data class WrappedJsStruct
   @DoNotStrip
   @Keep
   constructor(
+    @DoNotStrip
+    @Keep
     val value: JsStyleStruct
   ) {
   /* main constructor */


### PR DESCRIPTION
Kotlin structs were holding the Kotlin-friendly types (e.g. `() -> Unit`) instead of the Cxx-ready types (e.g. `Func_void`).

This caused errors when converting Kotlin structs to C++ as C++ couldn't find the Cxx-ready types in the `data class`.
Now this is fixed and the Kotlin structs actually hold the Cxx-ready type, and provides a convenience initializer for Kotlin.