### PR TITLE
feat: Add `NITRO_MIN_LOG_LEVEL` compiler flag

### DIFF
--- a/packages/react-native-nitro-modules/cpp/platform/NitroLogger.hpp
+++ b/packages/react-native-nitro-modules/cpp/platform/NitroLogger.hpp
@@ -16,6 +16,16 @@ namespace margelo::nitro {
 
 enum class LogLevel { Debug, Info, Warning, Error };
 
+constexpr LogLevel kMinLogLevel = [] {
+#ifdef NITRO_MIN_LOG_LEVEL
+    constexpr int v = NITRO_MIN_LOG_LEVEL; // passed via -DNITRO_MIN_LOG_LEVEL=0..3
+    static_assert(v >= 0 && v <= 3, "NITRO_MIN_LOG_LEVEL is out of range!");
+    return static_cast<LogLevel>(v);
+#else
+    return LogLevel::Warning; // default is just warning
+#endif
+}();
+
 class Logger final {
 private:
   Logger() = delete;
@@ -29,10 +39,13 @@ public:
     static_assert(all_are_trivially_copyable<Args...>(), "All arguments passed to Logger::log(..) must be trivially copyable! "
                                                          "Did you try to pass a complex type, like std::string?");
 
-    // 2. Format all arguments in the message
+    // 2. Make sure we want to enable those kinds of logs - if not, return
+    if (static_cast<int>(level) < static_cast<int>(kMinLogLevel)) return;
+
+    // 3. Format all arguments in the message
     std::string message = formatString(format, args...);
 
-    // 3. Call the platform specific log function
+    // 4. Call the platform specific log function
     nativeLog(level, tag, message);
 #endif
   }


### PR DESCRIPTION
Adds the compiler flag `NITRO_MIN_LOG_LEVEL`.

This flag can be used to set the minimum log level for the `NitroLogger` - if it is set to `0` (`Debug`), all logs will be visible. If it is set to `2` (`Warning`) (the default), only warnings and errors will be visible, and debug-/info-logs will be dropped.

This flag can and should be set in your App's Podfile/CMake file. If not set, `2` will be the default. In the Nitro Example app we set it to `0`.

- Fixes https://github.com/mrousavy/nitro/issues/883