### PR TITLE
fix: remove double spaces in nitrogen logs

### DIFF
--- a/packages/nitrogen/src/init.ts
+++ b/packages/nitrogen/src/init.ts
@@ -13,7 +13,7 @@ export async function initNewNitroModule(
   ref: string = 'main'
 ): Promise<void> {
   Logger.info(
-    `⚙️  Creating new Nitro Module "${chalk.bold(moduleName)}" in ${chalk.underline(prettifyDirectory(baseDirectory))}...`
+    `⚙️ Creating new Nitro Module "${chalk.bold(moduleName)}" in ${chalk.underline(prettifyDirectory(baseDirectory))}...`
   )
 
   const directory = path.join(baseDirectory, moduleName)
@@ -33,7 +33,7 @@ export async function initNewNitroModule(
     'packages/template',
     directory
   )
-  Logger.info(`🏗️  Constructing template...`)
+  Logger.info(`🏗️ Constructing template...`)
 
   const cleanLibraryName = moduleName.replace('react-native-', '')
   const cxxNamespace = cleanLibraryName.replaceAll('-', '')
@@ -118,7 +118,7 @@ async function downloadGitHubFolder(
     process.chdir(initialDir)
 
     Logger.debug(
-      `🗑️  Removing temporary folder ${chalk.underline(prettifyDirectory(tempDir))}...`
+      `🗑️ Removing temporary folder ${chalk.underline(prettifyDirectory(tempDir))}...`
     )
     await fs.rm(tempDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
Removes unnecessary spaces when creating a Nitro Module using nitrogen (see screenshot below).

<img width="1234" height="147" alt="Screenshot 2025-09-19 at 15 21 36" src="https://github.com/user-attachments/assets/c8c8ad04-3cd1-4a81-b09d-123171eb6fb6" />

If these spaces were intentional, feel free to close this PR. I just started trying Nitro Modules and noticed it. I'd love to learn and contribute to this project. Looks like a great, easy first contribution!