### PR TITLE
feat: Add `NitroModules.isHybridObject(...)`

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1617,6 +1617,13 @@ export function getTests(
         .didNotThrow()
         .equals(true)
     ),
+    createTest('NitroModules.isHybridObject(testObject) to be true', () =>
+      it(() => {
+        return NitroModules.isHybridObject(testObject)
+      })
+        .didNotThrow()
+        .equals(true)
+    ),
     createTest('NitroModules.hasNativeState(testObject) to be true', () =>
       it(() => {
         return NitroModules.hasNativeState(testObject)

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
@@ -18,6 +18,7 @@ void HybridNitroModulesProxy::loadHybridMethods() {
   registerHybrids(this, [](Prototype& prototype) {
     prototype.registerHybridMethod("createHybridObject", &HybridNitroModulesProxy::createHybridObject);
     prototype.registerHybridMethod("hasHybridObject", &HybridNitroModulesProxy::hasHybridObject);
+    prototype.registerRawHybridMethod("isHybridObject", 1, &HybridNitroModulesProxy::isHybridObject);
     prototype.registerHybridMethod("getAllHybridObjectNames", &HybridNitroModulesProxy::getAllHybridObjectNames);
 
     prototype.registerHybridMethod("box", &HybridNitroModulesProxy::box);
@@ -37,6 +38,20 @@ std::shared_ptr<HybridObject> HybridNitroModulesProxy::createHybridObject(const 
 
 bool HybridNitroModulesProxy::hasHybridObject(const std::string& name) {
   return HybridObjectRegistry::hasHybridObject(name);
+}
+
+jsi::Value HybridNitroModulesProxy::isHybridObject(jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* args, size_t size) {
+  if (size != 1 || !args[0].isObject()) {
+    return false;
+  }
+  jsi::Object object = args[0].getObject(runtime);
+  if (!object.hasNativeState(runtime)) {
+    return false;
+  }
+  std::shared_ptr<jsi::NativeState> nativeState = object.getNativeState(runtime);
+  std::shared_ptr<HybridObject> maybeHybridObject = std::dynamic_pointer_cast<HybridObject>(nativeState);
+  bool isHybrid = maybeHybridObject != nullptr;
+  return jsi::Value(isHybrid);
 }
 
 std::vector<std::string> HybridNitroModulesProxy::getAllHybridObjectNames() {

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
@@ -40,20 +40,6 @@ bool HybridNitroModulesProxy::hasHybridObject(const std::string& name) {
   return HybridObjectRegistry::hasHybridObject(name);
 }
 
-jsi::Value HybridNitroModulesProxy::isHybridObject(jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* args, size_t size) {
-  if (size != 1 || !args[0].isObject()) {
-    return false;
-  }
-  jsi::Object object = args[0].getObject(runtime);
-  if (!object.hasNativeState(runtime)) {
-    return false;
-  }
-  std::shared_ptr<jsi::NativeState> nativeState = object.getNativeState(runtime);
-  std::shared_ptr<HybridObject> maybeHybridObject = std::dynamic_pointer_cast<HybridObject>(nativeState);
-  bool isHybrid = maybeHybridObject != nullptr;
-  return jsi::Value(isHybrid);
-}
-
 std::vector<std::string> HybridNitroModulesProxy::getAllHybridObjectNames() {
   return HybridObjectRegistry::getAllHybridObjectNames();
 }
@@ -68,6 +54,20 @@ jsi::Value HybridNitroModulesProxy::hasNativeState(jsi::Runtime& runtime, const 
     return false;
   }
   return args[0].getObject(runtime).hasNativeState(runtime);
+}
+
+jsi::Value HybridNitroModulesProxy::isHybridObject(jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* args, size_t size) {
+  if (size != 1 || !args[0].isObject()) {
+    return false;
+  }
+  jsi::Object object = args[0].getObject(runtime);
+  if (!object.hasNativeState(runtime)) {
+    return false;
+  }
+  std::shared_ptr<jsi::NativeState> nativeState = object.getNativeState(runtime);
+  std::shared_ptr<HybridObject> maybeHybridObject = std::dynamic_pointer_cast<HybridObject>(nativeState);
+  bool isHybrid = maybeHybridObject != nullptr;
+  return jsi::Value(isHybrid);
 }
 
 std::shared_ptr<HybridObject> HybridNitroModulesProxy::updateMemorySize(const std::shared_ptr<HybridObject>& hybridObject) {

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.hpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.hpp
@@ -22,7 +22,7 @@ namespace margelo::nitro {
  * 3. Pass the object from `.toObject()` it to JS (either install in global, or return somehow)
  * 4. From JS, you can access methods on this HybridObject to create all other HybridObjects.
  */
-class HybridNitroModulesProxy : public HybridObject {
+class HybridNitroModulesProxy final : public HybridObject {
 public:
   explicit HybridNitroModulesProxy() : HybridObject(TAG) {}
 
@@ -33,13 +33,13 @@ public:
   // Hybrid Object Registry
   std::shared_ptr<HybridObject> createHybridObject(const std::string& name);
   bool hasHybridObject(const std::string& name);
-  jsi::Value isHybridObject(jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* args, size_t size);
   std::vector<std::string> getAllHybridObjectNames();
 
   // Helpers
   std::shared_ptr<BoxedHybridObject> box(const std::shared_ptr<HybridObject>& hybridObject);
   std::shared_ptr<HybridObject> updateMemorySize(const std::shared_ptr<HybridObject>& hybridObject);
   jsi::Value hasNativeState(jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* args, size_t size);
+  jsi::Value isHybridObject(jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* args, size_t size);
 
   // Build Info
   std::string getBuildType();

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.hpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.hpp
@@ -33,6 +33,7 @@ public:
   // Hybrid Object Registry
   std::shared_ptr<HybridObject> createHybridObject(const std::string& name);
   bool hasHybridObject(const std::string& name);
+  jsi::Value isHybridObject(jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* args, size_t size);
   std::vector<std::string> getAllHybridObjectNames();
 
   // Helpers

--- a/packages/react-native-nitro-modules/src/NitroModulesProxy.ts
+++ b/packages/react-native-nitro-modules/src/NitroModulesProxy.ts
@@ -24,6 +24,10 @@ export interface NitroModulesProxy extends HybridObject {
    */
   hasHybridObject(name: string): boolean
   /**
+   * Returns whether the given {@linkcode object} is a {@linkcode HybridObject}, or not.
+   */
+  isHybridObject(object: object): object is HybridObject
+  /**
    * Get a list of all registered Hybrid Objects.
    */
   getAllHybridObjectNames(): string[]


### PR DESCRIPTION
Adds a method to check whether the given object is a `HybridObject` or not.