### PR TITLE
fix: Throw better error message in default `HybridObject` constructor

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp
@@ -45,10 +45,12 @@ public:
   HybridObject(HybridObject&& move) = delete;
   /**
    * HybridObjects cannot be default-constructed!
+   * Use this instead;
+   * ```cpp
+   * MyHybridObject(): HybridObject(TAG) {}
+   * ```
    */
-  HybridObject() {
-    throw std::runtime_error("Cannot default-construct HybridObject!");
-  }
+  HybridObject() = delete;
 
 public:
   /**

--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp
@@ -50,7 +50,10 @@ public:
    * MyHybridObject(): HybridObject(TAG) {}
    * ```
    */
-  HybridObject() = delete;
+  HybridObject() {
+    throw std::runtime_error("Cannot default-construct HybridObject! "
+                             "Did you forget to add the `HybridObject(TAG)` base-constructor call to your Hybrid Object's constructor?");
+  }
 
 public:
   /**


### PR DESCRIPTION
avoids confusion.