### PR TITLE
fix: Set `SWIFT_COMPILATION_MODE` to `incremental`

### DIFF
--- a/packages/nitrogen/src/autolinking/ios/createPodspecRubyExtension.ts
+++ b/packages/nitrogen/src/autolinking/ios/createPodspecRubyExtension.ts
@@ -61,6 +61,8 @@ def add_nitrogen_files(spec)
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
     # Enables C++ <-> Swift interop (by default it's only C)
     "SWIFT_OBJC_INTEROP_MODE" => "objcxx",
+    # Only changed Swift files are recompiled also fixes std::string build error
+    "SWIFT_COMPILATION_MODE" => "incremental",
     # Enables stricter modular headers
     "DEFINES_MODULE" => "YES",
   })

--- a/packages/react-native-nitro-modules/NitroModules.podspec
+++ b/packages/react-native-nitro-modules/NitroModules.podspec
@@ -62,6 +62,8 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
     # Enables C++ <-> Swift interop (by default it's only C)
     "SWIFT_OBJC_INTEROP_MODE" => "objcxx",
+    # Only changed Swift files are recompiled also fixes std::string build error
+    "SWIFT_COMPILATION_MODE" => "incremental",
     # Enables stricter modular headers
     "DEFINES_MODULE" => "YES",
   }

--- a/packages/react-native-nitro-test-external/nitrogen/generated/ios/NitroTestExternal+autolinking.rb
+++ b/packages/react-native-nitro-test-external/nitrogen/generated/ios/NitroTestExternal+autolinking.rb
@@ -54,6 +54,8 @@ def add_nitrogen_files(spec)
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
     # Enables C++ <-> Swift interop (by default it's only C)
     "SWIFT_OBJC_INTEROP_MODE" => "objcxx",
+    # Only changed Swift files are recompiled also fixes std::string build error
+    "SWIFT_COMPILATION_MODE" => "incremental",
     # Enables stricter modular headers
     "DEFINES_MODULE" => "YES",
   })

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest+autolinking.rb
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest+autolinking.rb
@@ -54,6 +54,8 @@ def add_nitrogen_files(spec)
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
     # Enables C++ <-> Swift interop (by default it's only C)
     "SWIFT_OBJC_INTEROP_MODE" => "objcxx",
+    # Only changed Swift files are recompiled also fixes std::string build error
+    "SWIFT_COMPILATION_MODE" => "incremental",
     # Enables stricter modular headers
     "DEFINES_MODULE" => "YES",
   })


### PR DESCRIPTION
 Sets the `SWIFT_COMPILATION_MODE` to `incremental` to avoid recompiling everything when a single file changes


 This potentially fixes the `std::string` release build error in https://github.com/mrousavy/react-native-nitro-image/issues/49