### PR TITLE
perf: Make Map `get_...` value faster

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -321,7 +321,7 @@ inline std::vector<${keyType}> get_${name}_keys(const ${name}& map) {
   return keys;
 }
 inline ${valueType} get_${name}_value(const ${name}& map, const ${keyType}& key) {
-  return map.at(key);
+  return map.find(key)->second;
 }
 inline void emplace_${name}(${name}& map, const ${keyType}& key, const ${valueType}& value) {
   map.emplace(key, value);

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -314,7 +314,7 @@ namespace margelo::nitro::test::bridge::swift {
     return keys;
   }
   inline std::variant<double, bool> get_std__unordered_map_std__string__std__variant_double__bool___value(const std__unordered_map_std__string__std__variant_double__bool__& map, const std::string& key) {
-    return map.at(key);
+    return map.find(key)->second;
   }
   inline void emplace_std__unordered_map_std__string__std__variant_double__bool__(std__unordered_map_std__string__std__variant_double__bool__& map, const std::string& key, const std::variant<double, bool>& value) {
     map.emplace(key, value);
@@ -339,7 +339,7 @@ namespace margelo::nitro::test::bridge::swift {
     return keys;
   }
   inline std::string get_std__unordered_map_std__string__std__string__value(const std__unordered_map_std__string__std__string_& map, const std::string& key) {
-    return map.at(key);
+    return map.find(key)->second;
   }
   inline void emplace_std__unordered_map_std__string__std__string_(std__unordered_map_std__string__std__string_& map, const std::string& key, const std::string& value) {
     map.emplace(key, value);


### PR DESCRIPTION
`std::unordered_map::at(...)` performs bounds checking and exception handling, while `std::unordered_map::find(...)->second` does not and is therefore faster.

We only use this in generated code anyways and we know those keys exist. Also, exceptions cannot be caught in Swift anyways.