### PR TITLE
perf: Make all C++ bridge functions `noexcept`

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -240,10 +240,10 @@ using ${name} = ${actualType};
 inline ${actualType} create_${name}(const ${wrappedBridge.getTypeCode('c++')}& value) noexcept {
   return ${actualType}(${indent(wrappedBridge.parseFromSwiftToCpp('value', 'c++'), '    ')});
 }
-inline bool has_value_${name}(const ${actualType}& optional) {
+inline bool has_value_${name}(const ${actualType}& optional) noexcept {
   return optional.has_value();
 }
-inline ${wrappedBridge.getTypeCode('c++')} get_${name}(const ${actualType}& optional) {
+inline ${wrappedBridge.getTypeCode('c++')} get_${name}(const ${actualType}& optional) noexcept {
   return *optional;
 }
     `.trim(),

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -147,17 +147,17 @@ return ${cxxNamespace}::get_${internalName}(cppType);
  * Specialized version of \`${escapeComments(actualType)}\`.
  */
 using ${name} = ${actualType};
-${actualType} create_${name}(void* _Nonnull swiftUnsafePointer);
-void* _Nonnull get_${name}(${name} cppType);
+${actualType} create_${name}(void* _Nonnull swiftUnsafePointer) noexcept;
+void* _Nonnull get_${name}(${name} cppType) noexcept;
     `.trim(),
       requiredIncludes: type.getRequiredImports('c++'),
     },
     cxxImplementation: {
       code: `
-${actualType} create_${name}(void* _Nonnull swiftUnsafePointer) {
+${actualType} create_${name}(void* _Nonnull swiftUnsafePointer) noexcept {
   ${indent(createImplementation, '  ')}
 }
-void* _Nonnull get_${name}(${name} cppType) {
+void* _Nonnull get_${name}(${name} cppType) noexcept {
   ${indent(getImplementation, '  ')}
 }
     `.trim(),
@@ -190,7 +190,7 @@ function createCxxUpcastHelper(
     specializationName: funcName,
     cxxHeader: {
       code: `
-inline ${cppBaseType} ${funcName}(${cppChildType} child) { return child; }
+inline ${cppBaseType} ${funcName}(${cppChildType} child) noexcept { return child; }
 `.trim(),
       requiredIncludes: [],
     },
@@ -210,7 +210,7 @@ function createCxxWeakPtrHelper(type: HybridObjectType): SwiftCxxHelper {
     cxxHeader: {
       code: `
 using ${specializationName} = ${actualType};
-inline ${specializationName} ${funcName}(const ${parameterType}& strong) { return strong; }
+inline ${specializationName} ${funcName}(const ${parameterType}& strong) noexcept { return strong; }
 `.trim(),
       requiredIncludes: [],
     },
@@ -237,7 +237,7 @@ function createCxxOptionalSwiftHelper(type: OptionalType): SwiftCxxHelper {
  * Specialized version of \`${escapeComments(actualType)}\`.
  */
 using ${name} = ${actualType};
-inline ${actualType} create_${name}(const ${wrappedBridge.getTypeCode('c++')}& value) {
+inline ${actualType} create_${name}(const ${wrappedBridge.getTypeCode('c++')}& value) noexcept {
   return ${actualType}(${indent(wrappedBridge.parseFromSwiftToCpp('value', 'c++'), '    ')});
 }
 inline bool has_value_${name}(const ${actualType}& optional) {
@@ -277,7 +277,7 @@ function createCxxVectorSwiftHelper(type: ArrayType): SwiftCxxHelper {
  * Specialized version of \`${escapeComments(actualType)}\`.
  */
 using ${name} = ${actualType};
-inline ${actualType} create_${name}(size_t size) {
+inline ${actualType} create_${name}(size_t size) noexcept {
   ${actualType} vector;
   vector.reserve(size);
   return vector;
@@ -315,12 +315,12 @@ function createCxxUnorderedMapSwiftHelper(type: RecordType): SwiftCxxHelper {
  * Specialized version of \`${escapeComments(actualType)}\`.
  */
 using ${name} = ${actualType};
-inline ${actualType} create_${name}(size_t size) {
+inline ${actualType} create_${name}(size_t size) noexcept {
   ${actualType} map;
   map.reserve(size);
   return map;
 }
-inline std::vector<${keyType}> get_${name}_keys(const ${name}& map) {
+inline std::vector<${keyType}> get_${name}_keys(const ${name}& map) noexcept {
   std::vector<${keyType}> keys;
   keys.reserve(map.size());
   for (const auto& entry : map) {
@@ -331,7 +331,7 @@ inline std::vector<${keyType}> get_${name}_keys(const ${name}& map) {
 inline ${valueType} get_${name}_value(const ${name}& map, const ${keyType}& key) {
   return map.find(key)->second;
 }
-inline void emplace_${name}(${name}& map, const ${keyType}& key, const ${valueType}& value) {
+inline void emplace_${name}(${name}& map, const ${keyType}& key, const ${valueType}& value) noexcept {
   map.emplace(key, value);
 }
       `.trim(),
@@ -420,14 +420,14 @@ using ${name} = ${actualType};
 class ${wrapperName} final {
 public:
   explicit ${wrapperName}(${actualType}&& func): _function(std::make_unique<${actualType}>(std::move(func))) {}
-  inline ${callFuncReturnType} call(${callCppFuncParamsSignature.join(', ')}) const {
+  inline ${callFuncReturnType} call(${callCppFuncParamsSignature.join(', ')}) const noexcept {
     ${indent(callCppFuncBody, '    ')}
   }
 private:
   std::unique_ptr<${actualType}> _function;
 } SWIFT_NONCOPYABLE;
-${name} create_${name}(void* _Nonnull swiftClosureWrapper);
-inline ${wrapperName} wrap_${name}(${name} value) {
+${name} create_${name}(void* _Nonnull swiftClosureWrapper) noexcept;
+inline ${wrapperName} wrap_${name}(${name} value) noexcept {
   return ${wrapperName}(std::move(value));
 }
     `.trim(),
@@ -447,7 +447,7 @@ inline ${wrapperName} wrap_${name}(${name} value) {
     },
     cxxImplementation: {
       code: `
-${name} create_${name}(void* _Nonnull swiftClosureWrapper) {
+${name} create_${name}(void* _Nonnull swiftClosureWrapper) noexcept {
   auto swiftClosure = ${swiftClassName}::fromUnsafe(swiftClosureWrapper);
   return [swiftClosure = std::move(swiftClosure)](${paramsSignature.join(', ')}) mutable -> ${type.returnType.getCode('c++')} {
     ${indent(body, '    ')}
@@ -480,14 +480,14 @@ function createCxxVariantSwiftHelper(type: VariantType): SwiftCxxHelper {
       : t.getCode('c++')
 
     return `
-inline ${name} create_${name}(${param} value) {
+inline ${name} create_${name}(${param} value) noexcept {
   return ${name}(value);
 }
       `.trim()
   })
   const getFunctions = type.variants.map((t, i) => {
     return `
-inline ${t.getCode('c++')} get_${i}() const {
+inline ${t.getCode('c++')} get_${i}() const noexcept {
   return std::get<${i}>(variant);
 }`.trim()
   })
@@ -505,10 +505,10 @@ inline ${t.getCode('c++')} get_${i}() const {
 struct ${name} {
   ${actualType} variant;
   ${name}(${actualType} variant): variant(variant) { }
-  operator ${actualType}() const {
+  operator ${actualType}() const noexcept {
     return variant;
   }
-  inline size_t index() const {
+  inline size_t index() const noexcept {
     return variant.index();
   }
   ${indent(getFunctions.join('\n'), '  ')}
@@ -553,7 +553,7 @@ function createCxxTupleSwiftHelper(type: TupleType): SwiftCxxHelper {
  * Specialized version of \`${escapeComments(actualType)}\`.
  */
 using ${name} = ${actualType};
-inline ${actualType} create_${name}(${typesSignature}) {
+inline ${actualType} create_${name}(${typesSignature}) noexcept {
   return ${actualType} { ${typesForward} };
 }
      `.trim(),
@@ -585,7 +585,7 @@ function createCxxResultWrapperSwiftHelper(
   if (type.result.kind === 'void') {
     functions.push(
       `
-inline ${name} ${funcName}() {
+inline ${name} ${funcName}() noexcept {
   return ${actualType}::withValue();
 }`.trim()
     )
@@ -595,14 +595,14 @@ inline ${name} ${funcName}() {
       : type.result.getCode('c++')
     functions.push(
       `
-inline ${name} ${funcName}(${typeParam} value) {
+inline ${name} ${funcName}(${typeParam} value) noexcept {
   return ${actualType}::withValue(${type.result.canBePassedByReference ? 'value' : 'std::move(value)'});
 }`.trim()
     )
   }
   functions.push(
     `
-inline ${name} ${funcName}(const ${type.error.getCode('c++')}& error) {
+inline ${name} ${funcName}(const ${type.error.getCode('c++')}& error) noexcept {
   return ${actualType}::withError(error);
 }`.trim()
   )
@@ -650,10 +650,10 @@ function createCxxPromiseSwiftHelper(type: PromiseType): SwiftCxxHelper {
  * Specialized version of \`${escapeComments(actualType)}\`.
  */
 using ${name} = ${actualType};
-inline ${actualType} create_${name}() {
+inline ${actualType} create_${name}() noexcept {
   return Promise<${resultingType}>::create();
 }
-inline PromiseHolder<${resultingType}> wrap_${name}(${actualType} promise) {
+inline PromiseHolder<${resultingType}> wrap_${name}(${actualType} promise) noexcept {
   return PromiseHolder<${resultingType}>(std::move(promise));
 }
        `.trim(),

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -328,7 +328,7 @@ inline std::vector<${keyType}> get_${name}_keys(const ${name}& map) noexcept {
   }
   return keys;
 }
-inline ${valueType} get_${name}_value(const ${name}& map, const ${keyType}& key) {
+inline ${valueType} get_${name}_value(const ${name}& map, const ${keyType}& key) noexcept {
   return map.find(key)->second;
 }
 inline void emplace_${name}(${name}& map, const ${keyType}& key, const ${valueType}& value) noexcept {

--- a/packages/react-native-nitro-test-external/nitrogen/generated/ios/NitroTestExternal-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-test-external/nitrogen/generated/ios/NitroTestExternal-Swift-Cxx-Bridge.cpp
@@ -14,11 +14,11 @@
 namespace margelo::nitro::test::external::bridge::swift {
 
   // pragma MARK: std::shared_ptr<HybridSomeExternalObjectSpec>
-  std::shared_ptr<HybridSomeExternalObjectSpec> create_std__shared_ptr_HybridSomeExternalObjectSpec_(void* _Nonnull swiftUnsafePointer) {
+  std::shared_ptr<HybridSomeExternalObjectSpec> create_std__shared_ptr_HybridSomeExternalObjectSpec_(void* _Nonnull swiftUnsafePointer) noexcept {
     NitroTestExternal::HybridSomeExternalObjectSpec_cxx swiftPart = NitroTestExternal::HybridSomeExternalObjectSpec_cxx::fromUnsafe(swiftUnsafePointer);
     return std::make_shared<margelo::nitro::test::external::HybridSomeExternalObjectSpecSwift>(swiftPart);
   }
-  void* _Nonnull get_std__shared_ptr_HybridSomeExternalObjectSpec_(std__shared_ptr_HybridSomeExternalObjectSpec_ cppType) {
+  void* _Nonnull get_std__shared_ptr_HybridSomeExternalObjectSpec_(std__shared_ptr_HybridSomeExternalObjectSpec_ cppType) noexcept {
     std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::external::HybridSomeExternalObjectSpecSwift>(cppType);
     #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {

--- a/packages/react-native-nitro-test-external/nitrogen/generated/ios/NitroTestExternal-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test-external/nitrogen/generated/ios/NitroTestExternal-Swift-Cxx-Bridge.hpp
@@ -33,19 +33,19 @@ namespace margelo::nitro::test::external::bridge::swift {
    * Specialized version of `std::shared_ptr<HybridSomeExternalObjectSpec>`.
    */
   using std__shared_ptr_HybridSomeExternalObjectSpec_ = std::shared_ptr<HybridSomeExternalObjectSpec>;
-  std::shared_ptr<HybridSomeExternalObjectSpec> create_std__shared_ptr_HybridSomeExternalObjectSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_HybridSomeExternalObjectSpec_(std__shared_ptr_HybridSomeExternalObjectSpec_ cppType);
+  std::shared_ptr<HybridSomeExternalObjectSpec> create_std__shared_ptr_HybridSomeExternalObjectSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
+  void* _Nonnull get_std__shared_ptr_HybridSomeExternalObjectSpec_(std__shared_ptr_HybridSomeExternalObjectSpec_ cppType) noexcept;
   
   // pragma MARK: std::weak_ptr<HybridSomeExternalObjectSpec>
   using std__weak_ptr_HybridSomeExternalObjectSpec_ = std::weak_ptr<HybridSomeExternalObjectSpec>;
-  inline std__weak_ptr_HybridSomeExternalObjectSpec_ weakify_std__shared_ptr_HybridSomeExternalObjectSpec_(const std::shared_ptr<HybridSomeExternalObjectSpec>& strong) { return strong; }
+  inline std__weak_ptr_HybridSomeExternalObjectSpec_ weakify_std__shared_ptr_HybridSomeExternalObjectSpec_(const std::shared_ptr<HybridSomeExternalObjectSpec>& strong) noexcept { return strong; }
   
   // pragma MARK: Result<std::string>
   using Result_std__string_ = Result<std::string>;
-  inline Result_std__string_ create_Result_std__string_(const std::string& value) {
+  inline Result_std__string_ create_Result_std__string_(const std::string& value) noexcept {
     return Result<std::string>::withValue(value);
   }
-  inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) {
+  inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) noexcept {
     return Result<std::string>::withError(error);
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.cpp
@@ -18,11 +18,11 @@
 namespace margelo::nitro::test::bridge::swift {
 
   // pragma MARK: std::shared_ptr<HybridTestObjectSwiftKotlinSpec>
-  std::shared_ptr<HybridTestObjectSwiftKotlinSpec> create_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(void* _Nonnull swiftUnsafePointer) {
+  std::shared_ptr<HybridTestObjectSwiftKotlinSpec> create_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(void* _Nonnull swiftUnsafePointer) noexcept {
     NitroTest::HybridTestObjectSwiftKotlinSpec_cxx swiftPart = NitroTest::HybridTestObjectSwiftKotlinSpec_cxx::fromUnsafe(swiftUnsafePointer);
     return std::make_shared<margelo::nitro::test::HybridTestObjectSwiftKotlinSpecSwift>(swiftPart);
   }
-  void* _Nonnull get_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(std__shared_ptr_HybridTestObjectSwiftKotlinSpec_ cppType) {
+  void* _Nonnull get_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(std__shared_ptr_HybridTestObjectSwiftKotlinSpec_ cppType) noexcept {
     std::shared_ptr<margelo::nitro::test::HybridTestObjectSwiftKotlinSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridTestObjectSwiftKotlinSpecSwift>(cppType);
     #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
@@ -34,7 +34,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void(double /* value */)>
-  Func_void_double create_Func_void_double(void* _Nonnull swiftClosureWrapper) {
+  Func_void_double create_Func_void_double(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void_double::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](double value) mutable -> void {
       swiftClosure.call(value);
@@ -42,7 +42,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const std::vector<Powertrain>& /* array */)>
-  Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void_std__vector_Powertrain_::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::vector<Powertrain>& array) mutable -> void {
       swiftClosure.call(array);
@@ -50,7 +50,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void()>
-  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) {
+  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)]() mutable -> void {
       swiftClosure.call();
@@ -58,7 +58,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const std::exception_ptr& /* error */)>
-  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void_std__exception_ptr::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::exception_ptr& error) mutable -> void {
       swiftClosure.call(error);
@@ -66,7 +66,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void(int64_t /* result */)>
-  Func_void_int64_t create_Func_void_int64_t(void* _Nonnull swiftClosureWrapper) {
+  Func_void_int64_t create_Func_void_int64_t(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void_int64_t::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](int64_t result) mutable -> void {
       swiftClosure.call(result);
@@ -74,7 +74,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const Car& /* result */)>
-  Func_void_Car create_Func_void_Car(void* _Nonnull swiftClosureWrapper) {
+  Func_void_Car create_Func_void_Car(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void_Car::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const Car& result) mutable -> void {
       swiftClosure.call(result);
@@ -82,7 +82,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void(std::optional<double> /* maybe */)>
-  Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void_std__optional_double_::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](std::optional<double> maybe) mutable -> void {
       swiftClosure.call(maybe);
@@ -90,7 +90,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<std::shared_ptr<Promise<double>>()>
-  Func_std__shared_ptr_Promise_double__ create_Func_std__shared_ptr_Promise_double__(void* _Nonnull swiftClosureWrapper) {
+  Func_std__shared_ptr_Promise_double__ create_Func_std__shared_ptr_Promise_double__(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_std__shared_ptr_Promise_double__::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)]() mutable -> std::shared_ptr<Promise<double>> {
       auto __result = swiftClosure.call();
@@ -99,7 +99,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>
-  Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ create_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(void* _Nonnull swiftClosureWrapper) {
+  Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ create_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)]() mutable -> std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> {
       auto __result = swiftClosure.call();
@@ -108,7 +108,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const std::shared_ptr<Promise<double>>& /* result */)>
-  Func_void_std__shared_ptr_Promise_double__ create_Func_void_std__shared_ptr_Promise_double__(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__shared_ptr_Promise_double__ create_Func_void_std__shared_ptr_Promise_double__(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void_std__shared_ptr_Promise_double__::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::shared_ptr<Promise<double>>& result) mutable -> void {
       swiftClosure.call(result);
@@ -116,7 +116,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)>
-  Func_void_std__shared_ptr_ArrayBuffer_ create_Func_void_std__shared_ptr_ArrayBuffer_(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__shared_ptr_ArrayBuffer_ create_Func_void_std__shared_ptr_ArrayBuffer_(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void_std__shared_ptr_ArrayBuffer_::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::shared_ptr<ArrayBuffer>& result) mutable -> void {
       swiftClosure.call(ArrayBufferHolder(result));
@@ -124,7 +124,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>
-  Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ create_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(void* _Nonnull swiftClosureWrapper) {
+  Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ create_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)]() mutable -> std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> {
       auto __result = swiftClosure.call();
@@ -133,7 +133,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>& /* result */)>
-  Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ create_Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ create_Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>& result) mutable -> void {
       swiftClosure.call(result);
@@ -141,7 +141,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<std::shared_ptr<Promise<std::string>>()>
-  Func_std__shared_ptr_Promise_std__string__ create_Func_std__shared_ptr_Promise_std__string__(void* _Nonnull swiftClosureWrapper) {
+  Func_std__shared_ptr_Promise_std__string__ create_Func_std__shared_ptr_Promise_std__string__(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_std__shared_ptr_Promise_std__string__::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)]() mutable -> std::shared_ptr<Promise<std::string>> {
       auto __result = swiftClosure.call();
@@ -150,7 +150,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const std::string& /* result */)>
-  Func_void_std__string create_Func_void_std__string(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__string create_Func_void_std__string(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_void_std__string::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::string& result) mutable -> void {
       swiftClosure.call(result);
@@ -158,11 +158,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::shared_ptr<HybridBaseSpec>
-  std::shared_ptr<HybridBaseSpec> create_std__shared_ptr_HybridBaseSpec_(void* _Nonnull swiftUnsafePointer) {
+  std::shared_ptr<HybridBaseSpec> create_std__shared_ptr_HybridBaseSpec_(void* _Nonnull swiftUnsafePointer) noexcept {
     NitroTest::HybridBaseSpec_cxx swiftPart = NitroTest::HybridBaseSpec_cxx::fromUnsafe(swiftUnsafePointer);
     return std::make_shared<margelo::nitro::test::HybridBaseSpecSwift>(swiftPart);
   }
-  void* _Nonnull get_std__shared_ptr_HybridBaseSpec_(std__shared_ptr_HybridBaseSpec_ cppType) {
+  void* _Nonnull get_std__shared_ptr_HybridBaseSpec_(std__shared_ptr_HybridBaseSpec_ cppType) noexcept {
     std::shared_ptr<margelo::nitro::test::HybridBaseSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridBaseSpecSwift>(cppType);
     #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
@@ -174,11 +174,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::shared_ptr<HybridChildSpec>
-  std::shared_ptr<HybridChildSpec> create_std__shared_ptr_HybridChildSpec_(void* _Nonnull swiftUnsafePointer) {
+  std::shared_ptr<HybridChildSpec> create_std__shared_ptr_HybridChildSpec_(void* _Nonnull swiftUnsafePointer) noexcept {
     NitroTest::HybridChildSpec_cxx swiftPart = NitroTest::HybridChildSpec_cxx::fromUnsafe(swiftUnsafePointer);
     return std::make_shared<margelo::nitro::test::HybridChildSpecSwift>(swiftPart);
   }
-  void* _Nonnull get_std__shared_ptr_HybridChildSpec_(std__shared_ptr_HybridChildSpec_ cppType) {
+  void* _Nonnull get_std__shared_ptr_HybridChildSpec_(std__shared_ptr_HybridChildSpec_ cppType) noexcept {
     std::shared_ptr<margelo::nitro::test::HybridChildSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridChildSpecSwift>(cppType);
     #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
@@ -190,7 +190,7 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::function<double()>
-  Func_double create_Func_double(void* _Nonnull swiftClosureWrapper) {
+  Func_double create_Func_double(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroTest::Func_double::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)]() mutable -> double {
       auto __result = swiftClosure.call();
@@ -199,11 +199,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::shared_ptr<HybridTestViewSpec>
-  std::shared_ptr<HybridTestViewSpec> create_std__shared_ptr_HybridTestViewSpec_(void* _Nonnull swiftUnsafePointer) {
+  std::shared_ptr<HybridTestViewSpec> create_std__shared_ptr_HybridTestViewSpec_(void* _Nonnull swiftUnsafePointer) noexcept {
     NitroTest::HybridTestViewSpec_cxx swiftPart = NitroTest::HybridTestViewSpec_cxx::fromUnsafe(swiftUnsafePointer);
     return std::make_shared<margelo::nitro::test::HybridTestViewSpecSwift>(swiftPart);
   }
-  void* _Nonnull get_std__shared_ptr_HybridTestViewSpec_(std__shared_ptr_HybridTestViewSpec_ cppType) {
+  void* _Nonnull get_std__shared_ptr_HybridTestViewSpec_(std__shared_ptr_HybridTestViewSpec_ cppType) noexcept {
     std::shared_ptr<margelo::nitro::test::HybridTestViewSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::test::HybridTestViewSpecSwift>(cppType);
     #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {
@@ -215,11 +215,11 @@ namespace margelo::nitro::test::bridge::swift {
   }
   
   // pragma MARK: std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>
-  std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec> create_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(void* _Nonnull swiftUnsafePointer) {
+  std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec> create_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(void* _Nonnull swiftUnsafePointer) noexcept {
     // Implemented in NitroTestExternal
     return margelo::nitro::test::external::bridge::swift::create_std__shared_ptr_HybridSomeExternalObjectSpec_(swiftUnsafePointer);
   }
-  void* _Nonnull get_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ cppType) {
+  void* _Nonnull get_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ cppType) noexcept {
     // Implemented in NitroTestExternal
     return margelo::nitro::test::external::bridge::swift::get_std__shared_ptr_HybridSomeExternalObjectSpec_(cppType);
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -90,11 +90,11 @@ namespace margelo::nitro::test::bridge::swift {
   using std__shared_ptr_HybridTestObjectSwiftKotlinSpec_ = std::shared_ptr<HybridTestObjectSwiftKotlinSpec>;
   std::shared_ptr<HybridTestObjectSwiftKotlinSpec> create_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
   void* _Nonnull get_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(std__shared_ptr_HybridTestObjectSwiftKotlinSpec_ cppType) noexcept;
-
+  
   // pragma MARK: std::weak_ptr<HybridTestObjectSwiftKotlinSpec>
   using std__weak_ptr_HybridTestObjectSwiftKotlinSpec_ = std::weak_ptr<HybridTestObjectSwiftKotlinSpec>;
   inline std__weak_ptr_HybridTestObjectSwiftKotlinSpec_ weakify_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& strong) noexcept { return strong; }
-
+  
   // pragma MARK: std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>
   /**
    * Specialized version of `std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>`.
@@ -103,13 +103,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>> create_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& value) noexcept {
     return std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>(value);
   }
-  inline bool has_value_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& optional) {
+  inline bool has_value_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& optional) noexcept {
     return optional.has_value();
   }
-  inline std::shared_ptr<HybridTestObjectSwiftKotlinSpec> get_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& optional) {
+  inline std::shared_ptr<HybridTestObjectSwiftKotlinSpec> get_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& optional) noexcept {
     return *optional;
   }
-
+  
   // pragma MARK: std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>
   /**
    * Wrapper struct for `std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>`.
@@ -138,7 +138,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& value) noexcept {
     return std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(value);
   }
-
+  
   // pragma MARK: std::optional<std::string>
   /**
    * Specialized version of `std::optional<std::string>`.
@@ -147,13 +147,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) noexcept {
     return std::optional<std::string>(value);
   }
-  inline bool has_value_std__optional_std__string_(const std::optional<std::string>& optional) {
+  inline bool has_value_std__optional_std__string_(const std::optional<std::string>& optional) noexcept {
     return optional.has_value();
   }
-  inline std::string get_std__optional_std__string_(const std::optional<std::string>& optional) {
+  inline std::string get_std__optional_std__string_(const std::optional<std::string>& optional) noexcept {
     return *optional;
   }
-
+  
   // pragma MARK: std::vector<std::string>
   /**
    * Specialized version of `std::vector<std::string>`.
@@ -164,7 +164,7 @@ namespace margelo::nitro::test::bridge::swift {
     vector.reserve(size);
     return vector;
   }
-
+  
   // pragma MARK: std::optional<std::vector<std::string>>
   /**
    * Specialized version of `std::optional<std::vector<std::string>>`.
@@ -173,13 +173,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<std::vector<std::string>> create_std__optional_std__vector_std__string__(const std::vector<std::string>& value) noexcept {
     return std::optional<std::vector<std::string>>(value);
   }
-  inline bool has_value_std__optional_std__vector_std__string__(const std::optional<std::vector<std::string>>& optional) {
+  inline bool has_value_std__optional_std__vector_std__string__(const std::optional<std::vector<std::string>>& optional) noexcept {
     return optional.has_value();
   }
-  inline std::vector<std::string> get_std__optional_std__vector_std__string__(const std::optional<std::vector<std::string>>& optional) {
+  inline std::vector<std::string> get_std__optional_std__vector_std__string__(const std::optional<std::vector<std::string>>& optional) noexcept {
     return *optional;
   }
-
+  
   // pragma MARK: std::optional<Powertrain>
   /**
    * Specialized version of `std::optional<Powertrain>`.
@@ -188,13 +188,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value) noexcept {
     return std::optional<Powertrain>(value);
   }
-  inline bool has_value_std__optional_Powertrain_(const std::optional<Powertrain>& optional) {
+  inline bool has_value_std__optional_Powertrain_(const std::optional<Powertrain>& optional) noexcept {
     return optional.has_value();
   }
-  inline Powertrain get_std__optional_Powertrain_(const std::optional<Powertrain>& optional) {
+  inline Powertrain get_std__optional_Powertrain_(const std::optional<Powertrain>& optional) noexcept {
     return *optional;
   }
-
+  
   // pragma MARK: std::optional<OldEnum>
   /**
    * Specialized version of `std::optional<OldEnum>`.
@@ -203,13 +203,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<OldEnum> create_std__optional_OldEnum_(const OldEnum& value) noexcept {
     return std::optional<OldEnum>(value);
   }
-  inline bool has_value_std__optional_OldEnum_(const std::optional<OldEnum>& optional) {
+  inline bool has_value_std__optional_OldEnum_(const std::optional<OldEnum>& optional) noexcept {
     return optional.has_value();
   }
-  inline OldEnum get_std__optional_OldEnum_(const std::optional<OldEnum>& optional) {
+  inline OldEnum get_std__optional_OldEnum_(const std::optional<OldEnum>& optional) noexcept {
     return *optional;
   }
-
+  
   // pragma MARK: std::function<void(double /* value */)>
   /**
    * Specialized version of `std::function<void(double)>`.
@@ -231,7 +231,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_double_Wrapper wrap_Func_void_double(Func_void_double value) noexcept {
     return Func_void_double_Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::optional<std::function<void(double /* value */)>>
   /**
    * Specialized version of `std::optional<std::function<void(double / * value * /)>>`.
@@ -240,13 +240,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<std::function<void(double /* value */)>> create_std__optional_std__function_void_double____value______(const std::function<void(double /* value */)>& value) noexcept {
     return std::optional<std::function<void(double /* value */)>>(value);
   }
-  inline bool has_value_std__optional_std__function_void_double____value______(const std::optional<std::function<void(double /* value */)>>& optional) {
+  inline bool has_value_std__optional_std__function_void_double____value______(const std::optional<std::function<void(double /* value */)>>& optional) noexcept {
     return optional.has_value();
   }
-  inline std::function<void(double /* value */)> get_std__optional_std__function_void_double____value______(const std::optional<std::function<void(double /* value */)>>& optional) {
+  inline std::function<void(double /* value */)> get_std__optional_std__function_void_double____value______(const std::optional<std::function<void(double /* value */)>>& optional) noexcept {
     return *optional;
   }
-
+  
   // pragma MARK: std::vector<double>
   /**
    * Specialized version of `std::vector<double>`.
@@ -257,7 +257,7 @@ namespace margelo::nitro::test::bridge::swift {
     vector.reserve(size);
     return vector;
   }
-
+  
   // pragma MARK: std::vector<Person>
   /**
    * Specialized version of `std::vector<Person>`.
@@ -268,7 +268,7 @@ namespace margelo::nitro::test::bridge::swift {
     vector.reserve(size);
     return vector;
   }
-
+  
   // pragma MARK: std::vector<Powertrain>
   /**
    * Specialized version of `std::vector<Powertrain>`.
@@ -279,7 +279,7 @@ namespace margelo::nitro::test::bridge::swift {
     vector.reserve(size);
     return vector;
   }
-
+  
   // pragma MARK: std::function<void(const std::vector<Powertrain>& /* array */)>
   /**
    * Specialized version of `std::function<void(const std::vector<Powertrain>&)>`.
@@ -301,7 +301,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_std__vector_Powertrain__Wrapper wrap_Func_void_std__vector_Powertrain_(Func_void_std__vector_Powertrain_ value) noexcept {
     return Func_void_std__vector_Powertrain__Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::variant<double, bool>
   /**
    * Wrapper struct for `std::variant<double, bool>`.
@@ -330,7 +330,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline std__variant_double__bool_ create_std__variant_double__bool_(bool value) noexcept {
     return std__variant_double__bool_(value);
   }
-
+  
   // pragma MARK: std::unordered_map<std::string, std::variant<double, bool>>
   /**
    * Specialized version of `std::unordered_map<std::string, std::variant<double, bool>>`.
@@ -355,7 +355,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline void emplace_std__unordered_map_std__string__std__variant_double__bool__(std__unordered_map_std__string__std__variant_double__bool__& map, const std::string& key, const std::variant<double, bool>& value) noexcept {
     map.emplace(key, value);
   }
-
+  
   // pragma MARK: std::unordered_map<std::string, std::string>
   /**
    * Specialized version of `std::unordered_map<std::string, std::string>`.
@@ -380,7 +380,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline void emplace_std__unordered_map_std__string__std__string_(std__unordered_map_std__string__std__string_& map, const std::string& key, const std::string& value) noexcept {
     map.emplace(key, value);
   }
-
+  
   // pragma MARK: std::shared_ptr<Promise<void>>
   /**
    * Specialized version of `std::shared_ptr<Promise<void>>`.
@@ -392,7 +392,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline PromiseHolder<void> wrap_std__shared_ptr_Promise_void__(std::shared_ptr<Promise<void>> promise) noexcept {
     return PromiseHolder<void>(std::move(promise));
   }
-
+  
   // pragma MARK: std::function<void()>
   /**
    * Specialized version of `std::function<void()>`.
@@ -414,7 +414,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_Wrapper wrap_Func_void(Func_void value) noexcept {
     return Func_void_Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::function<void(const std::exception_ptr& /* error */)>
   /**
    * Specialized version of `std::function<void(const std::exception_ptr&)>`.
@@ -436,7 +436,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_std__exception_ptr_Wrapper wrap_Func_void_std__exception_ptr(Func_void_std__exception_ptr value) noexcept {
     return Func_void_std__exception_ptr_Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::optional<bool>
   /**
    * Specialized version of `std::optional<bool>`.
@@ -445,13 +445,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<bool> create_std__optional_bool_(const bool& value) noexcept {
     return std::optional<bool>(value);
   }
-  inline bool has_value_std__optional_bool_(const std::optional<bool>& optional) {
+  inline bool has_value_std__optional_bool_(const std::optional<bool>& optional) noexcept {
     return optional.has_value();
   }
-  inline bool get_std__optional_bool_(const std::optional<bool>& optional) {
+  inline bool get_std__optional_bool_(const std::optional<bool>& optional) noexcept {
     return *optional;
   }
-
+  
   // pragma MARK: std::variant<std::string, double>
   /**
    * Wrapper struct for `std::variant<std::string, double>`.
@@ -480,7 +480,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline std__variant_std__string__double_ create_std__variant_std__string__double_(double value) noexcept {
     return std__variant_std__string__double_(value);
   }
-
+  
   // pragma MARK: std::shared_ptr<Promise<int64_t>>
   /**
    * Specialized version of `std::shared_ptr<Promise<int64_t>>`.
@@ -492,7 +492,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline PromiseHolder<int64_t> wrap_std__shared_ptr_Promise_int64_t__(std::shared_ptr<Promise<int64_t>> promise) noexcept {
     return PromiseHolder<int64_t>(std::move(promise));
   }
-
+  
   // pragma MARK: std::function<void(int64_t /* result */)>
   /**
    * Specialized version of `std::function<void(int64_t)>`.
@@ -514,7 +514,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_int64_t_Wrapper wrap_Func_void_int64_t(Func_void_int64_t value) noexcept {
     return Func_void_int64_t_Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::shared_ptr<Promise<double>>
   /**
    * Specialized version of `std::shared_ptr<Promise<double>>`.
@@ -526,7 +526,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline PromiseHolder<double> wrap_std__shared_ptr_Promise_double__(std::shared_ptr<Promise<double>> promise) noexcept {
     return PromiseHolder<double>(std::move(promise));
   }
-
+  
   // pragma MARK: std::optional<Person>
   /**
    * Specialized version of `std::optional<Person>`.
@@ -535,13 +535,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<Person> create_std__optional_Person_(const Person& value) noexcept {
     return std::optional<Person>(value);
   }
-  inline bool has_value_std__optional_Person_(const std::optional<Person>& optional) {
+  inline bool has_value_std__optional_Person_(const std::optional<Person>& optional) noexcept {
     return optional.has_value();
   }
-  inline Person get_std__optional_Person_(const std::optional<Person>& optional) {
+  inline Person get_std__optional_Person_(const std::optional<Person>& optional) noexcept {
     return *optional;
   }
-
+  
   // pragma MARK: std::shared_ptr<Promise<Car>>
   /**
    * Specialized version of `std::shared_ptr<Promise<Car>>`.
@@ -553,7 +553,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline PromiseHolder<Car> wrap_std__shared_ptr_Promise_Car__(std::shared_ptr<Promise<Car>> promise) noexcept {
     return PromiseHolder<Car>(std::move(promise));
   }
-
+  
   // pragma MARK: std::function<void(const Car& /* result */)>
   /**
    * Specialized version of `std::function<void(const Car&)>`.
@@ -575,7 +575,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_Car_Wrapper wrap_Func_void_Car(Func_void_Car value) noexcept {
     return Func_void_Car_Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::optional<double>
   /**
    * Specialized version of `std::optional<double>`.
@@ -584,13 +584,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::optional<double> create_std__optional_double_(const double& value) noexcept {
     return std::optional<double>(value);
   }
-  inline bool has_value_std__optional_double_(const std::optional<double>& optional) {
+  inline bool has_value_std__optional_double_(const std::optional<double>& optional) noexcept {
     return optional.has_value();
   }
-  inline double get_std__optional_double_(const std::optional<double>& optional) {
+  inline double get_std__optional_double_(const std::optional<double>& optional) noexcept {
     return *optional;
   }
-
+  
   // pragma MARK: std::function<void(std::optional<double> /* maybe */)>
   /**
    * Specialized version of `std::function<void(std::optional<double>)>`.
@@ -612,7 +612,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_std__optional_double__Wrapper wrap_Func_void_std__optional_double_(Func_void_std__optional_double_ value) noexcept {
     return Func_void_std__optional_double__Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::function<std::shared_ptr<Promise<double>>()>
   /**
    * Specialized version of `std::function<std::shared_ptr<Promise<double>>()>`.
@@ -635,7 +635,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_std__shared_ptr_Promise_double___Wrapper wrap_Func_std__shared_ptr_Promise_double__(Func_std__shared_ptr_Promise_double__ value) noexcept {
     return Func_std__shared_ptr_Promise_double___Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>
   /**
    * Specialized version of `std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>`.
@@ -658,7 +658,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____Wrapper wrap_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ value) noexcept {
     return Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>
   /**
    * Specialized version of `std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>`.
@@ -670,7 +670,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline PromiseHolder<std::shared_ptr<Promise<double>>> wrap_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> promise) noexcept {
     return PromiseHolder<std::shared_ptr<Promise<double>>>(std::move(promise));
   }
-
+  
   // pragma MARK: std::function<void(const std::shared_ptr<Promise<double>>& /* result */)>
   /**
    * Specialized version of `std::function<void(const std::shared_ptr<Promise<double>>&)>`.
@@ -692,7 +692,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_std__shared_ptr_Promise_double___Wrapper wrap_Func_void_std__shared_ptr_Promise_double__(Func_void_std__shared_ptr_Promise_double__ value) noexcept {
     return Func_void_std__shared_ptr_Promise_double___Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>
   /**
    * Specialized version of `std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>`.
@@ -704,7 +704,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline PromiseHolder<std::shared_ptr<ArrayBuffer>> wrap_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___(std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> promise) noexcept {
     return PromiseHolder<std::shared_ptr<ArrayBuffer>>(std::move(promise));
   }
-
+  
   // pragma MARK: std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)>
   /**
    * Specialized version of `std::function<void(const std::shared_ptr<ArrayBuffer>&)>`.
@@ -726,7 +726,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_std__shared_ptr_ArrayBuffer__Wrapper wrap_Func_void_std__shared_ptr_ArrayBuffer_(Func_void_std__shared_ptr_ArrayBuffer_ value) noexcept {
     return Func_void_std__shared_ptr_ArrayBuffer__Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>
   /**
    * Specialized version of `std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>`.
@@ -749,7 +749,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______Wrapper wrap_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ value) noexcept {
     return Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>
   /**
    * Specialized version of `std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>`.
@@ -761,7 +761,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline PromiseHolder<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>> wrap_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> promise) noexcept {
     return PromiseHolder<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>(std::move(promise));
   }
-
+  
   // pragma MARK: std::function<void(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>& /* result */)>
   /**
    * Specialized version of `std::function<void(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>&)>`.
@@ -783,7 +783,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____Wrapper wrap_Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___(Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ value) noexcept {
     return Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::function<std::shared_ptr<Promise<std::string>>()>
   /**
    * Specialized version of `std::function<std::shared_ptr<Promise<std::string>>()>`.
@@ -806,7 +806,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_std__shared_ptr_Promise_std__string___Wrapper wrap_Func_std__shared_ptr_Promise_std__string__(Func_std__shared_ptr_Promise_std__string__ value) noexcept {
     return Func_std__shared_ptr_Promise_std__string___Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::shared_ptr<Promise<std::string>>
   /**
    * Specialized version of `std::shared_ptr<Promise<std::string>>`.
@@ -818,7 +818,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline PromiseHolder<std::string> wrap_std__shared_ptr_Promise_std__string__(std::shared_ptr<Promise<std::string>> promise) noexcept {
     return PromiseHolder<std::string>(std::move(promise));
   }
-
+  
   // pragma MARK: std::function<void(const std::string& /* result */)>
   /**
    * Specialized version of `std::function<void(const std::string&)>`.
@@ -840,7 +840,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_void_std__string_Wrapper wrap_Func_void_std__string(Func_void_std__string value) noexcept {
     return Func_void_std__string_Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>
   /**
    * Wrapper struct for `std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>`.
@@ -887,7 +887,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<std::string>& value) noexcept {
     return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
   }
-
+  
   // pragma MARK: std::variant<bool, OldEnum>
   /**
    * Wrapper struct for `std::variant<bool, OldEnum>`.
@@ -916,7 +916,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(OldEnum value) noexcept {
     return std__variant_bool__OldEnum_(value);
   }
-
+  
   // pragma MARK: std::variant<bool, WeirdNumbersEnum>
   /**
    * Wrapper struct for `std::variant<bool, WeirdNumbersEnum>`.
@@ -945,7 +945,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline std__variant_bool__WeirdNumbersEnum_ create_std__variant_bool__WeirdNumbersEnum_(WeirdNumbersEnum value) noexcept {
     return std__variant_bool__WeirdNumbersEnum_(value);
   }
-
+  
   // pragma MARK: std::variant<Car, Person>
   /**
    * Wrapper struct for `std::variant<Car, Person>`.
@@ -974,7 +974,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline std__variant_Car__Person_ create_std__variant_Car__Person_(const Person& value) noexcept {
     return std__variant_Car__Person_(value);
   }
-
+  
   // pragma MARK: std::variant<std::string, Car>
   /**
    * Wrapper struct for `std::variant<std::string, Car>`.
@@ -1003,7 +1003,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline std__variant_std__string__Car_ create_std__variant_std__string__Car_(const Car& value) noexcept {
     return std__variant_std__string__Car_(value);
   }
-
+  
   // pragma MARK: std::shared_ptr<HybridBaseSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridBaseSpec>`.
@@ -1011,11 +1011,11 @@ namespace margelo::nitro::test::bridge::swift {
   using std__shared_ptr_HybridBaseSpec_ = std::shared_ptr<HybridBaseSpec>;
   std::shared_ptr<HybridBaseSpec> create_std__shared_ptr_HybridBaseSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
   void* _Nonnull get_std__shared_ptr_HybridBaseSpec_(std__shared_ptr_HybridBaseSpec_ cppType) noexcept;
-
+  
   // pragma MARK: std::weak_ptr<HybridBaseSpec>
   using std__weak_ptr_HybridBaseSpec_ = std::weak_ptr<HybridBaseSpec>;
   inline std__weak_ptr_HybridBaseSpec_ weakify_std__shared_ptr_HybridBaseSpec_(const std::shared_ptr<HybridBaseSpec>& strong) noexcept { return strong; }
-
+  
   // pragma MARK: std::shared_ptr<HybridChildSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridChildSpec>`.
@@ -1023,14 +1023,14 @@ namespace margelo::nitro::test::bridge::swift {
   using std__shared_ptr_HybridChildSpec_ = std::shared_ptr<HybridChildSpec>;
   std::shared_ptr<HybridChildSpec> create_std__shared_ptr_HybridChildSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
   void* _Nonnull get_std__shared_ptr_HybridChildSpec_(std__shared_ptr_HybridChildSpec_ cppType) noexcept;
-
+  
   // pragma MARK: std::shared_ptr<HybridBaseSpec>
   inline std::shared_ptr<HybridBaseSpec> upcast_Child_to_Base(std::shared_ptr<HybridChildSpec> child) noexcept { return child; }
-
+  
   // pragma MARK: std::weak_ptr<HybridChildSpec>
   using std__weak_ptr_HybridChildSpec_ = std::weak_ptr<HybridChildSpec>;
   inline std__weak_ptr_HybridChildSpec_ weakify_std__shared_ptr_HybridChildSpec_(const std::shared_ptr<HybridChildSpec>& strong) noexcept { return strong; }
-
+  
   // pragma MARK: std::function<double()>
   /**
    * Specialized version of `std::function<double()>`.
@@ -1053,7 +1053,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Func_double_Wrapper wrap_Func_double(Func_double value) noexcept {
     return Func_double_Wrapper(std::move(value));
   }
-
+  
   // pragma MARK: std::shared_ptr<HybridTestViewSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridTestViewSpec>`.
@@ -1061,11 +1061,11 @@ namespace margelo::nitro::test::bridge::swift {
   using std__shared_ptr_HybridTestViewSpec_ = std::shared_ptr<HybridTestViewSpec>;
   std::shared_ptr<HybridTestViewSpec> create_std__shared_ptr_HybridTestViewSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
   void* _Nonnull get_std__shared_ptr_HybridTestViewSpec_(std__shared_ptr_HybridTestViewSpec_ cppType) noexcept;
-
+  
   // pragma MARK: std::weak_ptr<HybridTestViewSpec>
   using std__weak_ptr_HybridTestViewSpec_ = std::weak_ptr<HybridTestViewSpec>;
   inline std__weak_ptr_HybridTestViewSpec_ weakify_std__shared_ptr_HybridTestViewSpec_(const std::shared_ptr<HybridTestViewSpec>& strong) noexcept { return strong; }
-
+  
   // pragma MARK: std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>
   /**
    * Specialized version of `std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>`.
@@ -1073,11 +1073,11 @@ namespace margelo::nitro::test::bridge::swift {
   using std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ = std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>;
   std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec> create_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
   void* _Nonnull get_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ cppType) noexcept;
-
+  
   // pragma MARK: std::weak_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>
   using std__weak_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ = std::weak_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>;
   inline std__weak_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ weakify_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(const std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>& strong) noexcept { return strong; }
-
+  
   // pragma MARK: Result<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>
   using Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ = Result<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>;
   inline Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& value) noexcept {
@@ -1086,7 +1086,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>>
   using Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___ = Result<std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>>;
   inline Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___ create_Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___(const std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& value) noexcept {
@@ -1095,7 +1095,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___ create_Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___(const std::exception_ptr& error) noexcept {
     return Result<std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>>::withError(error);
   }
-
+  
   // pragma MARK: Result<void>
   using Result_void_ = Result<void>;
   inline Result_void_ create_Result_void_() noexcept {
@@ -1104,7 +1104,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
     return Result<void>::withError(error);
   }
-
+  
   // pragma MARK: Result<double>
   using Result_double_ = Result<double>;
   inline Result_double_ create_Result_double_(double value) noexcept {
@@ -1113,7 +1113,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_double_ create_Result_double_(const std::exception_ptr& error) noexcept {
     return Result<double>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::string>
   using Result_std__string_ = Result<std::string>;
   inline Result_std__string_ create_Result_std__string_(const std::string& value) noexcept {
@@ -1122,7 +1122,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) noexcept {
     return Result<std::string>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::vector<std::string>>
   using Result_std__vector_std__string__ = Result<std::vector<std::string>>;
   inline Result_std__vector_std__string__ create_Result_std__vector_std__string__(const std::vector<std::string>& value) noexcept {
@@ -1131,7 +1131,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__vector_std__string__ create_Result_std__vector_std__string__(const std::exception_ptr& error) noexcept {
     return Result<std::vector<std::string>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::vector<double>>
   using Result_std__vector_double__ = Result<std::vector<double>>;
   inline Result_std__vector_double__ create_Result_std__vector_double__(const std::vector<double>& value) noexcept {
@@ -1140,7 +1140,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__vector_double__ create_Result_std__vector_double__(const std::exception_ptr& error) noexcept {
     return Result<std::vector<double>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::vector<Person>>
   using Result_std__vector_Person__ = Result<std::vector<Person>>;
   inline Result_std__vector_Person__ create_Result_std__vector_Person__(const std::vector<Person>& value) noexcept {
@@ -1149,7 +1149,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__vector_Person__ create_Result_std__vector_Person__(const std::exception_ptr& error) noexcept {
     return Result<std::vector<Person>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::vector<Powertrain>>
   using Result_std__vector_Powertrain__ = Result<std::vector<Powertrain>>;
   inline Result_std__vector_Powertrain__ create_Result_std__vector_Powertrain__(const std::vector<Powertrain>& value) noexcept {
@@ -1158,7 +1158,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__vector_Powertrain__ create_Result_std__vector_Powertrain__(const std::exception_ptr& error) noexcept {
     return Result<std::vector<Powertrain>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::shared_ptr<AnyMap>>
   using Result_std__shared_ptr_AnyMap__ = Result<std::shared_ptr<AnyMap>>;
   inline Result_std__shared_ptr_AnyMap__ create_Result_std__shared_ptr_AnyMap__(const std::shared_ptr<AnyMap>& value) noexcept {
@@ -1167,7 +1167,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__shared_ptr_AnyMap__ create_Result_std__shared_ptr_AnyMap__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<AnyMap>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::unordered_map<std::string, std::variant<double, bool>>>
   using Result_std__unordered_map_std__string__std__variant_double__bool___ = Result<std::unordered_map<std::string, std::variant<double, bool>>>;
   inline Result_std__unordered_map_std__string__std__variant_double__bool___ create_Result_std__unordered_map_std__string__std__variant_double__bool___(const std::unordered_map<std::string, std::variant<double, bool>>& value) noexcept {
@@ -1176,7 +1176,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__unordered_map_std__string__std__variant_double__bool___ create_Result_std__unordered_map_std__string__std__variant_double__bool___(const std::exception_ptr& error) noexcept {
     return Result<std::unordered_map<std::string, std::variant<double, bool>>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::unordered_map<std::string, std::string>>
   using Result_std__unordered_map_std__string__std__string__ = Result<std::unordered_map<std::string, std::string>>;
   inline Result_std__unordered_map_std__string__std__string__ create_Result_std__unordered_map_std__string__std__string__(const std::unordered_map<std::string, std::string>& value) noexcept {
@@ -1185,7 +1185,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__unordered_map_std__string__std__string__ create_Result_std__unordered_map_std__string__std__string__(const std::exception_ptr& error) noexcept {
     return Result<std::unordered_map<std::string, std::string>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::shared_ptr<Promise<void>>>
   using Result_std__shared_ptr_Promise_void___ = Result<std::shared_ptr<Promise<void>>>;
   inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::shared_ptr<Promise<void>>& value) noexcept {
@@ -1194,7 +1194,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<void>>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::optional<Powertrain>>
   using Result_std__optional_Powertrain__ = Result<std::optional<Powertrain>>;
   inline Result_std__optional_Powertrain__ create_Result_std__optional_Powertrain__(std::optional<Powertrain> value) noexcept {
@@ -1203,7 +1203,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__optional_Powertrain__ create_Result_std__optional_Powertrain__(const std::exception_ptr& error) noexcept {
     return Result<std::optional<Powertrain>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::chrono::system_clock::time_point>
   using Result_std__chrono__system_clock__time_point_ = Result<std::chrono::system_clock::time_point>;
   inline Result_std__chrono__system_clock__time_point_ create_Result_std__chrono__system_clock__time_point_(std::chrono::system_clock::time_point value) noexcept {
@@ -1212,7 +1212,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__chrono__system_clock__time_point_ create_Result_std__chrono__system_clock__time_point_(const std::exception_ptr& error) noexcept {
     return Result<std::chrono::system_clock::time_point>::withError(error);
   }
-
+  
   // pragma MARK: Result<int64_t>
   using Result_int64_t_ = Result<int64_t>;
   inline Result_int64_t_ create_Result_int64_t_(int64_t value) noexcept {
@@ -1221,7 +1221,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_int64_t_ create_Result_int64_t_(const std::exception_ptr& error) noexcept {
     return Result<int64_t>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::shared_ptr<Promise<int64_t>>>
   using Result_std__shared_ptr_Promise_int64_t___ = Result<std::shared_ptr<Promise<int64_t>>>;
   inline Result_std__shared_ptr_Promise_int64_t___ create_Result_std__shared_ptr_Promise_int64_t___(const std::shared_ptr<Promise<int64_t>>& value) noexcept {
@@ -1230,7 +1230,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__shared_ptr_Promise_int64_t___ create_Result_std__shared_ptr_Promise_int64_t___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<int64_t>>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::shared_ptr<Promise<double>>>
   using Result_std__shared_ptr_Promise_double___ = Result<std::shared_ptr<Promise<double>>>;
   inline Result_std__shared_ptr_Promise_double___ create_Result_std__shared_ptr_Promise_double___(const std::shared_ptr<Promise<double>>& value) noexcept {
@@ -1239,7 +1239,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__shared_ptr_Promise_double___ create_Result_std__shared_ptr_Promise_double___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<double>>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::shared_ptr<Promise<Car>>>
   using Result_std__shared_ptr_Promise_Car___ = Result<std::shared_ptr<Promise<Car>>>;
   inline Result_std__shared_ptr_Promise_Car___ create_Result_std__shared_ptr_Promise_Car___(const std::shared_ptr<Promise<Car>>& value) noexcept {
@@ -1248,7 +1248,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__shared_ptr_Promise_Car___ create_Result_std__shared_ptr_Promise_Car___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<Car>>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>
   using Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____ = Result<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>;
   inline Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____ create_Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>& value) noexcept {
@@ -1257,7 +1257,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____ create_Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::function<void(double /* value */)>>
   using Result_std__function_void_double____value______ = Result<std::function<void(double /* value */)>>;
   inline Result_std__function_void_double____value______ create_Result_std__function_void_double____value______(const std::function<void(double /* value */)>& value) noexcept {
@@ -1266,7 +1266,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__function_void_double____value______ create_Result_std__function_void_double____value______(const std::exception_ptr& error) noexcept {
     return Result<std::function<void(double /* value */)>>::withError(error);
   }
-
+  
   // pragma MARK: Result<Car>
   using Result_Car_ = Result<Car>;
   inline Result_Car_ create_Result_Car_(const Car& value) noexcept {
@@ -1275,7 +1275,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_Car_ create_Result_Car_(const std::exception_ptr& error) noexcept {
     return Result<Car>::withError(error);
   }
-
+  
   // pragma MARK: Result<bool>
   using Result_bool_ = Result<bool>;
   inline Result_bool_ create_Result_bool_(bool value) noexcept {
@@ -1284,7 +1284,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_bool_ create_Result_bool_(const std::exception_ptr& error) noexcept {
     return Result<bool>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::optional<Person>>
   using Result_std__optional_Person__ = Result<std::optional<Person>>;
   inline Result_std__optional_Person__ create_Result_std__optional_Person__(const std::optional<Person>& value) noexcept {
@@ -1293,7 +1293,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__optional_Person__ create_Result_std__optional_Person__(const std::exception_ptr& error) noexcept {
     return Result<std::optional<Person>>::withError(error);
   }
-
+  
   // pragma MARK: Result<WrappedJsStruct>
   using Result_WrappedJsStruct_ = Result<WrappedJsStruct>;
   inline Result_WrappedJsStruct_ create_Result_WrappedJsStruct_(const WrappedJsStruct& value) noexcept {
@@ -1302,7 +1302,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_WrappedJsStruct_ create_Result_WrappedJsStruct_(const std::exception_ptr& error) noexcept {
     return Result<WrappedJsStruct>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::shared_ptr<ArrayBuffer>>
   using Result_std__shared_ptr_ArrayBuffer__ = Result<std::shared_ptr<ArrayBuffer>>;
   inline Result_std__shared_ptr_ArrayBuffer__ create_Result_std__shared_ptr_ArrayBuffer__(const std::shared_ptr<ArrayBuffer>& value) noexcept {
@@ -1311,7 +1311,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__shared_ptr_ArrayBuffer__ create_Result_std__shared_ptr_ArrayBuffer__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<ArrayBuffer>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::variant<std::string, double>>
   using Result_std__variant_std__string__double__ = Result<std::variant<std::string, double>>;
   inline Result_std__variant_std__string__double__ create_Result_std__variant_std__string__double__(const std::variant<std::string, double>& value) noexcept {
@@ -1320,7 +1320,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__variant_std__string__double__ create_Result_std__variant_std__string__double__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<std::string, double>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::variant<bool, OldEnum>>
   using Result_std__variant_bool__OldEnum__ = Result<std::variant<bool, OldEnum>>;
   inline Result_std__variant_bool__OldEnum__ create_Result_std__variant_bool__OldEnum__(const std::variant<bool, OldEnum>& value) noexcept {
@@ -1329,7 +1329,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__variant_bool__OldEnum__ create_Result_std__variant_bool__OldEnum__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<bool, OldEnum>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::variant<bool, WeirdNumbersEnum>>
   using Result_std__variant_bool__WeirdNumbersEnum__ = Result<std::variant<bool, WeirdNumbersEnum>>;
   inline Result_std__variant_bool__WeirdNumbersEnum__ create_Result_std__variant_bool__WeirdNumbersEnum__(const std::variant<bool, WeirdNumbersEnum>& value) noexcept {
@@ -1338,7 +1338,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__variant_bool__WeirdNumbersEnum__ create_Result_std__variant_bool__WeirdNumbersEnum__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<bool, WeirdNumbersEnum>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::variant<Car, Person>>
   using Result_std__variant_Car__Person__ = Result<std::variant<Car, Person>>;
   inline Result_std__variant_Car__Person__ create_Result_std__variant_Car__Person__(const std::variant<Car, Person>& value) noexcept {
@@ -1347,7 +1347,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__variant_Car__Person__ create_Result_std__variant_Car__Person__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<Car, Person>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::variant<std::string, Car>>
   using Result_std__variant_std__string__Car__ = Result<std::variant<std::string, Car>>;
   inline Result_std__variant_std__string__Car__ create_Result_std__variant_std__string__Car__(const std::variant<std::string, Car>& value) noexcept {
@@ -1356,7 +1356,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__variant_std__string__Car__ create_Result_std__variant_std__string__Car__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<std::string, Car>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::shared_ptr<HybridChildSpec>>
   using Result_std__shared_ptr_HybridChildSpec__ = Result<std::shared_ptr<HybridChildSpec>>;
   inline Result_std__shared_ptr_HybridChildSpec__ create_Result_std__shared_ptr_HybridChildSpec__(const std::shared_ptr<HybridChildSpec>& value) noexcept {
@@ -1365,7 +1365,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__shared_ptr_HybridChildSpec__ create_Result_std__shared_ptr_HybridChildSpec__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<HybridChildSpec>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::shared_ptr<HybridBaseSpec>>
   using Result_std__shared_ptr_HybridBaseSpec__ = Result<std::shared_ptr<HybridBaseSpec>>;
   inline Result_std__shared_ptr_HybridBaseSpec__ create_Result_std__shared_ptr_HybridBaseSpec__(const std::shared_ptr<HybridBaseSpec>& value) noexcept {
@@ -1374,7 +1374,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__shared_ptr_HybridBaseSpec__ create_Result_std__shared_ptr_HybridBaseSpec__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<HybridBaseSpec>>::withError(error);
   }
-
+  
   // pragma MARK: Result<std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>>
   using Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__ = Result<std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>>;
   inline Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__ create_Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__(const std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>& value) noexcept {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -349,7 +349,7 @@ namespace margelo::nitro::test::bridge::swift {
     }
     return keys;
   }
-  inline std::variant<double, bool> get_std__unordered_map_std__string__std__variant_double__bool___value(const std__unordered_map_std__string__std__variant_double__bool__& map, const std::string& key) {
+  inline std::variant<double, bool> get_std__unordered_map_std__string__std__variant_double__bool___value(const std__unordered_map_std__string__std__variant_double__bool__& map, const std::string& key) noexcept {
     return map.find(key)->second;
   }
   inline void emplace_std__unordered_map_std__string__std__variant_double__bool__(std__unordered_map_std__string__std__variant_double__bool__& map, const std::string& key, const std::variant<double, bool>& value) noexcept {
@@ -374,7 +374,7 @@ namespace margelo::nitro::test::bridge::swift {
     }
     return keys;
   }
-  inline std::string get_std__unordered_map_std__string__std__string__value(const std__unordered_map_std__string__std__string_& map, const std::string& key) {
+  inline std::string get_std__unordered_map_std__string__std__string__value(const std__unordered_map_std__string__std__string_& map, const std::string& key) noexcept {
     return map.find(key)->second;
   }
   inline void emplace_std__unordered_map_std__string__std__string_(std__unordered_map_std__string__std__string_& map, const std::string& key, const std::string& value) noexcept {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -88,19 +88,19 @@ namespace margelo::nitro::test::bridge::swift {
    * Specialized version of `std::shared_ptr<HybridTestObjectSwiftKotlinSpec>`.
    */
   using std__shared_ptr_HybridTestObjectSwiftKotlinSpec_ = std::shared_ptr<HybridTestObjectSwiftKotlinSpec>;
-  std::shared_ptr<HybridTestObjectSwiftKotlinSpec> create_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(std__shared_ptr_HybridTestObjectSwiftKotlinSpec_ cppType);
-  
+  std::shared_ptr<HybridTestObjectSwiftKotlinSpec> create_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
+  void* _Nonnull get_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(std__shared_ptr_HybridTestObjectSwiftKotlinSpec_ cppType) noexcept;
+
   // pragma MARK: std::weak_ptr<HybridTestObjectSwiftKotlinSpec>
   using std__weak_ptr_HybridTestObjectSwiftKotlinSpec_ = std::weak_ptr<HybridTestObjectSwiftKotlinSpec>;
-  inline std__weak_ptr_HybridTestObjectSwiftKotlinSpec_ weakify_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& strong) { return strong; }
-  
+  inline std__weak_ptr_HybridTestObjectSwiftKotlinSpec_ weakify_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& strong) noexcept { return strong; }
+
   // pragma MARK: std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>
   /**
    * Specialized version of `std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>`.
    */
   using std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ = std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>;
-  inline std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>> create_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& value) {
+  inline std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>> create_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& value) noexcept {
     return std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>(value);
   }
   inline bool has_value_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& optional) {
@@ -109,7 +109,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::shared_ptr<HybridTestObjectSwiftKotlinSpec> get_std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::optional<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& optional) {
     return *optional;
   }
-  
+
   // pragma MARK: std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>
   /**
    * Wrapper struct for `std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>`.
@@ -119,32 +119,32 @@ namespace margelo::nitro::test::bridge::swift {
   struct std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ {
     std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>> variant;
     std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>> variant): variant(variant) { }
-    operator std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>() const {
+    operator std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>() const noexcept {
       return variant;
     }
-    inline size_t index() const {
+    inline size_t index() const noexcept {
       return variant.index();
     }
-    inline Person get_0() const {
+    inline Person get_0() const noexcept {
       return std::get<0>(variant);
     }
-    inline std::shared_ptr<HybridTestObjectSwiftKotlinSpec> get_1() const {
+    inline std::shared_ptr<HybridTestObjectSwiftKotlinSpec> get_1() const noexcept {
       return std::get<1>(variant);
     }
   };
-  inline std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const Person& value) {
+  inline std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const Person& value) noexcept {
     return std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(value);
   }
-  inline std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& value) {
+  inline std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& value) noexcept {
     return std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(value);
   }
-  
+
   // pragma MARK: std::optional<std::string>
   /**
    * Specialized version of `std::optional<std::string>`.
    */
   using std__optional_std__string_ = std::optional<std::string>;
-  inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) {
+  inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) noexcept {
     return std::optional<std::string>(value);
   }
   inline bool has_value_std__optional_std__string_(const std::optional<std::string>& optional) {
@@ -153,24 +153,24 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::string get_std__optional_std__string_(const std::optional<std::string>& optional) {
     return *optional;
   }
-  
+
   // pragma MARK: std::vector<std::string>
   /**
    * Specialized version of `std::vector<std::string>`.
    */
   using std__vector_std__string_ = std::vector<std::string>;
-  inline std::vector<std::string> create_std__vector_std__string_(size_t size) {
+  inline std::vector<std::string> create_std__vector_std__string_(size_t size) noexcept {
     std::vector<std::string> vector;
     vector.reserve(size);
     return vector;
   }
-  
+
   // pragma MARK: std::optional<std::vector<std::string>>
   /**
    * Specialized version of `std::optional<std::vector<std::string>>`.
    */
   using std__optional_std__vector_std__string__ = std::optional<std::vector<std::string>>;
-  inline std::optional<std::vector<std::string>> create_std__optional_std__vector_std__string__(const std::vector<std::string>& value) {
+  inline std::optional<std::vector<std::string>> create_std__optional_std__vector_std__string__(const std::vector<std::string>& value) noexcept {
     return std::optional<std::vector<std::string>>(value);
   }
   inline bool has_value_std__optional_std__vector_std__string__(const std::optional<std::vector<std::string>>& optional) {
@@ -179,13 +179,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::vector<std::string> get_std__optional_std__vector_std__string__(const std::optional<std::vector<std::string>>& optional) {
     return *optional;
   }
-  
+
   // pragma MARK: std::optional<Powertrain>
   /**
    * Specialized version of `std::optional<Powertrain>`.
    */
   using std__optional_Powertrain_ = std::optional<Powertrain>;
-  inline std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value) {
+  inline std::optional<Powertrain> create_std__optional_Powertrain_(const Powertrain& value) noexcept {
     return std::optional<Powertrain>(value);
   }
   inline bool has_value_std__optional_Powertrain_(const std::optional<Powertrain>& optional) {
@@ -194,13 +194,13 @@ namespace margelo::nitro::test::bridge::swift {
   inline Powertrain get_std__optional_Powertrain_(const std::optional<Powertrain>& optional) {
     return *optional;
   }
-  
+
   // pragma MARK: std::optional<OldEnum>
   /**
    * Specialized version of `std::optional<OldEnum>`.
    */
   using std__optional_OldEnum_ = std::optional<OldEnum>;
-  inline std::optional<OldEnum> create_std__optional_OldEnum_(const OldEnum& value) {
+  inline std::optional<OldEnum> create_std__optional_OldEnum_(const OldEnum& value) noexcept {
     return std::optional<OldEnum>(value);
   }
   inline bool has_value_std__optional_OldEnum_(const std::optional<OldEnum>& optional) {
@@ -209,7 +209,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline OldEnum get_std__optional_OldEnum_(const std::optional<OldEnum>& optional) {
     return *optional;
   }
-  
+
   // pragma MARK: std::function<void(double /* value */)>
   /**
    * Specialized version of `std::function<void(double)>`.
@@ -221,23 +221,23 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_double_Wrapper final {
   public:
     explicit Func_void_double_Wrapper(std::function<void(double /* value */)>&& func): _function(std::make_unique<std::function<void(double /* value */)>>(std::move(func))) {}
-    inline void call(double value) const {
+    inline void call(double value) const noexcept {
       _function->operator()(value);
     }
   private:
     std::unique_ptr<std::function<void(double /* value */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_double create_Func_void_double(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_double_Wrapper wrap_Func_void_double(Func_void_double value) {
+  Func_void_double create_Func_void_double(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_double_Wrapper wrap_Func_void_double(Func_void_double value) noexcept {
     return Func_void_double_Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::optional<std::function<void(double /* value */)>>
   /**
    * Specialized version of `std::optional<std::function<void(double / * value * /)>>`.
    */
   using std__optional_std__function_void_double____value______ = std::optional<std::function<void(double /* value */)>>;
-  inline std::optional<std::function<void(double /* value */)>> create_std__optional_std__function_void_double____value______(const std::function<void(double /* value */)>& value) {
+  inline std::optional<std::function<void(double /* value */)>> create_std__optional_std__function_void_double____value______(const std::function<void(double /* value */)>& value) noexcept {
     return std::optional<std::function<void(double /* value */)>>(value);
   }
   inline bool has_value_std__optional_std__function_void_double____value______(const std::optional<std::function<void(double /* value */)>>& optional) {
@@ -246,40 +246,40 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::function<void(double /* value */)> get_std__optional_std__function_void_double____value______(const std::optional<std::function<void(double /* value */)>>& optional) {
     return *optional;
   }
-  
+
   // pragma MARK: std::vector<double>
   /**
    * Specialized version of `std::vector<double>`.
    */
   using std__vector_double_ = std::vector<double>;
-  inline std::vector<double> create_std__vector_double_(size_t size) {
+  inline std::vector<double> create_std__vector_double_(size_t size) noexcept {
     std::vector<double> vector;
     vector.reserve(size);
     return vector;
   }
-  
+
   // pragma MARK: std::vector<Person>
   /**
    * Specialized version of `std::vector<Person>`.
    */
   using std__vector_Person_ = std::vector<Person>;
-  inline std::vector<Person> create_std__vector_Person_(size_t size) {
+  inline std::vector<Person> create_std__vector_Person_(size_t size) noexcept {
     std::vector<Person> vector;
     vector.reserve(size);
     return vector;
   }
-  
+
   // pragma MARK: std::vector<Powertrain>
   /**
    * Specialized version of `std::vector<Powertrain>`.
    */
   using std__vector_Powertrain_ = std::vector<Powertrain>;
-  inline std::vector<Powertrain> create_std__vector_Powertrain_(size_t size) {
+  inline std::vector<Powertrain> create_std__vector_Powertrain_(size_t size) noexcept {
     std::vector<Powertrain> vector;
     vector.reserve(size);
     return vector;
   }
-  
+
   // pragma MARK: std::function<void(const std::vector<Powertrain>& /* array */)>
   /**
    * Specialized version of `std::function<void(const std::vector<Powertrain>&)>`.
@@ -291,17 +291,17 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_std__vector_Powertrain__Wrapper final {
   public:
     explicit Func_void_std__vector_Powertrain__Wrapper(std::function<void(const std::vector<Powertrain>& /* array */)>&& func): _function(std::make_unique<std::function<void(const std::vector<Powertrain>& /* array */)>>(std::move(func))) {}
-    inline void call(std::vector<Powertrain> array) const {
+    inline void call(std::vector<Powertrain> array) const noexcept {
       _function->operator()(array);
     }
   private:
     std::unique_ptr<std::function<void(const std::vector<Powertrain>& /* array */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__vector_Powertrain__Wrapper wrap_Func_void_std__vector_Powertrain_(Func_void_std__vector_Powertrain_ value) {
+  Func_void_std__vector_Powertrain_ create_Func_void_std__vector_Powertrain_(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__vector_Powertrain__Wrapper wrap_Func_void_std__vector_Powertrain_(Func_void_std__vector_Powertrain_ value) noexcept {
     return Func_void_std__vector_Powertrain__Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::variant<double, bool>
   /**
    * Wrapper struct for `std::variant<double, bool>`.
@@ -311,37 +311,37 @@ namespace margelo::nitro::test::bridge::swift {
   struct std__variant_double__bool_ {
     std::variant<double, bool> variant;
     std__variant_double__bool_(std::variant<double, bool> variant): variant(variant) { }
-    operator std::variant<double, bool>() const {
+    operator std::variant<double, bool>() const noexcept {
       return variant;
     }
-    inline size_t index() const {
+    inline size_t index() const noexcept {
       return variant.index();
     }
-    inline double get_0() const {
+    inline double get_0() const noexcept {
       return std::get<0>(variant);
     }
-    inline bool get_1() const {
+    inline bool get_1() const noexcept {
       return std::get<1>(variant);
     }
   };
-  inline std__variant_double__bool_ create_std__variant_double__bool_(double value) {
+  inline std__variant_double__bool_ create_std__variant_double__bool_(double value) noexcept {
     return std__variant_double__bool_(value);
   }
-  inline std__variant_double__bool_ create_std__variant_double__bool_(bool value) {
+  inline std__variant_double__bool_ create_std__variant_double__bool_(bool value) noexcept {
     return std__variant_double__bool_(value);
   }
-  
+
   // pragma MARK: std::unordered_map<std::string, std::variant<double, bool>>
   /**
    * Specialized version of `std::unordered_map<std::string, std::variant<double, bool>>`.
    */
   using std__unordered_map_std__string__std__variant_double__bool__ = std::unordered_map<std::string, std::variant<double, bool>>;
-  inline std::unordered_map<std::string, std::variant<double, bool>> create_std__unordered_map_std__string__std__variant_double__bool__(size_t size) {
+  inline std::unordered_map<std::string, std::variant<double, bool>> create_std__unordered_map_std__string__std__variant_double__bool__(size_t size) noexcept {
     std::unordered_map<std::string, std::variant<double, bool>> map;
     map.reserve(size);
     return map;
   }
-  inline std::vector<std::string> get_std__unordered_map_std__string__std__variant_double__bool___keys(const std__unordered_map_std__string__std__variant_double__bool__& map) {
+  inline std::vector<std::string> get_std__unordered_map_std__string__std__variant_double__bool___keys(const std__unordered_map_std__string__std__variant_double__bool__& map) noexcept {
     std::vector<std::string> keys;
     keys.reserve(map.size());
     for (const auto& entry : map) {
@@ -352,21 +352,21 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::variant<double, bool> get_std__unordered_map_std__string__std__variant_double__bool___value(const std__unordered_map_std__string__std__variant_double__bool__& map, const std::string& key) {
     return map.find(key)->second;
   }
-  inline void emplace_std__unordered_map_std__string__std__variant_double__bool__(std__unordered_map_std__string__std__variant_double__bool__& map, const std::string& key, const std::variant<double, bool>& value) {
+  inline void emplace_std__unordered_map_std__string__std__variant_double__bool__(std__unordered_map_std__string__std__variant_double__bool__& map, const std::string& key, const std::variant<double, bool>& value) noexcept {
     map.emplace(key, value);
   }
-  
+
   // pragma MARK: std::unordered_map<std::string, std::string>
   /**
    * Specialized version of `std::unordered_map<std::string, std::string>`.
    */
   using std__unordered_map_std__string__std__string_ = std::unordered_map<std::string, std::string>;
-  inline std::unordered_map<std::string, std::string> create_std__unordered_map_std__string__std__string_(size_t size) {
+  inline std::unordered_map<std::string, std::string> create_std__unordered_map_std__string__std__string_(size_t size) noexcept {
     std::unordered_map<std::string, std::string> map;
     map.reserve(size);
     return map;
   }
-  inline std::vector<std::string> get_std__unordered_map_std__string__std__string__keys(const std__unordered_map_std__string__std__string_& map) {
+  inline std::vector<std::string> get_std__unordered_map_std__string__std__string__keys(const std__unordered_map_std__string__std__string_& map) noexcept {
     std::vector<std::string> keys;
     keys.reserve(map.size());
     for (const auto& entry : map) {
@@ -377,22 +377,22 @@ namespace margelo::nitro::test::bridge::swift {
   inline std::string get_std__unordered_map_std__string__std__string__value(const std__unordered_map_std__string__std__string_& map, const std::string& key) {
     return map.find(key)->second;
   }
-  inline void emplace_std__unordered_map_std__string__std__string_(std__unordered_map_std__string__std__string_& map, const std::string& key, const std::string& value) {
+  inline void emplace_std__unordered_map_std__string__std__string_(std__unordered_map_std__string__std__string_& map, const std::string& key, const std::string& value) noexcept {
     map.emplace(key, value);
   }
-  
+
   // pragma MARK: std::shared_ptr<Promise<void>>
   /**
    * Specialized version of `std::shared_ptr<Promise<void>>`.
    */
   using std__shared_ptr_Promise_void__ = std::shared_ptr<Promise<void>>;
-  inline std::shared_ptr<Promise<void>> create_std__shared_ptr_Promise_void__() {
+  inline std::shared_ptr<Promise<void>> create_std__shared_ptr_Promise_void__() noexcept {
     return Promise<void>::create();
   }
-  inline PromiseHolder<void> wrap_std__shared_ptr_Promise_void__(std::shared_ptr<Promise<void>> promise) {
+  inline PromiseHolder<void> wrap_std__shared_ptr_Promise_void__(std::shared_ptr<Promise<void>> promise) noexcept {
     return PromiseHolder<void>(std::move(promise));
   }
-  
+
   // pragma MARK: std::function<void()>
   /**
    * Specialized version of `std::function<void()>`.
@@ -404,17 +404,17 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_Wrapper final {
   public:
     explicit Func_void_Wrapper(std::function<void()>&& func): _function(std::make_unique<std::function<void()>>(std::move(func))) {}
-    inline void call() const {
+    inline void call() const noexcept {
       _function->operator()();
     }
   private:
     std::unique_ptr<std::function<void()>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_Wrapper wrap_Func_void(Func_void value) {
+  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_Wrapper wrap_Func_void(Func_void value) noexcept {
     return Func_void_Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::function<void(const std::exception_ptr& /* error */)>
   /**
    * Specialized version of `std::function<void(const std::exception_ptr&)>`.
@@ -426,23 +426,23 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_std__exception_ptr_Wrapper final {
   public:
     explicit Func_void_std__exception_ptr_Wrapper(std::function<void(const std::exception_ptr& /* error */)>&& func): _function(std::make_unique<std::function<void(const std::exception_ptr& /* error */)>>(std::move(func))) {}
-    inline void call(std::exception_ptr error) const {
+    inline void call(std::exception_ptr error) const noexcept {
       _function->operator()(error);
     }
   private:
     std::unique_ptr<std::function<void(const std::exception_ptr& /* error */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__exception_ptr_Wrapper wrap_Func_void_std__exception_ptr(Func_void_std__exception_ptr value) {
+  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__exception_ptr_Wrapper wrap_Func_void_std__exception_ptr(Func_void_std__exception_ptr value) noexcept {
     return Func_void_std__exception_ptr_Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::optional<bool>
   /**
    * Specialized version of `std::optional<bool>`.
    */
   using std__optional_bool_ = std::optional<bool>;
-  inline std::optional<bool> create_std__optional_bool_(const bool& value) {
+  inline std::optional<bool> create_std__optional_bool_(const bool& value) noexcept {
     return std::optional<bool>(value);
   }
   inline bool has_value_std__optional_bool_(const std::optional<bool>& optional) {
@@ -451,7 +451,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline bool get_std__optional_bool_(const std::optional<bool>& optional) {
     return *optional;
   }
-  
+
   // pragma MARK: std::variant<std::string, double>
   /**
    * Wrapper struct for `std::variant<std::string, double>`.
@@ -461,38 +461,38 @@ namespace margelo::nitro::test::bridge::swift {
   struct std__variant_std__string__double_ {
     std::variant<std::string, double> variant;
     std__variant_std__string__double_(std::variant<std::string, double> variant): variant(variant) { }
-    operator std::variant<std::string, double>() const {
+    operator std::variant<std::string, double>() const noexcept {
       return variant;
     }
-    inline size_t index() const {
+    inline size_t index() const noexcept {
       return variant.index();
     }
-    inline std::string get_0() const {
+    inline std::string get_0() const noexcept {
       return std::get<0>(variant);
     }
-    inline double get_1() const {
+    inline double get_1() const noexcept {
       return std::get<1>(variant);
     }
   };
-  inline std__variant_std__string__double_ create_std__variant_std__string__double_(const std::string& value) {
+  inline std__variant_std__string__double_ create_std__variant_std__string__double_(const std::string& value) noexcept {
     return std__variant_std__string__double_(value);
   }
-  inline std__variant_std__string__double_ create_std__variant_std__string__double_(double value) {
+  inline std__variant_std__string__double_ create_std__variant_std__string__double_(double value) noexcept {
     return std__variant_std__string__double_(value);
   }
-  
+
   // pragma MARK: std::shared_ptr<Promise<int64_t>>
   /**
    * Specialized version of `std::shared_ptr<Promise<int64_t>>`.
    */
   using std__shared_ptr_Promise_int64_t__ = std::shared_ptr<Promise<int64_t>>;
-  inline std::shared_ptr<Promise<int64_t>> create_std__shared_ptr_Promise_int64_t__() {
+  inline std::shared_ptr<Promise<int64_t>> create_std__shared_ptr_Promise_int64_t__() noexcept {
     return Promise<int64_t>::create();
   }
-  inline PromiseHolder<int64_t> wrap_std__shared_ptr_Promise_int64_t__(std::shared_ptr<Promise<int64_t>> promise) {
+  inline PromiseHolder<int64_t> wrap_std__shared_ptr_Promise_int64_t__(std::shared_ptr<Promise<int64_t>> promise) noexcept {
     return PromiseHolder<int64_t>(std::move(promise));
   }
-  
+
   // pragma MARK: std::function<void(int64_t /* result */)>
   /**
    * Specialized version of `std::function<void(int64_t)>`.
@@ -504,35 +504,35 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_int64_t_Wrapper final {
   public:
     explicit Func_void_int64_t_Wrapper(std::function<void(int64_t /* result */)>&& func): _function(std::make_unique<std::function<void(int64_t /* result */)>>(std::move(func))) {}
-    inline void call(int64_t result) const {
+    inline void call(int64_t result) const noexcept {
       _function->operator()(result);
     }
   private:
     std::unique_ptr<std::function<void(int64_t /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_int64_t create_Func_void_int64_t(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_int64_t_Wrapper wrap_Func_void_int64_t(Func_void_int64_t value) {
+  Func_void_int64_t create_Func_void_int64_t(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_int64_t_Wrapper wrap_Func_void_int64_t(Func_void_int64_t value) noexcept {
     return Func_void_int64_t_Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::shared_ptr<Promise<double>>
   /**
    * Specialized version of `std::shared_ptr<Promise<double>>`.
    */
   using std__shared_ptr_Promise_double__ = std::shared_ptr<Promise<double>>;
-  inline std::shared_ptr<Promise<double>> create_std__shared_ptr_Promise_double__() {
+  inline std::shared_ptr<Promise<double>> create_std__shared_ptr_Promise_double__() noexcept {
     return Promise<double>::create();
   }
-  inline PromiseHolder<double> wrap_std__shared_ptr_Promise_double__(std::shared_ptr<Promise<double>> promise) {
+  inline PromiseHolder<double> wrap_std__shared_ptr_Promise_double__(std::shared_ptr<Promise<double>> promise) noexcept {
     return PromiseHolder<double>(std::move(promise));
   }
-  
+
   // pragma MARK: std::optional<Person>
   /**
    * Specialized version of `std::optional<Person>`.
    */
   using std__optional_Person_ = std::optional<Person>;
-  inline std::optional<Person> create_std__optional_Person_(const Person& value) {
+  inline std::optional<Person> create_std__optional_Person_(const Person& value) noexcept {
     return std::optional<Person>(value);
   }
   inline bool has_value_std__optional_Person_(const std::optional<Person>& optional) {
@@ -541,19 +541,19 @@ namespace margelo::nitro::test::bridge::swift {
   inline Person get_std__optional_Person_(const std::optional<Person>& optional) {
     return *optional;
   }
-  
+
   // pragma MARK: std::shared_ptr<Promise<Car>>
   /**
    * Specialized version of `std::shared_ptr<Promise<Car>>`.
    */
   using std__shared_ptr_Promise_Car__ = std::shared_ptr<Promise<Car>>;
-  inline std::shared_ptr<Promise<Car>> create_std__shared_ptr_Promise_Car__() {
+  inline std::shared_ptr<Promise<Car>> create_std__shared_ptr_Promise_Car__() noexcept {
     return Promise<Car>::create();
   }
-  inline PromiseHolder<Car> wrap_std__shared_ptr_Promise_Car__(std::shared_ptr<Promise<Car>> promise) {
+  inline PromiseHolder<Car> wrap_std__shared_ptr_Promise_Car__(std::shared_ptr<Promise<Car>> promise) noexcept {
     return PromiseHolder<Car>(std::move(promise));
   }
-  
+
   // pragma MARK: std::function<void(const Car& /* result */)>
   /**
    * Specialized version of `std::function<void(const Car&)>`.
@@ -565,23 +565,23 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_Car_Wrapper final {
   public:
     explicit Func_void_Car_Wrapper(std::function<void(const Car& /* result */)>&& func): _function(std::make_unique<std::function<void(const Car& /* result */)>>(std::move(func))) {}
-    inline void call(Car result) const {
+    inline void call(Car result) const noexcept {
       _function->operator()(result);
     }
   private:
     std::unique_ptr<std::function<void(const Car& /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_Car create_Func_void_Car(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_Car_Wrapper wrap_Func_void_Car(Func_void_Car value) {
+  Func_void_Car create_Func_void_Car(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_Car_Wrapper wrap_Func_void_Car(Func_void_Car value) noexcept {
     return Func_void_Car_Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::optional<double>
   /**
    * Specialized version of `std::optional<double>`.
    */
   using std__optional_double_ = std::optional<double>;
-  inline std::optional<double> create_std__optional_double_(const double& value) {
+  inline std::optional<double> create_std__optional_double_(const double& value) noexcept {
     return std::optional<double>(value);
   }
   inline bool has_value_std__optional_double_(const std::optional<double>& optional) {
@@ -590,7 +590,7 @@ namespace margelo::nitro::test::bridge::swift {
   inline double get_std__optional_double_(const std::optional<double>& optional) {
     return *optional;
   }
-  
+
   // pragma MARK: std::function<void(std::optional<double> /* maybe */)>
   /**
    * Specialized version of `std::function<void(std::optional<double>)>`.
@@ -602,17 +602,17 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_std__optional_double__Wrapper final {
   public:
     explicit Func_void_std__optional_double__Wrapper(std::function<void(std::optional<double> /* maybe */)>&& func): _function(std::make_unique<std::function<void(std::optional<double> /* maybe */)>>(std::move(func))) {}
-    inline void call(std::optional<double> maybe) const {
+    inline void call(std::optional<double> maybe) const noexcept {
       _function->operator()(maybe);
     }
   private:
     std::unique_ptr<std::function<void(std::optional<double> /* maybe */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__optional_double__Wrapper wrap_Func_void_std__optional_double_(Func_void_std__optional_double_ value) {
+  Func_void_std__optional_double_ create_Func_void_std__optional_double_(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__optional_double__Wrapper wrap_Func_void_std__optional_double_(Func_void_std__optional_double_ value) noexcept {
     return Func_void_std__optional_double__Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::function<std::shared_ptr<Promise<double>>()>
   /**
    * Specialized version of `std::function<std::shared_ptr<Promise<double>>()>`.
@@ -624,18 +624,18 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_std__shared_ptr_Promise_double___Wrapper final {
   public:
     explicit Func_std__shared_ptr_Promise_double___Wrapper(std::function<std::shared_ptr<Promise<double>>()>&& func): _function(std::make_unique<std::function<std::shared_ptr<Promise<double>>()>>(std::move(func))) {}
-    inline std::shared_ptr<Promise<double>> call() const {
+    inline std::shared_ptr<Promise<double>> call() const noexcept {
       auto __result = _function->operator()();
       return __result;
     }
   private:
     std::unique_ptr<std::function<std::shared_ptr<Promise<double>>()>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_std__shared_ptr_Promise_double__ create_Func_std__shared_ptr_Promise_double__(void* _Nonnull swiftClosureWrapper);
-  inline Func_std__shared_ptr_Promise_double___Wrapper wrap_Func_std__shared_ptr_Promise_double__(Func_std__shared_ptr_Promise_double__ value) {
+  Func_std__shared_ptr_Promise_double__ create_Func_std__shared_ptr_Promise_double__(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_std__shared_ptr_Promise_double___Wrapper wrap_Func_std__shared_ptr_Promise_double__(Func_std__shared_ptr_Promise_double__ value) noexcept {
     return Func_std__shared_ptr_Promise_double___Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>
   /**
    * Specialized version of `std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>`.
@@ -647,30 +647,30 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____Wrapper final {
   public:
     explicit Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____Wrapper(std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>&& func): _function(std::make_unique<std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>>(std::move(func))) {}
-    inline std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> call() const {
+    inline std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> call() const noexcept {
       auto __result = _function->operator()();
       return __result;
     }
   private:
     std::unique_ptr<std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>()>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ create_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(void* _Nonnull swiftClosureWrapper);
-  inline Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____Wrapper wrap_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ value) {
+  Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ create_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____Wrapper wrap_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____ value) noexcept {
     return Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>
   /**
    * Specialized version of `std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>`.
    */
   using std__shared_ptr_Promise_std__shared_ptr_Promise_double____ = std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>>;
-  inline std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> create_std__shared_ptr_Promise_std__shared_ptr_Promise_double____() {
+  inline std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> create_std__shared_ptr_Promise_std__shared_ptr_Promise_double____() noexcept {
     return Promise<std::shared_ptr<Promise<double>>>::create();
   }
-  inline PromiseHolder<std::shared_ptr<Promise<double>>> wrap_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> promise) {
+  inline PromiseHolder<std::shared_ptr<Promise<double>>> wrap_std__shared_ptr_Promise_std__shared_ptr_Promise_double____(std::shared_ptr<Promise<std::shared_ptr<Promise<double>>>> promise) noexcept {
     return PromiseHolder<std::shared_ptr<Promise<double>>>(std::move(promise));
   }
-  
+
   // pragma MARK: std::function<void(const std::shared_ptr<Promise<double>>& /* result */)>
   /**
    * Specialized version of `std::function<void(const std::shared_ptr<Promise<double>>&)>`.
@@ -682,29 +682,29 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_std__shared_ptr_Promise_double___Wrapper final {
   public:
     explicit Func_void_std__shared_ptr_Promise_double___Wrapper(std::function<void(const std::shared_ptr<Promise<double>>& /* result */)>&& func): _function(std::make_unique<std::function<void(const std::shared_ptr<Promise<double>>& /* result */)>>(std::move(func))) {}
-    inline void call(std::shared_ptr<Promise<double>> result) const {
+    inline void call(std::shared_ptr<Promise<double>> result) const noexcept {
       _function->operator()(result);
     }
   private:
     std::unique_ptr<std::function<void(const std::shared_ptr<Promise<double>>& /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__shared_ptr_Promise_double__ create_Func_void_std__shared_ptr_Promise_double__(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__shared_ptr_Promise_double___Wrapper wrap_Func_void_std__shared_ptr_Promise_double__(Func_void_std__shared_ptr_Promise_double__ value) {
+  Func_void_std__shared_ptr_Promise_double__ create_Func_void_std__shared_ptr_Promise_double__(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__shared_ptr_Promise_double___Wrapper wrap_Func_void_std__shared_ptr_Promise_double__(Func_void_std__shared_ptr_Promise_double__ value) noexcept {
     return Func_void_std__shared_ptr_Promise_double___Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>
   /**
    * Specialized version of `std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>`.
    */
   using std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ = std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>;
-  inline std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> create_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___() {
+  inline std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> create_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___() noexcept {
     return Promise<std::shared_ptr<ArrayBuffer>>::create();
   }
-  inline PromiseHolder<std::shared_ptr<ArrayBuffer>> wrap_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___(std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> promise) {
+  inline PromiseHolder<std::shared_ptr<ArrayBuffer>> wrap_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___(std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> promise) noexcept {
     return PromiseHolder<std::shared_ptr<ArrayBuffer>>(std::move(promise));
   }
-  
+
   // pragma MARK: std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)>
   /**
    * Specialized version of `std::function<void(const std::shared_ptr<ArrayBuffer>&)>`.
@@ -716,17 +716,17 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_std__shared_ptr_ArrayBuffer__Wrapper final {
   public:
     explicit Func_void_std__shared_ptr_ArrayBuffer__Wrapper(std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)>&& func): _function(std::make_unique<std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)>>(std::move(func))) {}
-    inline void call(ArrayBufferHolder result) const {
+    inline void call(ArrayBufferHolder result) const noexcept {
       _function->operator()(result.getArrayBuffer());
     }
   private:
     std::unique_ptr<std::function<void(const std::shared_ptr<ArrayBuffer>& /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__shared_ptr_ArrayBuffer_ create_Func_void_std__shared_ptr_ArrayBuffer_(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__shared_ptr_ArrayBuffer__Wrapper wrap_Func_void_std__shared_ptr_ArrayBuffer_(Func_void_std__shared_ptr_ArrayBuffer_ value) {
+  Func_void_std__shared_ptr_ArrayBuffer_ create_Func_void_std__shared_ptr_ArrayBuffer_(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__shared_ptr_ArrayBuffer__Wrapper wrap_Func_void_std__shared_ptr_ArrayBuffer_(Func_void_std__shared_ptr_ArrayBuffer_ value) noexcept {
     return Func_void_std__shared_ptr_ArrayBuffer__Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>
   /**
    * Specialized version of `std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>`.
@@ -738,30 +738,30 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______Wrapper final {
   public:
     explicit Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______Wrapper(std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>&& func): _function(std::make_unique<std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>>(std::move(func))) {}
-    inline std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> call() const {
+    inline std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> call() const noexcept {
       auto __result = _function->operator()();
       return __result;
     }
   private:
     std::unique_ptr<std::function<std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>()>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ create_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(void* _Nonnull swiftClosureWrapper);
-  inline Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______Wrapper wrap_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ value) {
+  Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ create_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______Wrapper wrap_Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ value) noexcept {
     return Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer______Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>
   /**
    * Specialized version of `std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>`.
    */
   using std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____ = std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>>;
-  inline std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> create_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____() {
+  inline std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> create_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____() noexcept {
     return Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>::create();
   }
-  inline PromiseHolder<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>> wrap_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> promise) {
+  inline PromiseHolder<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>> wrap_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____(std::shared_ptr<Promise<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>> promise) noexcept {
     return PromiseHolder<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>(std::move(promise));
   }
-  
+
   // pragma MARK: std::function<void(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>& /* result */)>
   /**
    * Specialized version of `std::function<void(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>&)>`.
@@ -773,17 +773,17 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____Wrapper final {
   public:
     explicit Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____Wrapper(std::function<void(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>& /* result */)>&& func): _function(std::make_unique<std::function<void(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>& /* result */)>>(std::move(func))) {}
-    inline void call(std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> result) const {
+    inline void call(std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> result) const noexcept {
       _function->operator()(result);
     }
   private:
     std::unique_ptr<std::function<void(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>& /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ create_Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____Wrapper wrap_Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___(Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ value) {
+  Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ create_Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____Wrapper wrap_Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___(Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer___ value) noexcept {
     return Func_void_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::function<std::shared_ptr<Promise<std::string>>()>
   /**
    * Specialized version of `std::function<std::shared_ptr<Promise<std::string>>()>`.
@@ -795,30 +795,30 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_std__shared_ptr_Promise_std__string___Wrapper final {
   public:
     explicit Func_std__shared_ptr_Promise_std__string___Wrapper(std::function<std::shared_ptr<Promise<std::string>>()>&& func): _function(std::make_unique<std::function<std::shared_ptr<Promise<std::string>>()>>(std::move(func))) {}
-    inline std::shared_ptr<Promise<std::string>> call() const {
+    inline std::shared_ptr<Promise<std::string>> call() const noexcept {
       auto __result = _function->operator()();
       return __result;
     }
   private:
     std::unique_ptr<std::function<std::shared_ptr<Promise<std::string>>()>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_std__shared_ptr_Promise_std__string__ create_Func_std__shared_ptr_Promise_std__string__(void* _Nonnull swiftClosureWrapper);
-  inline Func_std__shared_ptr_Promise_std__string___Wrapper wrap_Func_std__shared_ptr_Promise_std__string__(Func_std__shared_ptr_Promise_std__string__ value) {
+  Func_std__shared_ptr_Promise_std__string__ create_Func_std__shared_ptr_Promise_std__string__(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_std__shared_ptr_Promise_std__string___Wrapper wrap_Func_std__shared_ptr_Promise_std__string__(Func_std__shared_ptr_Promise_std__string__ value) noexcept {
     return Func_std__shared_ptr_Promise_std__string___Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::shared_ptr<Promise<std::string>>
   /**
    * Specialized version of `std::shared_ptr<Promise<std::string>>`.
    */
   using std__shared_ptr_Promise_std__string__ = std::shared_ptr<Promise<std::string>>;
-  inline std::shared_ptr<Promise<std::string>> create_std__shared_ptr_Promise_std__string__() {
+  inline std::shared_ptr<Promise<std::string>> create_std__shared_ptr_Promise_std__string__() noexcept {
     return Promise<std::string>::create();
   }
-  inline PromiseHolder<std::string> wrap_std__shared_ptr_Promise_std__string__(std::shared_ptr<Promise<std::string>> promise) {
+  inline PromiseHolder<std::string> wrap_std__shared_ptr_Promise_std__string__(std::shared_ptr<Promise<std::string>> promise) noexcept {
     return PromiseHolder<std::string>(std::move(promise));
   }
-  
+
   // pragma MARK: std::function<void(const std::string& /* result */)>
   /**
    * Specialized version of `std::function<void(const std::string&)>`.
@@ -830,17 +830,17 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_void_std__string_Wrapper final {
   public:
     explicit Func_void_std__string_Wrapper(std::function<void(const std::string& /* result */)>&& func): _function(std::make_unique<std::function<void(const std::string& /* result */)>>(std::move(func))) {}
-    inline void call(std::string result) const {
+    inline void call(std::string result) const noexcept {
       _function->operator()(result);
     }
   private:
     std::unique_ptr<std::function<void(const std::string& /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__string create_Func_void_std__string(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__string_Wrapper wrap_Func_void_std__string(Func_void_std__string value) {
+  Func_void_std__string create_Func_void_std__string(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__string_Wrapper wrap_Func_void_std__string(Func_void_std__string value) noexcept {
     return Func_void_std__string_Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>
   /**
    * Wrapper struct for `std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>`.
@@ -850,44 +850,44 @@ namespace margelo::nitro::test::bridge::swift {
   struct std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ {
     std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>> variant;
     std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>> variant): variant(variant) { }
-    operator std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>() const {
+    operator std::variant<std::string, double, bool, std::vector<double>, std::vector<std::string>>() const noexcept {
       return variant;
     }
-    inline size_t index() const {
+    inline size_t index() const noexcept {
       return variant.index();
     }
-    inline std::string get_0() const {
+    inline std::string get_0() const noexcept {
       return std::get<0>(variant);
     }
-    inline double get_1() const {
+    inline double get_1() const noexcept {
       return std::get<1>(variant);
     }
-    inline bool get_2() const {
+    inline bool get_2() const noexcept {
       return std::get<2>(variant);
     }
-    inline std::vector<double> get_3() const {
+    inline std::vector<double> get_3() const noexcept {
       return std::get<3>(variant);
     }
-    inline std::vector<std::string> get_4() const {
+    inline std::vector<std::string> get_4() const noexcept {
       return std::get<4>(variant);
     }
   };
-  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::string& value) {
+  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::string& value) noexcept {
     return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
   }
-  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(double value) {
+  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(double value) noexcept {
     return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
   }
-  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(bool value) {
+  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(bool value) noexcept {
     return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
   }
-  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<double>& value) {
+  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<double>& value) noexcept {
     return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
   }
-  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<std::string>& value) {
+  inline std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__ create_std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(const std::vector<std::string>& value) noexcept {
     return std__variant_std__string__double__bool__std__vector_double___std__vector_std__string__(value);
   }
-  
+
   // pragma MARK: std::variant<bool, OldEnum>
   /**
    * Wrapper struct for `std::variant<bool, OldEnum>`.
@@ -897,26 +897,26 @@ namespace margelo::nitro::test::bridge::swift {
   struct std__variant_bool__OldEnum_ {
     std::variant<bool, OldEnum> variant;
     std__variant_bool__OldEnum_(std::variant<bool, OldEnum> variant): variant(variant) { }
-    operator std::variant<bool, OldEnum>() const {
+    operator std::variant<bool, OldEnum>() const noexcept {
       return variant;
     }
-    inline size_t index() const {
+    inline size_t index() const noexcept {
       return variant.index();
     }
-    inline bool get_0() const {
+    inline bool get_0() const noexcept {
       return std::get<0>(variant);
     }
-    inline OldEnum get_1() const {
+    inline OldEnum get_1() const noexcept {
       return std::get<1>(variant);
     }
   };
-  inline std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(bool value) {
+  inline std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(bool value) noexcept {
     return std__variant_bool__OldEnum_(value);
   }
-  inline std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(OldEnum value) {
+  inline std__variant_bool__OldEnum_ create_std__variant_bool__OldEnum_(OldEnum value) noexcept {
     return std__variant_bool__OldEnum_(value);
   }
-  
+
   // pragma MARK: std::variant<bool, WeirdNumbersEnum>
   /**
    * Wrapper struct for `std::variant<bool, WeirdNumbersEnum>`.
@@ -926,26 +926,26 @@ namespace margelo::nitro::test::bridge::swift {
   struct std__variant_bool__WeirdNumbersEnum_ {
     std::variant<bool, WeirdNumbersEnum> variant;
     std__variant_bool__WeirdNumbersEnum_(std::variant<bool, WeirdNumbersEnum> variant): variant(variant) { }
-    operator std::variant<bool, WeirdNumbersEnum>() const {
+    operator std::variant<bool, WeirdNumbersEnum>() const noexcept {
       return variant;
     }
-    inline size_t index() const {
+    inline size_t index() const noexcept {
       return variant.index();
     }
-    inline bool get_0() const {
+    inline bool get_0() const noexcept {
       return std::get<0>(variant);
     }
-    inline WeirdNumbersEnum get_1() const {
+    inline WeirdNumbersEnum get_1() const noexcept {
       return std::get<1>(variant);
     }
   };
-  inline std__variant_bool__WeirdNumbersEnum_ create_std__variant_bool__WeirdNumbersEnum_(bool value) {
+  inline std__variant_bool__WeirdNumbersEnum_ create_std__variant_bool__WeirdNumbersEnum_(bool value) noexcept {
     return std__variant_bool__WeirdNumbersEnum_(value);
   }
-  inline std__variant_bool__WeirdNumbersEnum_ create_std__variant_bool__WeirdNumbersEnum_(WeirdNumbersEnum value) {
+  inline std__variant_bool__WeirdNumbersEnum_ create_std__variant_bool__WeirdNumbersEnum_(WeirdNumbersEnum value) noexcept {
     return std__variant_bool__WeirdNumbersEnum_(value);
   }
-  
+
   // pragma MARK: std::variant<Car, Person>
   /**
    * Wrapper struct for `std::variant<Car, Person>`.
@@ -955,26 +955,26 @@ namespace margelo::nitro::test::bridge::swift {
   struct std__variant_Car__Person_ {
     std::variant<Car, Person> variant;
     std__variant_Car__Person_(std::variant<Car, Person> variant): variant(variant) { }
-    operator std::variant<Car, Person>() const {
+    operator std::variant<Car, Person>() const noexcept {
       return variant;
     }
-    inline size_t index() const {
+    inline size_t index() const noexcept {
       return variant.index();
     }
-    inline Car get_0() const {
+    inline Car get_0() const noexcept {
       return std::get<0>(variant);
     }
-    inline Person get_1() const {
+    inline Person get_1() const noexcept {
       return std::get<1>(variant);
     }
   };
-  inline std__variant_Car__Person_ create_std__variant_Car__Person_(const Car& value) {
+  inline std__variant_Car__Person_ create_std__variant_Car__Person_(const Car& value) noexcept {
     return std__variant_Car__Person_(value);
   }
-  inline std__variant_Car__Person_ create_std__variant_Car__Person_(const Person& value) {
+  inline std__variant_Car__Person_ create_std__variant_Car__Person_(const Person& value) noexcept {
     return std__variant_Car__Person_(value);
   }
-  
+
   // pragma MARK: std::variant<std::string, Car>
   /**
    * Wrapper struct for `std::variant<std::string, Car>`.
@@ -984,53 +984,53 @@ namespace margelo::nitro::test::bridge::swift {
   struct std__variant_std__string__Car_ {
     std::variant<std::string, Car> variant;
     std__variant_std__string__Car_(std::variant<std::string, Car> variant): variant(variant) { }
-    operator std::variant<std::string, Car>() const {
+    operator std::variant<std::string, Car>() const noexcept {
       return variant;
     }
-    inline size_t index() const {
+    inline size_t index() const noexcept {
       return variant.index();
     }
-    inline std::string get_0() const {
+    inline std::string get_0() const noexcept {
       return std::get<0>(variant);
     }
-    inline Car get_1() const {
+    inline Car get_1() const noexcept {
       return std::get<1>(variant);
     }
   };
-  inline std__variant_std__string__Car_ create_std__variant_std__string__Car_(const std::string& value) {
+  inline std__variant_std__string__Car_ create_std__variant_std__string__Car_(const std::string& value) noexcept {
     return std__variant_std__string__Car_(value);
   }
-  inline std__variant_std__string__Car_ create_std__variant_std__string__Car_(const Car& value) {
+  inline std__variant_std__string__Car_ create_std__variant_std__string__Car_(const Car& value) noexcept {
     return std__variant_std__string__Car_(value);
   }
-  
+
   // pragma MARK: std::shared_ptr<HybridBaseSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridBaseSpec>`.
    */
   using std__shared_ptr_HybridBaseSpec_ = std::shared_ptr<HybridBaseSpec>;
-  std::shared_ptr<HybridBaseSpec> create_std__shared_ptr_HybridBaseSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_HybridBaseSpec_(std__shared_ptr_HybridBaseSpec_ cppType);
-  
+  std::shared_ptr<HybridBaseSpec> create_std__shared_ptr_HybridBaseSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
+  void* _Nonnull get_std__shared_ptr_HybridBaseSpec_(std__shared_ptr_HybridBaseSpec_ cppType) noexcept;
+
   // pragma MARK: std::weak_ptr<HybridBaseSpec>
   using std__weak_ptr_HybridBaseSpec_ = std::weak_ptr<HybridBaseSpec>;
-  inline std__weak_ptr_HybridBaseSpec_ weakify_std__shared_ptr_HybridBaseSpec_(const std::shared_ptr<HybridBaseSpec>& strong) { return strong; }
-  
+  inline std__weak_ptr_HybridBaseSpec_ weakify_std__shared_ptr_HybridBaseSpec_(const std::shared_ptr<HybridBaseSpec>& strong) noexcept { return strong; }
+
   // pragma MARK: std::shared_ptr<HybridChildSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridChildSpec>`.
    */
   using std__shared_ptr_HybridChildSpec_ = std::shared_ptr<HybridChildSpec>;
-  std::shared_ptr<HybridChildSpec> create_std__shared_ptr_HybridChildSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_HybridChildSpec_(std__shared_ptr_HybridChildSpec_ cppType);
-  
+  std::shared_ptr<HybridChildSpec> create_std__shared_ptr_HybridChildSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
+  void* _Nonnull get_std__shared_ptr_HybridChildSpec_(std__shared_ptr_HybridChildSpec_ cppType) noexcept;
+
   // pragma MARK: std::shared_ptr<HybridBaseSpec>
-  inline std::shared_ptr<HybridBaseSpec> upcast_Child_to_Base(std::shared_ptr<HybridChildSpec> child) { return child; }
-  
+  inline std::shared_ptr<HybridBaseSpec> upcast_Child_to_Base(std::shared_ptr<HybridChildSpec> child) noexcept { return child; }
+
   // pragma MARK: std::weak_ptr<HybridChildSpec>
   using std__weak_ptr_HybridChildSpec_ = std::weak_ptr<HybridChildSpec>;
-  inline std__weak_ptr_HybridChildSpec_ weakify_std__shared_ptr_HybridChildSpec_(const std::shared_ptr<HybridChildSpec>& strong) { return strong; }
-  
+  inline std__weak_ptr_HybridChildSpec_ weakify_std__shared_ptr_HybridChildSpec_(const std::shared_ptr<HybridChildSpec>& strong) noexcept { return strong; }
+
   // pragma MARK: std::function<double()>
   /**
    * Specialized version of `std::function<double()>`.
@@ -1042,345 +1042,345 @@ namespace margelo::nitro::test::bridge::swift {
   class Func_double_Wrapper final {
   public:
     explicit Func_double_Wrapper(std::function<double()>&& func): _function(std::make_unique<std::function<double()>>(std::move(func))) {}
-    inline double call() const {
+    inline double call() const noexcept {
       auto __result = _function->operator()();
       return __result;
     }
   private:
     std::unique_ptr<std::function<double()>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_double create_Func_double(void* _Nonnull swiftClosureWrapper);
-  inline Func_double_Wrapper wrap_Func_double(Func_double value) {
+  Func_double create_Func_double(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_double_Wrapper wrap_Func_double(Func_double value) noexcept {
     return Func_double_Wrapper(std::move(value));
   }
-  
+
   // pragma MARK: std::shared_ptr<HybridTestViewSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridTestViewSpec>`.
    */
   using std__shared_ptr_HybridTestViewSpec_ = std::shared_ptr<HybridTestViewSpec>;
-  std::shared_ptr<HybridTestViewSpec> create_std__shared_ptr_HybridTestViewSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_HybridTestViewSpec_(std__shared_ptr_HybridTestViewSpec_ cppType);
-  
+  std::shared_ptr<HybridTestViewSpec> create_std__shared_ptr_HybridTestViewSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
+  void* _Nonnull get_std__shared_ptr_HybridTestViewSpec_(std__shared_ptr_HybridTestViewSpec_ cppType) noexcept;
+
   // pragma MARK: std::weak_ptr<HybridTestViewSpec>
   using std__weak_ptr_HybridTestViewSpec_ = std::weak_ptr<HybridTestViewSpec>;
-  inline std__weak_ptr_HybridTestViewSpec_ weakify_std__shared_ptr_HybridTestViewSpec_(const std::shared_ptr<HybridTestViewSpec>& strong) { return strong; }
-  
+  inline std__weak_ptr_HybridTestViewSpec_ weakify_std__shared_ptr_HybridTestViewSpec_(const std::shared_ptr<HybridTestViewSpec>& strong) noexcept { return strong; }
+
   // pragma MARK: std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>
   /**
    * Specialized version of `std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>`.
    */
   using std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ = std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>;
-  std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec> create_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ cppType);
-  
+  std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec> create_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
+  void* _Nonnull get_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ cppType) noexcept;
+
   // pragma MARK: std::weak_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>
   using std__weak_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ = std::weak_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>;
-  inline std__weak_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ weakify_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(const std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>& strong) { return strong; }
-  
+  inline std__weak_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_ weakify_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_(const std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>& strong) noexcept { return strong; }
+
   // pragma MARK: Result<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>
   using Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ = Result<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>;
-  inline Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& value) {
+  inline Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::shared_ptr<HybridTestObjectSwiftKotlinSpec>& value) noexcept {
     return Result<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>::withValue(value);
   }
-  inline Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ create_Result_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>>
   using Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___ = Result<std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>>;
-  inline Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___ create_Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___(const std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& value) {
+  inline Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___ create_Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___(const std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>& value) noexcept {
     return Result<std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>>::withValue(value);
   }
-  inline Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___ create_Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___(const std::exception_ptr& error) {
+  inline Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___ create_Result_std__variant_Person__std__shared_ptr_HybridTestObjectSwiftKotlinSpec___(const std::exception_ptr& error) noexcept {
     return Result<std::variant<Person, std::shared_ptr<HybridTestObjectSwiftKotlinSpec>>>::withError(error);
   }
-  
+
   // pragma MARK: Result<void>
   using Result_void_ = Result<void>;
-  inline Result_void_ create_Result_void_() {
+  inline Result_void_ create_Result_void_() noexcept {
     return Result<void>::withValue();
   }
-  inline Result_void_ create_Result_void_(const std::exception_ptr& error) {
+  inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
     return Result<void>::withError(error);
   }
-  
+
   // pragma MARK: Result<double>
   using Result_double_ = Result<double>;
-  inline Result_double_ create_Result_double_(double value) {
+  inline Result_double_ create_Result_double_(double value) noexcept {
     return Result<double>::withValue(std::move(value));
   }
-  inline Result_double_ create_Result_double_(const std::exception_ptr& error) {
+  inline Result_double_ create_Result_double_(const std::exception_ptr& error) noexcept {
     return Result<double>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::string>
   using Result_std__string_ = Result<std::string>;
-  inline Result_std__string_ create_Result_std__string_(const std::string& value) {
+  inline Result_std__string_ create_Result_std__string_(const std::string& value) noexcept {
     return Result<std::string>::withValue(value);
   }
-  inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) {
+  inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) noexcept {
     return Result<std::string>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::vector<std::string>>
   using Result_std__vector_std__string__ = Result<std::vector<std::string>>;
-  inline Result_std__vector_std__string__ create_Result_std__vector_std__string__(const std::vector<std::string>& value) {
+  inline Result_std__vector_std__string__ create_Result_std__vector_std__string__(const std::vector<std::string>& value) noexcept {
     return Result<std::vector<std::string>>::withValue(value);
   }
-  inline Result_std__vector_std__string__ create_Result_std__vector_std__string__(const std::exception_ptr& error) {
+  inline Result_std__vector_std__string__ create_Result_std__vector_std__string__(const std::exception_ptr& error) noexcept {
     return Result<std::vector<std::string>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::vector<double>>
   using Result_std__vector_double__ = Result<std::vector<double>>;
-  inline Result_std__vector_double__ create_Result_std__vector_double__(const std::vector<double>& value) {
+  inline Result_std__vector_double__ create_Result_std__vector_double__(const std::vector<double>& value) noexcept {
     return Result<std::vector<double>>::withValue(value);
   }
-  inline Result_std__vector_double__ create_Result_std__vector_double__(const std::exception_ptr& error) {
+  inline Result_std__vector_double__ create_Result_std__vector_double__(const std::exception_ptr& error) noexcept {
     return Result<std::vector<double>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::vector<Person>>
   using Result_std__vector_Person__ = Result<std::vector<Person>>;
-  inline Result_std__vector_Person__ create_Result_std__vector_Person__(const std::vector<Person>& value) {
+  inline Result_std__vector_Person__ create_Result_std__vector_Person__(const std::vector<Person>& value) noexcept {
     return Result<std::vector<Person>>::withValue(value);
   }
-  inline Result_std__vector_Person__ create_Result_std__vector_Person__(const std::exception_ptr& error) {
+  inline Result_std__vector_Person__ create_Result_std__vector_Person__(const std::exception_ptr& error) noexcept {
     return Result<std::vector<Person>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::vector<Powertrain>>
   using Result_std__vector_Powertrain__ = Result<std::vector<Powertrain>>;
-  inline Result_std__vector_Powertrain__ create_Result_std__vector_Powertrain__(const std::vector<Powertrain>& value) {
+  inline Result_std__vector_Powertrain__ create_Result_std__vector_Powertrain__(const std::vector<Powertrain>& value) noexcept {
     return Result<std::vector<Powertrain>>::withValue(value);
   }
-  inline Result_std__vector_Powertrain__ create_Result_std__vector_Powertrain__(const std::exception_ptr& error) {
+  inline Result_std__vector_Powertrain__ create_Result_std__vector_Powertrain__(const std::exception_ptr& error) noexcept {
     return Result<std::vector<Powertrain>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::shared_ptr<AnyMap>>
   using Result_std__shared_ptr_AnyMap__ = Result<std::shared_ptr<AnyMap>>;
-  inline Result_std__shared_ptr_AnyMap__ create_Result_std__shared_ptr_AnyMap__(const std::shared_ptr<AnyMap>& value) {
+  inline Result_std__shared_ptr_AnyMap__ create_Result_std__shared_ptr_AnyMap__(const std::shared_ptr<AnyMap>& value) noexcept {
     return Result<std::shared_ptr<AnyMap>>::withValue(value);
   }
-  inline Result_std__shared_ptr_AnyMap__ create_Result_std__shared_ptr_AnyMap__(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_AnyMap__ create_Result_std__shared_ptr_AnyMap__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<AnyMap>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::unordered_map<std::string, std::variant<double, bool>>>
   using Result_std__unordered_map_std__string__std__variant_double__bool___ = Result<std::unordered_map<std::string, std::variant<double, bool>>>;
-  inline Result_std__unordered_map_std__string__std__variant_double__bool___ create_Result_std__unordered_map_std__string__std__variant_double__bool___(const std::unordered_map<std::string, std::variant<double, bool>>& value) {
+  inline Result_std__unordered_map_std__string__std__variant_double__bool___ create_Result_std__unordered_map_std__string__std__variant_double__bool___(const std::unordered_map<std::string, std::variant<double, bool>>& value) noexcept {
     return Result<std::unordered_map<std::string, std::variant<double, bool>>>::withValue(value);
   }
-  inline Result_std__unordered_map_std__string__std__variant_double__bool___ create_Result_std__unordered_map_std__string__std__variant_double__bool___(const std::exception_ptr& error) {
+  inline Result_std__unordered_map_std__string__std__variant_double__bool___ create_Result_std__unordered_map_std__string__std__variant_double__bool___(const std::exception_ptr& error) noexcept {
     return Result<std::unordered_map<std::string, std::variant<double, bool>>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::unordered_map<std::string, std::string>>
   using Result_std__unordered_map_std__string__std__string__ = Result<std::unordered_map<std::string, std::string>>;
-  inline Result_std__unordered_map_std__string__std__string__ create_Result_std__unordered_map_std__string__std__string__(const std::unordered_map<std::string, std::string>& value) {
+  inline Result_std__unordered_map_std__string__std__string__ create_Result_std__unordered_map_std__string__std__string__(const std::unordered_map<std::string, std::string>& value) noexcept {
     return Result<std::unordered_map<std::string, std::string>>::withValue(value);
   }
-  inline Result_std__unordered_map_std__string__std__string__ create_Result_std__unordered_map_std__string__std__string__(const std::exception_ptr& error) {
+  inline Result_std__unordered_map_std__string__std__string__ create_Result_std__unordered_map_std__string__std__string__(const std::exception_ptr& error) noexcept {
     return Result<std::unordered_map<std::string, std::string>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::shared_ptr<Promise<void>>>
   using Result_std__shared_ptr_Promise_void___ = Result<std::shared_ptr<Promise<void>>>;
-  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::shared_ptr<Promise<void>>& value) {
+  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::shared_ptr<Promise<void>>& value) noexcept {
     return Result<std::shared_ptr<Promise<void>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<void>>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::optional<Powertrain>>
   using Result_std__optional_Powertrain__ = Result<std::optional<Powertrain>>;
-  inline Result_std__optional_Powertrain__ create_Result_std__optional_Powertrain__(std::optional<Powertrain> value) {
+  inline Result_std__optional_Powertrain__ create_Result_std__optional_Powertrain__(std::optional<Powertrain> value) noexcept {
     return Result<std::optional<Powertrain>>::withValue(std::move(value));
   }
-  inline Result_std__optional_Powertrain__ create_Result_std__optional_Powertrain__(const std::exception_ptr& error) {
+  inline Result_std__optional_Powertrain__ create_Result_std__optional_Powertrain__(const std::exception_ptr& error) noexcept {
     return Result<std::optional<Powertrain>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::chrono::system_clock::time_point>
   using Result_std__chrono__system_clock__time_point_ = Result<std::chrono::system_clock::time_point>;
-  inline Result_std__chrono__system_clock__time_point_ create_Result_std__chrono__system_clock__time_point_(std::chrono::system_clock::time_point value) {
+  inline Result_std__chrono__system_clock__time_point_ create_Result_std__chrono__system_clock__time_point_(std::chrono::system_clock::time_point value) noexcept {
     return Result<std::chrono::system_clock::time_point>::withValue(std::move(value));
   }
-  inline Result_std__chrono__system_clock__time_point_ create_Result_std__chrono__system_clock__time_point_(const std::exception_ptr& error) {
+  inline Result_std__chrono__system_clock__time_point_ create_Result_std__chrono__system_clock__time_point_(const std::exception_ptr& error) noexcept {
     return Result<std::chrono::system_clock::time_point>::withError(error);
   }
-  
+
   // pragma MARK: Result<int64_t>
   using Result_int64_t_ = Result<int64_t>;
-  inline Result_int64_t_ create_Result_int64_t_(int64_t value) {
+  inline Result_int64_t_ create_Result_int64_t_(int64_t value) noexcept {
     return Result<int64_t>::withValue(std::move(value));
   }
-  inline Result_int64_t_ create_Result_int64_t_(const std::exception_ptr& error) {
+  inline Result_int64_t_ create_Result_int64_t_(const std::exception_ptr& error) noexcept {
     return Result<int64_t>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::shared_ptr<Promise<int64_t>>>
   using Result_std__shared_ptr_Promise_int64_t___ = Result<std::shared_ptr<Promise<int64_t>>>;
-  inline Result_std__shared_ptr_Promise_int64_t___ create_Result_std__shared_ptr_Promise_int64_t___(const std::shared_ptr<Promise<int64_t>>& value) {
+  inline Result_std__shared_ptr_Promise_int64_t___ create_Result_std__shared_ptr_Promise_int64_t___(const std::shared_ptr<Promise<int64_t>>& value) noexcept {
     return Result<std::shared_ptr<Promise<int64_t>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_int64_t___ create_Result_std__shared_ptr_Promise_int64_t___(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_int64_t___ create_Result_std__shared_ptr_Promise_int64_t___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<int64_t>>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::shared_ptr<Promise<double>>>
   using Result_std__shared_ptr_Promise_double___ = Result<std::shared_ptr<Promise<double>>>;
-  inline Result_std__shared_ptr_Promise_double___ create_Result_std__shared_ptr_Promise_double___(const std::shared_ptr<Promise<double>>& value) {
+  inline Result_std__shared_ptr_Promise_double___ create_Result_std__shared_ptr_Promise_double___(const std::shared_ptr<Promise<double>>& value) noexcept {
     return Result<std::shared_ptr<Promise<double>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_double___ create_Result_std__shared_ptr_Promise_double___(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_double___ create_Result_std__shared_ptr_Promise_double___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<double>>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::shared_ptr<Promise<Car>>>
   using Result_std__shared_ptr_Promise_Car___ = Result<std::shared_ptr<Promise<Car>>>;
-  inline Result_std__shared_ptr_Promise_Car___ create_Result_std__shared_ptr_Promise_Car___(const std::shared_ptr<Promise<Car>>& value) {
+  inline Result_std__shared_ptr_Promise_Car___ create_Result_std__shared_ptr_Promise_Car___(const std::shared_ptr<Promise<Car>>& value) noexcept {
     return Result<std::shared_ptr<Promise<Car>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_Car___ create_Result_std__shared_ptr_Promise_Car___(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_Car___ create_Result_std__shared_ptr_Promise_Car___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<Car>>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>
   using Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____ = Result<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>;
-  inline Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____ create_Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>& value) {
+  inline Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____ create_Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____(const std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>& value) noexcept {
     return Result<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____ create_Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____ create_Result_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer____(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::function<void(double /* value */)>>
   using Result_std__function_void_double____value______ = Result<std::function<void(double /* value */)>>;
-  inline Result_std__function_void_double____value______ create_Result_std__function_void_double____value______(const std::function<void(double /* value */)>& value) {
+  inline Result_std__function_void_double____value______ create_Result_std__function_void_double____value______(const std::function<void(double /* value */)>& value) noexcept {
     return Result<std::function<void(double /* value */)>>::withValue(value);
   }
-  inline Result_std__function_void_double____value______ create_Result_std__function_void_double____value______(const std::exception_ptr& error) {
+  inline Result_std__function_void_double____value______ create_Result_std__function_void_double____value______(const std::exception_ptr& error) noexcept {
     return Result<std::function<void(double /* value */)>>::withError(error);
   }
-  
+
   // pragma MARK: Result<Car>
   using Result_Car_ = Result<Car>;
-  inline Result_Car_ create_Result_Car_(const Car& value) {
+  inline Result_Car_ create_Result_Car_(const Car& value) noexcept {
     return Result<Car>::withValue(value);
   }
-  inline Result_Car_ create_Result_Car_(const std::exception_ptr& error) {
+  inline Result_Car_ create_Result_Car_(const std::exception_ptr& error) noexcept {
     return Result<Car>::withError(error);
   }
-  
+
   // pragma MARK: Result<bool>
   using Result_bool_ = Result<bool>;
-  inline Result_bool_ create_Result_bool_(bool value) {
+  inline Result_bool_ create_Result_bool_(bool value) noexcept {
     return Result<bool>::withValue(std::move(value));
   }
-  inline Result_bool_ create_Result_bool_(const std::exception_ptr& error) {
+  inline Result_bool_ create_Result_bool_(const std::exception_ptr& error) noexcept {
     return Result<bool>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::optional<Person>>
   using Result_std__optional_Person__ = Result<std::optional<Person>>;
-  inline Result_std__optional_Person__ create_Result_std__optional_Person__(const std::optional<Person>& value) {
+  inline Result_std__optional_Person__ create_Result_std__optional_Person__(const std::optional<Person>& value) noexcept {
     return Result<std::optional<Person>>::withValue(value);
   }
-  inline Result_std__optional_Person__ create_Result_std__optional_Person__(const std::exception_ptr& error) {
+  inline Result_std__optional_Person__ create_Result_std__optional_Person__(const std::exception_ptr& error) noexcept {
     return Result<std::optional<Person>>::withError(error);
   }
-  
+
   // pragma MARK: Result<WrappedJsStruct>
   using Result_WrappedJsStruct_ = Result<WrappedJsStruct>;
-  inline Result_WrappedJsStruct_ create_Result_WrappedJsStruct_(const WrappedJsStruct& value) {
+  inline Result_WrappedJsStruct_ create_Result_WrappedJsStruct_(const WrappedJsStruct& value) noexcept {
     return Result<WrappedJsStruct>::withValue(value);
   }
-  inline Result_WrappedJsStruct_ create_Result_WrappedJsStruct_(const std::exception_ptr& error) {
+  inline Result_WrappedJsStruct_ create_Result_WrappedJsStruct_(const std::exception_ptr& error) noexcept {
     return Result<WrappedJsStruct>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::shared_ptr<ArrayBuffer>>
   using Result_std__shared_ptr_ArrayBuffer__ = Result<std::shared_ptr<ArrayBuffer>>;
-  inline Result_std__shared_ptr_ArrayBuffer__ create_Result_std__shared_ptr_ArrayBuffer__(const std::shared_ptr<ArrayBuffer>& value) {
+  inline Result_std__shared_ptr_ArrayBuffer__ create_Result_std__shared_ptr_ArrayBuffer__(const std::shared_ptr<ArrayBuffer>& value) noexcept {
     return Result<std::shared_ptr<ArrayBuffer>>::withValue(value);
   }
-  inline Result_std__shared_ptr_ArrayBuffer__ create_Result_std__shared_ptr_ArrayBuffer__(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_ArrayBuffer__ create_Result_std__shared_ptr_ArrayBuffer__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<ArrayBuffer>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::variant<std::string, double>>
   using Result_std__variant_std__string__double__ = Result<std::variant<std::string, double>>;
-  inline Result_std__variant_std__string__double__ create_Result_std__variant_std__string__double__(const std::variant<std::string, double>& value) {
+  inline Result_std__variant_std__string__double__ create_Result_std__variant_std__string__double__(const std::variant<std::string, double>& value) noexcept {
     return Result<std::variant<std::string, double>>::withValue(value);
   }
-  inline Result_std__variant_std__string__double__ create_Result_std__variant_std__string__double__(const std::exception_ptr& error) {
+  inline Result_std__variant_std__string__double__ create_Result_std__variant_std__string__double__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<std::string, double>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::variant<bool, OldEnum>>
   using Result_std__variant_bool__OldEnum__ = Result<std::variant<bool, OldEnum>>;
-  inline Result_std__variant_bool__OldEnum__ create_Result_std__variant_bool__OldEnum__(const std::variant<bool, OldEnum>& value) {
+  inline Result_std__variant_bool__OldEnum__ create_Result_std__variant_bool__OldEnum__(const std::variant<bool, OldEnum>& value) noexcept {
     return Result<std::variant<bool, OldEnum>>::withValue(value);
   }
-  inline Result_std__variant_bool__OldEnum__ create_Result_std__variant_bool__OldEnum__(const std::exception_ptr& error) {
+  inline Result_std__variant_bool__OldEnum__ create_Result_std__variant_bool__OldEnum__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<bool, OldEnum>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::variant<bool, WeirdNumbersEnum>>
   using Result_std__variant_bool__WeirdNumbersEnum__ = Result<std::variant<bool, WeirdNumbersEnum>>;
-  inline Result_std__variant_bool__WeirdNumbersEnum__ create_Result_std__variant_bool__WeirdNumbersEnum__(const std::variant<bool, WeirdNumbersEnum>& value) {
+  inline Result_std__variant_bool__WeirdNumbersEnum__ create_Result_std__variant_bool__WeirdNumbersEnum__(const std::variant<bool, WeirdNumbersEnum>& value) noexcept {
     return Result<std::variant<bool, WeirdNumbersEnum>>::withValue(value);
   }
-  inline Result_std__variant_bool__WeirdNumbersEnum__ create_Result_std__variant_bool__WeirdNumbersEnum__(const std::exception_ptr& error) {
+  inline Result_std__variant_bool__WeirdNumbersEnum__ create_Result_std__variant_bool__WeirdNumbersEnum__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<bool, WeirdNumbersEnum>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::variant<Car, Person>>
   using Result_std__variant_Car__Person__ = Result<std::variant<Car, Person>>;
-  inline Result_std__variant_Car__Person__ create_Result_std__variant_Car__Person__(const std::variant<Car, Person>& value) {
+  inline Result_std__variant_Car__Person__ create_Result_std__variant_Car__Person__(const std::variant<Car, Person>& value) noexcept {
     return Result<std::variant<Car, Person>>::withValue(value);
   }
-  inline Result_std__variant_Car__Person__ create_Result_std__variant_Car__Person__(const std::exception_ptr& error) {
+  inline Result_std__variant_Car__Person__ create_Result_std__variant_Car__Person__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<Car, Person>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::variant<std::string, Car>>
   using Result_std__variant_std__string__Car__ = Result<std::variant<std::string, Car>>;
-  inline Result_std__variant_std__string__Car__ create_Result_std__variant_std__string__Car__(const std::variant<std::string, Car>& value) {
+  inline Result_std__variant_std__string__Car__ create_Result_std__variant_std__string__Car__(const std::variant<std::string, Car>& value) noexcept {
     return Result<std::variant<std::string, Car>>::withValue(value);
   }
-  inline Result_std__variant_std__string__Car__ create_Result_std__variant_std__string__Car__(const std::exception_ptr& error) {
+  inline Result_std__variant_std__string__Car__ create_Result_std__variant_std__string__Car__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<std::string, Car>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::shared_ptr<HybridChildSpec>>
   using Result_std__shared_ptr_HybridChildSpec__ = Result<std::shared_ptr<HybridChildSpec>>;
-  inline Result_std__shared_ptr_HybridChildSpec__ create_Result_std__shared_ptr_HybridChildSpec__(const std::shared_ptr<HybridChildSpec>& value) {
+  inline Result_std__shared_ptr_HybridChildSpec__ create_Result_std__shared_ptr_HybridChildSpec__(const std::shared_ptr<HybridChildSpec>& value) noexcept {
     return Result<std::shared_ptr<HybridChildSpec>>::withValue(value);
   }
-  inline Result_std__shared_ptr_HybridChildSpec__ create_Result_std__shared_ptr_HybridChildSpec__(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_HybridChildSpec__ create_Result_std__shared_ptr_HybridChildSpec__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<HybridChildSpec>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::shared_ptr<HybridBaseSpec>>
   using Result_std__shared_ptr_HybridBaseSpec__ = Result<std::shared_ptr<HybridBaseSpec>>;
-  inline Result_std__shared_ptr_HybridBaseSpec__ create_Result_std__shared_ptr_HybridBaseSpec__(const std::shared_ptr<HybridBaseSpec>& value) {
+  inline Result_std__shared_ptr_HybridBaseSpec__ create_Result_std__shared_ptr_HybridBaseSpec__(const std::shared_ptr<HybridBaseSpec>& value) noexcept {
     return Result<std::shared_ptr<HybridBaseSpec>>::withValue(value);
   }
-  inline Result_std__shared_ptr_HybridBaseSpec__ create_Result_std__shared_ptr_HybridBaseSpec__(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_HybridBaseSpec__ create_Result_std__shared_ptr_HybridBaseSpec__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<HybridBaseSpec>>::withError(error);
   }
-  
+
   // pragma MARK: Result<std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>>
   using Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__ = Result<std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>>;
-  inline Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__ create_Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__(const std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>& value) {
+  inline Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__ create_Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__(const std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>& value) noexcept {
     return Result<std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>>::withValue(value);
   }
-  inline Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__ create_Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__ create_Result_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec__(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>>::withError(error);
   }
 


### PR DESCRIPTION
Swift cannot catch C++ exceptions anyways.