### PR TITLE
feat: Add `CustomType<T1, T2>` type to nitrogen

### DIFF
--- a/packages/nitrogen/src/syntax/types/CustomType.ts
+++ b/packages/nitrogen/src/syntax/types/CustomType.ts
@@ -1,0 +1,48 @@
+import type { Language } from '../../getPlatformSpecs.js'
+import type { SourceFile, SourceImport } from '../SourceFile.js'
+import type { Type, TypeKind } from './Type.js'
+
+export class CustomType implements Type {
+  canBePassedByReference: boolean
+  typeName: string
+  headerImport: string
+
+  constructor(
+    canBePassedByReference: boolean,
+    typeName: string,
+    headerImport: string
+  ) {
+    this.canBePassedByReference = canBePassedByReference
+    this.typeName = typeName
+    this.headerImport = headerImport
+  }
+
+  get kind(): TypeKind {
+    return 'custom-type'
+  }
+
+  getCode(language: Language): string {
+    switch (language) {
+      case 'c++':
+        return this.typeName
+      default:
+        throw new Error(
+          `Language ${language} is not yet supported for CustomType "${this.typeName}"!`
+        )
+    }
+  }
+  getExtraFiles(): SourceFile[] {
+    return []
+  }
+  getRequiredImports(language: Language): SourceImport[] {
+    const imports: SourceImport[] = []
+    if (language === 'c++') {
+      imports.push({
+        name: this.headerImport,
+        language: 'c++',
+        space: 'user',
+      })
+    }
+    return imports
+  }
+}

--- a/packages/nitrogen/src/syntax/types/Type.ts
+++ b/packages/nitrogen/src/syntax/types/Type.ts
@@ -6,6 +6,7 @@ export type TypeKind =
   | 'array'
   | 'bigint'
   | 'boolean'
+  | 'custom-type'
   | 'enum'
   | 'error'
   | 'function'

--- a/packages/react-native-nitro-modules/src/CustomType.ts
+++ b/packages/react-native-nitro-modules/src/CustomType.ts
@@ -1,0 +1,9 @@
+/**
+ * Represents a custom, manually written native type.
+ * - {@linkcode TypeName}: Represents the name of the C++ class.
+ * - {@linkcode HeaderImport}: Represents the name of the C++ header that needs to be imported.
+ */
+export type CustomType<TypeName extends string, HeaderImport extends string> = {
+  __typeName?: TypeName
+  __headerImport?: HeaderImport
+}

--- a/packages/react-native-nitro-modules/src/index.ts
+++ b/packages/react-native-nitro-modules/src/index.ts
@@ -1,6 +1,7 @@
 export * from './HybridObject'
 export * from './NitroModules'
 export * from './AnyMap'
+export * from './CustomType'
 export * from './Constructor'
 export * from './Sync'
 

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -48,6 +48,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("passTuple", &HybridTestObjectCppSpec::passTuple);
       prototype.registerHybridMethod("newTestObject", &HybridTestObjectCppSpec::newTestObject);
       prototype.registerHybridMethod("getVariantHybrid", &HybridTestObjectCppSpec::getVariantHybrid);
+      prototype.registerHybridMethod("bounceNativeType", &HybridTestObjectCppSpec::bounceNativeType);
       prototype.registerHybridMethod("simpleFunc", &HybridTestObjectCppSpec::simpleFunc);
       prototype.registerHybridMethod("addNumbers", &HybridTestObjectCppSpec::addNumbers);
       prototype.registerHybridMethod("addStrings", &HybridTestObjectCppSpec::addStrings);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -55,6 +55,7 @@ namespace margelo::nitro::test::external { class HybridSomeExternalObjectSpec; }
 #include <functional>
 #include <variant>
 #include "Person.hpp"
+#include "SomeType.hpp"
 #include <NitroModules/AnyMap.hpp>
 #include <unordered_map>
 #include "MapWrapper.hpp"
@@ -135,6 +136,7 @@ namespace margelo::nitro::test {
       virtual std::tuple<double, std::string, bool> passTuple(const std::tuple<double, std::string, bool>& tuple) = 0;
       virtual std::shared_ptr<HybridTestObjectCppSpec> newTestObject() = 0;
       virtual std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person> getVariantHybrid(const std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person>& variant) = 0;
+      virtual SomeType bounceNativeType(SomeType value) = 0;
       virtual void simpleFunc() = 0;
       virtual double addNumbers(double a, double b) = 0;
       virtual std::string addStrings(const std::string& a, const std::string& b) = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -2,6 +2,7 @@ import {
   type HybridObject,
   type AnyMap,
   type Sync,
+  type CustomType,
 } from 'react-native-nitro-modules'
 import type { TestView } from './TestView.nitro'
 import type { SomeExternalObject } from 'react-native-nitro-test-external'
@@ -228,6 +229,10 @@ export interface TestObjectCpp
   newTestObject(): TestObjectCpp
   optionalHybrid?: TestObjectCpp
   getVariantHybrid(variant: TestObjectCpp | Person): TestObjectCpp | Person
+
+  bounceNativeType(
+    value: CustomType<'SomeType', 'SomeType.hpp'>
+  ): CustomType<'SomeType', 'SomeType.hpp'>
 }
 
 // This is a Swift/Kotlin-based `HybridObject`.


### PR DESCRIPTION
Adds a way to use custom C++ types. This is a pro-feature, because you are expected to be in the correct namespace and everything.

```ts
interface MyHybrid extends HybridObject {
  setValue(value: CustomType<'MyCustomType', 'MyCustomType.hpp'>): void
}
```

Then **you** need to add `MyCustomType.hpp` and implement `MyCustomType` + a `JSIConverter<MyCustomType>`:

```cpp
// MyCustomType.hpp

namespace margelo::nitro::dummy {
// struct, class or using alias
using MyCustomType = ...
}

namespace margelo::nitro {
// Implementation of JSIConverter<MyCustomType>
template<>
struct JSIConverter {
  jsi::Value toJSI(jsi::Runtime& runtime, MyCustomType value) { ... }
  MyCustomValue fromJSI(jsi::Runtime& runtime, jsi::Value value) { ... }
  bool canConvert(jsi::Runtime& runtime, jsi::Value value) { ... }
}
}
```

cc @jpudysz