### PR TITLE
feat: Add `@final` JS Doc to make Hybrid Objects final

### DIFF
--- a/docs/docs/hybrid-objects.md
+++ b/docs/docs/hybrid-objects.md
@@ -266,6 +266,18 @@ A Hybrid Object can either inherit from other Hybrid Objects, or satisfy a commo
   interface Video extends HybridObject, Media {}
   ```
 
+  ### Final HybridObjects
+
+  By default, all Hybrid Objects are subclassable. To make a Hybrid Object final (and therefore non-subclassable), you can add the `@final` JS-Doc annotation to it's declaration:
+
+  ```ts
+  interface Subclassable extends HybridObject {}
+  /**
+   * @final
+   */
+  interface NotSubclassable extends HybridObject {}
+  ```
+
   </TabItem>
   <TabItem value="manually" label="Manually">
 

--- a/packages/nitrogen/src/createPlatformSpec.ts
+++ b/packages/nitrogen/src/createPlatformSpec.ts
@@ -146,6 +146,15 @@ function getHybridObjectSpec(type: Type, language: Language): HybridObjectSpec {
     .filter((t) => isAnyHybridSubclass(t))
     .map((t) => getHybridObjectSpec(t, language))
 
+  for (const base of bases) {
+    if (base.isFinal) {
+      throw new Error(
+        `HybridObject "${base.name}" is final (@final) and cannot be subclassed! ` +
+          `(Subclassed in "${name}")`
+      )
+    }
+  }
+
   const spec: HybridObjectSpec = {
     language: language,
     name: name,

--- a/packages/nitrogen/src/createPlatformSpec.ts
+++ b/packages/nitrogen/src/createPlatformSpec.ts
@@ -69,6 +69,7 @@ function getHybridObjectSpec(type: Type, language: Language): HybridObjectSpec {
       methods: methodsSpec?.methods ?? [],
       properties: propsSpec.properties,
       name: name,
+      isFinal: true,
       config: config,
     }
   }
@@ -138,6 +139,9 @@ function getHybridObjectSpec(type: Type, language: Language): HybridObjectSpec {
     }
   }
 
+  const jsDocs = symbol.getJsDocTags()
+  const isFinal = jsDocs.some((j) => j.getName() === 'final')
+
   const bases = getBaseTypes(type)
     .filter((t) => isAnyHybridSubclass(t))
     .map((t) => getHybridObjectSpec(t, language))
@@ -149,6 +153,7 @@ function getHybridObjectSpec(type: Type, language: Language): HybridObjectSpec {
     methods: methods,
     baseTypes: bases,
     isHybridView: isHybridView(type),
+    isFinal: isFinal,
     config: config,
   }
   return spec

--- a/packages/nitrogen/src/syntax/HybridObjectSpec.ts
+++ b/packages/nitrogen/src/syntax/HybridObjectSpec.ts
@@ -10,5 +10,6 @@ export interface HybridObjectSpec {
   methods: Method[]
   baseTypes: HybridObjectSpec[]
   isHybridView: boolean
+  isFinal: boolean
   config: NitroConfig
 }

--- a/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
@@ -36,7 +36,8 @@ export function createFbjniHybridObject(spec: HybridObjectSpec): SourceFile[] {
     name.HybridTSpec
   )
   const cxxNamespace = spec.config.getCxxNamespace('c++')
-  const spaces = createIndentation(name.JHybridTSpec.length)
+  const maybeFinal = spec.isFinal ? `final` : ``
+  const spaces = createIndentation(name.JHybridTSpec.length + maybeFinal.length)
 
   let cppBase = 'JHybridObject'
   if (spec.baseTypes.length > 0) {
@@ -90,7 +91,7 @@ namespace ${cxxNamespace} {
 
   using namespace facebook;
 
-  class ${name.JHybridTSpec}: public jni::HybridClass<${name.JHybridTSpec}, ${cppBase}>,
+  class ${name.JHybridTSpec} ${maybeFinal}: public jni::HybridClass<${name.JHybridTSpec}, ${cppBase}>,
 ${spaces}          public virtual ${name.HybridTSpec} {
   public:
     static auto constexpr kJavaDescriptor = "L${jniClassDescriptor};";

--- a/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
+++ b/packages/nitrogen/src/syntax/kotlin/FbjniHybridObject.ts
@@ -92,7 +92,7 @@ namespace ${cxxNamespace} {
   using namespace facebook;
 
   class ${name.JHybridTSpec} ${maybeFinal}: public jni::HybridClass<${name.JHybridTSpec}, ${cppBase}>,
-${spaces}          public virtual ${name.HybridTSpec} {
+${spaces}           public virtual ${name.HybridTSpec} {
   public:
     static auto constexpr kJavaDescriptor = "L${jniClassDescriptor};";
     static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObject.ts
@@ -45,9 +45,13 @@ export function createSwiftHybridObject(spec: HybridObjectSpec): SourceFile[] {
   } else {
     baseMembers.push(`public init() { }`)
   }
+
+  let funcModifier = `func`
+  if (spec.isFinal) funcModifier = `final ${funcModifier}`
+  if (hasBaseClass) funcModifier = `override ${funcModifier}`
   baseMembers.push(
     `
-public ${hasBaseClass ? 'override func' : 'func'} getCxxWrapper() -> ${name.HybridTSpecCxx} {
+public ${funcModifier} getCxxWrapper() -> ${name.HybridTSpecCxx} {
 #if DEBUG
   guard self is ${name.HybridTSpec} else {
     fatalError("\`self\` is not a \`${name.HybridTSpec}\`! Did you accidentally inherit from \`${name.HybridTSpec}_base\` instead of \`${name.HybridTSpec}\`?")

--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -117,6 +117,9 @@ public override func getCxxPart() -> bridge.${baseBridge.specializationName} {
     ...extraSwiftImports.map((i) => `import ${i.name}`).filter(isNotDuplicate)
   )
 
+  const classModifier = spec.isFinal ? `public final class` : `open class`
+  const inheritance = hasBase ? `: ${baseClasses.join(', ')}` : ``
+
   const swiftCxxWrapperCode = `
 ${createFileMetadataString(`${name.HybridTSpecCxx}.swift`)}
 
@@ -132,7 +135,7 @@ ${imports.join('\n')}
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-${hasBase ? `open class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : `open class ${name.HybridTSpecCxx}`} {
+${classModifier} ${name.HybridTSpecCxx}${inheritance} {
   /**
    * The Swift <> C++ bridge's namespace (\`${NitroConfig.current.getSwiftBridgeNamespace('c++')}\`)
    * from \`${moduleName}-Swift-Cxx-Bridge.hpp\`.

--- a/packages/react-native-nitro-test-external/nitrogen/generated/android/c++/JHybridSomeExternalObjectSpec.hpp
+++ b/packages/react-native-nitro-test-external/nitrogen/generated/android/c++/JHybridSomeExternalObjectSpec.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::test::external {
   using namespace facebook;
 
   class JHybridSomeExternalObjectSpec : public jni::HybridClass<JHybridSomeExternalObjectSpec, JHybridObject>,
-                                       public virtual HybridSomeExternalObjectSpec {
+                                        public virtual HybridSomeExternalObjectSpec {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/test/external/HybridSomeExternalObjectSpec;";
     static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);

--- a/packages/react-native-nitro-test-external/nitrogen/generated/android/c++/JHybridSomeExternalObjectSpec.hpp
+++ b/packages/react-native-nitro-test-external/nitrogen/generated/android/c++/JHybridSomeExternalObjectSpec.hpp
@@ -18,7 +18,7 @@ namespace margelo::nitro::test::external {
 
   using namespace facebook;
 
-  class JHybridSomeExternalObjectSpec: public jni::HybridClass<JHybridSomeExternalObjectSpec, JHybridObject>,
+  class JHybridSomeExternalObjectSpec : public jni::HybridClass<JHybridSomeExternalObjectSpec, JHybridObject>,
                                        public virtual HybridSomeExternalObjectSpec {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/test/external/HybridSomeExternalObjectSpec;";

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridBaseSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridBaseSpec.hpp
@@ -18,7 +18,7 @@ namespace margelo::nitro::test {
 
   using namespace facebook;
 
-  class JHybridBaseSpec: public jni::HybridClass<JHybridBaseSpec, JHybridObject>,
+  class JHybridBaseSpec : public jni::HybridClass<JHybridBaseSpec, JHybridObject>,
                          public virtual HybridBaseSpec {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/test/HybridBaseSpec;";

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridBaseSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridBaseSpec.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   class JHybridBaseSpec : public jni::HybridClass<JHybridBaseSpec, JHybridObject>,
-                         public virtual HybridBaseSpec {
+                          public virtual HybridBaseSpec {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/test/HybridBaseSpec;";
     static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridChildSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridChildSpec.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::test {
 
   using namespace facebook;
 
-  class JHybridChildSpec: public jni::HybridClass<JHybridChildSpec, JHybridBaseSpec>,
+  class JHybridChildSpec : public jni::HybridClass<JHybridChildSpec, JHybridBaseSpec>,
                           public virtual HybridChildSpec {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/test/HybridChildSpec;";

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridChildSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridChildSpec.hpp
@@ -19,8 +19,8 @@ namespace margelo::nitro::test {
 
   using namespace facebook;
 
-  class JHybridChildSpec : public jni::HybridClass<JHybridChildSpec, JHybridBaseSpec>,
-                          public virtual HybridChildSpec {
+  class JHybridChildSpec final: public jni::HybridClass<JHybridChildSpec, JHybridBaseSpec>,
+                                public virtual HybridChildSpec {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/test/HybridChildSpec;";
     static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -18,7 +18,7 @@ namespace margelo::nitro::test {
 
   using namespace facebook;
 
-  class JHybridTestObjectSwiftKotlinSpec: public jni::HybridClass<JHybridTestObjectSwiftKotlinSpec, JHybridObject>,
+  class JHybridTestObjectSwiftKotlinSpec : public jni::HybridClass<JHybridTestObjectSwiftKotlinSpec, JHybridObject>,
                                           public virtual HybridTestObjectSwiftKotlinSpec {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec;";

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   class JHybridTestObjectSwiftKotlinSpec : public jni::HybridClass<JHybridTestObjectSwiftKotlinSpec, JHybridObject>,
-                                          public virtual HybridTestObjectSwiftKotlinSpec {
+                                           public virtual HybridTestObjectSwiftKotlinSpec {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec;";
     static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
@@ -18,8 +18,8 @@ namespace margelo::nitro::test {
 
   using namespace facebook;
 
-  class JHybridTestViewSpec: public jni::HybridClass<JHybridTestViewSpec, JHybridObject>,
-                             public virtual HybridTestViewSpec {
+  class JHybridTestViewSpec final: public jni::HybridClass<JHybridTestViewSpec, JHybridObject>,
+                                  public virtual HybridTestViewSpec {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/test/HybridTestViewSpec;";
     static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   class JHybridTestViewSpec final: public jni::HybridClass<JHybridTestViewSpec, JHybridObject>,
-                                  public virtual HybridTestViewSpec {
+                                   public virtual HybridTestViewSpec {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/test/HybridTestViewSpec;";
     static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -21,7 +21,7 @@ public protocol HybridChildSpec_protocol: HybridObject, HybridBaseSpec_protocol 
 open class HybridChildSpec_base: HybridBaseSpec_base {
   private weak var cxxWrapper: HybridChildSpec_cxx? = nil
   public override init() { super.init() }
-  public override func getCxxWrapper() -> HybridChildSpec_cxx {
+  public override final func getCxxWrapper() -> HybridChildSpec_cxx {
   #if DEBUG
     guard self is HybridChildSpec else {
       fatalError("`self` is not a `HybridChildSpec`! Did you accidentally inherit from `HybridChildSpec_base` instead of `HybridChildSpec`?")

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
@@ -17,7 +17,7 @@ import NitroModules
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-open class HybridChildSpec_cxx : HybridBaseSpec_cxx {
+open class HybridChildSpec_cxx: HybridBaseSpec_cxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::test::bridge::swift`)
    * from `NitroTest-Swift-Cxx-Bridge.hpp`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
@@ -17,7 +17,7 @@ import NitroModules
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-open class HybridChildSpec_cxx: HybridBaseSpec_cxx {
+public final class HybridChildSpec_cxx: HybridBaseSpec_cxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::test::bridge::swift`)
    * from `NitroTest-Swift-Cxx-Bridge.hpp`.

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
@@ -24,7 +24,7 @@ public protocol HybridTestViewSpec_protocol: HybridObject, HybridView {
 open class HybridTestViewSpec_base {
   private weak var cxxWrapper: HybridTestViewSpec_cxx? = nil
   public init() { }
-  public func getCxxWrapper() -> HybridTestViewSpec_cxx {
+  public final func getCxxWrapper() -> HybridTestViewSpec_cxx {
   #if DEBUG
     guard self is HybridTestViewSpec else {
       fatalError("`self` is not a `HybridTestViewSpec`! Did you accidentally inherit from `HybridTestViewSpec_base` instead of `HybridTestViewSpec`?")

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
@@ -17,7 +17,7 @@ import NitroModules
  * - Other HybridObjects need to be wrapped/unwrapped from the Swift TCxx wrapper
  * - Throwing methods need to be wrapped with a Result<T, Error> type, as exceptions cannot be propagated to C++
  */
-open class HybridTestViewSpec_cxx {
+public final class HybridTestViewSpec_cxx {
   /**
    * The Swift <> C++ bridge's namespace (`margelo::nitro::test::bridge::swift`)
    * from `NitroTest-Swift-Cxx-Bridge.hpp`.

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -268,6 +268,9 @@ export interface Base
 // This is a `HybridObject` that actually inherits from a different `HybridObject`.
 // This will set up an inheritance chain on the native side.
 // The native `Child` Swift/Kotlin class will inherit from the `Base` Swift/Kotlin class.
+/**
+ * @final
+ */
 export interface Child extends Base {
   readonly childValue: number
   // tests if the same variant can be used in a different HybridObject


### PR DESCRIPTION
By default, `HybridObject`s are subclassable. This PR adds an `@final` JS Doc to `HybridObjects` to make them final (therefore **not** subclassable):

```ts
interface A { value: number }
/** 
 * @final 
 */
interface B { value: number }
```

In this example, `A` is subclassable, while `B` is not.