### PR TITLE
fix: Generate `has_` and `get_` functions for `std::optional<...>`

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -442,6 +442,7 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
       case 'optional': {
         const optional = getTypeAs(this.type, OptionalType)
         const wrapping = new SwiftCxxBridgedType(optional.wrappingType, true)
+        const bridge = this.getBridgeOrThrow()
         switch (language) {
           case 'swift':
             if (wrapping.type.kind === 'enum') {
@@ -458,7 +459,8 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
             }
             return `
 { () -> ${optional.getCode('swift')} in
-  if let __unwrapped = ${cppParameterName}.value {
+  if bridge.has_${bridge.specializationName}(${cppParameterName}) {
+    let __unwrapped = bridge.get_${bridge.specializationName}(${cppParameterName})
     return ${indent(wrapping.parseFromCppToSwift('__unwrapped', language), '    ')}
   } else {
     return nil

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -238,6 +238,12 @@ using ${name} = ${actualType};
 inline ${actualType} create_${name}(const ${wrappedBridge.getTypeCode('c++')}& value) {
   return ${actualType}(${indent(wrappedBridge.parseFromSwiftToCpp('value', 'c++'), '    ')});
 }
+inline bool has_value_${name}(const ${actualType}& optional) {
+  return optional.has_value();
+}
+inline const ${wrappedBridge.getTypeCode('c++')}& get_${name}(const ${actualType}& optional) {
+  return optional.value();
+}
     `.trim(),
       requiredIncludes: [
         {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -103,6 +103,12 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>> create_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& value) {
     return std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>(value);
   }
+  inline bool has_value_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& optional) {
+    return optional.has_value();
+  }
+  inline const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& get_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& optional) {
+    return optional.value();
+  }
   
   // pragma MARK: std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>
   /**
@@ -141,6 +147,12 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) {
     return std::optional<std::string>(value);
   }
+  inline bool has_value_std__optional_std__string_(const std::optional<std::string>& optional) {
+    return optional.has_value();
+  }
+  inline const std::string& get_std__optional_std__string_(const std::optional<std::string>& optional) {
+    return optional.value();
+  }
   
   // pragma MARK: std::vector<std::string>
   /**
@@ -161,6 +173,12 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<std::vector<std::string>> create_std__optional_std__vector_std__string__(const std::vector<std::string>& value) {
     return std::optional<std::vector<std::string>>(value);
   }
+  inline bool has_value_std__optional_std__vector_std__string__(const std::optional<std::vector<std::string>>& optional) {
+    return optional.has_value();
+  }
+  inline const std::vector<std::string>& get_std__optional_std__vector_std__string__(const std::optional<std::vector<std::string>>& optional) {
+    return optional.value();
+  }
   
   // pragma MARK: std::optional<Powertrain>
   /**
@@ -170,6 +188,12 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value) {
     return std::optional<Powertrain>(value);
   }
+  inline bool has_value_std__optional_Powertrain_(const std::optional<Powertrain>& optional) {
+    return optional.has_value();
+  }
+  inline const Powertrain& get_std__optional_Powertrain_(const std::optional<Powertrain>& optional) {
+    return optional.value();
+  }
   
   // pragma MARK: std::optional<OldEnum>
   /**
@@ -178,6 +202,12 @@ namespace margelo::nitro::test::bridge::swift {
   using std__optional_OldEnum_ = std::optional<OldEnum>;
   inline std::optional<OldEnum> create_std__optional_OldEnum_(const OldEnum& value) {
     return std::optional<OldEnum>(value);
+  }
+  inline bool has_value_std__optional_OldEnum_(const std::optional<OldEnum>& optional) {
+    return optional.has_value();
+  }
+  inline const OldEnum& get_std__optional_OldEnum_(const std::optional<OldEnum>& optional) {
+    return optional.value();
   }
   
   // pragma MARK: std::function<void(double /* value */)>
@@ -209,6 +239,12 @@ namespace margelo::nitro::test::bridge::swift {
   using std__optional_std__function_void_double____value______ = std::optional<std::function<void(double /* value */)>>;
   inline std::optional<std::function<void(double /* value */)>> create_std__optional_std__function_void_double____value______(const std::function<void(double /* value */)>& value) {
     return std::optional<std::function<void(double /* value */)>>(value);
+  }
+  inline bool has_value_std__optional_std__function_void_double____value______(const std::optional<std::function<void(double /* value */)>>& optional) {
+    return optional.has_value();
+  }
+  inline const std::function<void(double /* value */)>& get_std__optional_std__function_void_double____value______(const std::optional<std::function<void(double /* value */)>>& optional) {
+    return optional.value();
   }
   
   // pragma MARK: std::vector<double>
@@ -409,6 +445,12 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<bool> create_std__optional_bool_(const bool& value) {
     return std::optional<bool>(value);
   }
+  inline bool has_value_std__optional_bool_(const std::optional<bool>& optional) {
+    return optional.has_value();
+  }
+  inline const bool& get_std__optional_bool_(const std::optional<bool>& optional) {
+    return optional.value();
+  }
   
   // pragma MARK: std::variant<std::string, double>
   /**
@@ -493,6 +535,12 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<Person> create_std__optional_Person_(const Person& value) {
     return std::optional<Person>(value);
   }
+  inline bool has_value_std__optional_Person_(const std::optional<Person>& optional) {
+    return optional.has_value();
+  }
+  inline const Person& get_std__optional_Person_(const std::optional<Person>& optional) {
+    return optional.value();
+  }
   
   // pragma MARK: std::shared_ptr<Promise<Car>>
   /**
@@ -535,6 +583,12 @@ namespace margelo::nitro::test::bridge::swift {
   using std__optional_double_ = std::optional<double>;
   inline std::optional<double> create_std__optional_double_(const double& value) {
     return std::optional<double>(value);
+  }
+  inline bool has_value_std__optional_double_(const std::optional<double>& optional) {
+    return optional.has_value();
+  }
+  inline const double& get_std__optional_double_(const std::optional<double>& optional) {
+    return optional.value();
   }
   
   // pragma MARK: std::function<void(std::optional<double> /* maybe */)>

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Car.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Car.swift
@@ -93,7 +93,8 @@ public extension Car {
     @inline(__always)
     get {
       return { () -> Person? in
-        if let __unwrapped = self.__driver.value {
+        if bridge.has_std__optional_Person_(self.__driver) {
+          let __unwrapped = bridge.get_std__optional_Person_(self.__driver)
           return __unwrapped
         } else {
           return nil

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -134,7 +134,8 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     @inline(__always)
     set {
       self.__implementation.optionalHybrid = { () -> (any HybridTestObjectSwiftKotlinSpec)? in
-        if let __unwrapped = newValue.value {
+        if bridge.has_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(newValue) {
+          let __unwrapped = bridge.get_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(newValue)
           return { () -> HybridTestObjectSwiftKotlinSpec in
             let __unsafePointer = bridge.get_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(__unwrapped)
             let __instance = HybridTestObjectSwiftKotlinSpec_cxx.fromUnsafe(__unsafePointer)
@@ -205,7 +206,8 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     @inline(__always)
     set {
       self.__implementation.stringOrUndefined = { () -> String? in
-        if let __unwrapped = newValue.value {
+        if bridge.has_std__optional_std__string_(newValue) {
+          let __unwrapped = bridge.get_std__optional_std__string_(newValue)
           return String(__unwrapped)
         } else {
           return nil
@@ -228,7 +230,8 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     @inline(__always)
     set {
       self.__implementation.stringOrNull = { () -> String? in
-        if let __unwrapped = newValue.value {
+        if bridge.has_std__optional_std__string_(newValue) {
+          let __unwrapped = bridge.get_std__optional_std__string_(newValue)
           return String(__unwrapped)
         } else {
           return nil
@@ -251,7 +254,8 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     @inline(__always)
     set {
       self.__implementation.optionalString = { () -> String? in
-        if let __unwrapped = newValue.value {
+        if bridge.has_std__optional_std__string_(newValue) {
+          let __unwrapped = bridge.get_std__optional_std__string_(newValue)
           return String(__unwrapped)
         } else {
           return nil
@@ -280,7 +284,8 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     @inline(__always)
     set {
       self.__implementation.optionalArray = { () -> [String]? in
-        if let __unwrapped = newValue.value {
+        if bridge.has_std__optional_std__vector_std__string__(newValue) {
+          let __unwrapped = bridge.get_std__optional_std__vector_std__string__(newValue)
           return __unwrapped.map({ __item in String(__item) })
         } else {
           return nil
@@ -340,7 +345,8 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     @inline(__always)
     set {
       self.__implementation.optionalCallback = { () -> ((_ value: Double) -> Void)? in
-        if let __unwrapped = newValue.value {
+        if bridge.has_std__optional_std__function_void_double____value______(newValue) {
+          let __unwrapped = bridge.get_std__optional_std__function_void_double____value______(newValue)
           return { () -> (Double) -> Void in
             let __wrappedFunction = bridge.wrap_Func_void_double(__unwrapped)
             return { (__value: Double) -> Void in
@@ -729,7 +735,8 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
   public final func tryOptionalParams(num: Double, boo: Bool, str: bridge.std__optional_std__string_) -> bridge.Result_std__string_ {
     do {
       let __result = try self.__implementation.tryOptionalParams(num: num, boo: boo, str: { () -> String? in
-        if let __unwrapped = str.value {
+        if bridge.has_std__optional_std__string_(str) {
+          let __unwrapped = bridge.get_std__optional_std__string_(str)
           return String(__unwrapped)
         } else {
           return nil


### PR DESCRIPTION
There is a Swift compiler bug (https://github.com/swiftlang/swift/issues/83801) where accessing any value on a `std::optional<std::string>` (like `.value`) causes a Swift compiler crash in release mode.

So as a temporary workaround, we instead write the C++ helper functions that perform the nullability check and the getter of those values ourselves.

- Fixes https://github.com/mrousavy/react-native-nitro-image/issues/49