### PR TITLE
fix: Make `structs` not primitively copyable

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -22,7 +22,6 @@ import { VariantType } from '../types/VariantType.js'
 import { getReferencedTypes } from '../getReferencedTypes.js'
 import {
   createSwiftCxxHelpers,
-  isPrimitivelyCopyable,
   type SwiftCxxHelper,
 } from './SwiftCxxTypeHelper.js'
 import { createSwiftEnumBridge } from './SwiftEnum.js'
@@ -33,6 +32,7 @@ import { NamedWrappingType } from '../types/NamedWrappingType.js'
 import { ErrorType } from '../types/ErrorType.js'
 import { createSwiftFunctionBridge } from './SwiftFunction.js'
 import type { Language } from '../../getPlatformSpecs.js'
+import { isPrimitivelyCopyable } from './isPrimitivelyCopyable.js'
 
 // TODO: Remove enum bridge once Swift fixes bidirectional enums crashing the `-Swift.h` header.
 

--- a/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxTypeHelper.ts
@@ -19,6 +19,7 @@ import { VoidType } from '../types/VoidType.js'
 import { NamedWrappingType } from '../types/NamedWrappingType.js'
 import { ErrorType } from '../types/ErrorType.js'
 import { ResultWrappingType } from '../types/ResultWrappingType.js'
+import { isPrimitivelyCopyable } from './isPrimitivelyCopyable.js'
 
 export interface SwiftCxxHelper {
   cxxHeader: {
@@ -258,11 +259,6 @@ inline ${wrappedBridge.getTypeCode('c++')} get_${name}(const ${actualType}& opti
     },
     dependencies: [],
   }
-}
-
-export function isPrimitivelyCopyable(type: Type): boolean {
-  const bridgedType = new SwiftCxxBridgedType(type, true)
-  return !bridgedType.needsSpecialHandling
 }
 
 /**

--- a/packages/nitrogen/src/syntax/swift/isPrimitivelyCopyable.ts
+++ b/packages/nitrogen/src/syntax/swift/isPrimitivelyCopyable.ts
@@ -1,0 +1,20 @@
+import type { Type } from '../types/Type.js'
+
+/**
+ * Returns `true` if the given {@linkcode type} is a datatype that
+ * can be copied without running a copy constructor or special logic
+ * to copy the data over. In other words; it's _primitively copyable_.
+ */
+export function isPrimitivelyCopyable(type: Type): boolean {
+  switch (type.kind) {
+    case 'number':
+    case 'boolean':
+    case 'bigint':
+    case 'enum':
+    case 'null':
+    case 'void':
+      return true
+    default:
+      return false
+  }
+}

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -268,11 +268,10 @@ namespace margelo::nitro::test::bridge::swift {
    * Specialized version of `std::vector<Person>`.
    */
   using std__vector_Person_ = std::vector<Person>;
-  inline std::vector<Person> copy_std__vector_Person_(const Person* CONTIGUOUS_MEMORY NON_NULL data, size_t size) noexcept {
-    return margelo::nitro::FastVectorCopy<Person>(data, size);
-  }
-  inline const Person* CONTIGUOUS_MEMORY NON_NULL get_data_std__vector_Person_(const std::vector<Person>& vector) noexcept {
-    return vector.data();
+  inline std::vector<Person> create_std__vector_Person_(size_t size) noexcept {
+    std::vector<Person> vector;
+    vector.reserve(size);
+    return vector;
   }
   
   // pragma MARK: std::vector<Powertrain>

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -529,14 +529,14 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func bounceStructs(array: bridge.std__vector_Person_) -> bridge.Result_std__vector_Person__ {
     do {
-      let __result = try self.__implementation.bounceStructs(array: { () -> [Person] in
-        let __data = bridge.get_data_std__vector_Person_(array)
-        let __size = array.size()
-        return Array(UnsafeBufferPointer(start: __data, count: __size))
-      }())
-      let __resultCpp = __result.withUnsafeBufferPointer { __pointer -> bridge.std__vector_Person_ in
-        return bridge.copy_std__vector_Person_(__pointer.baseAddress!, __result.count)
-      }
+      let __result = try self.__implementation.bounceStructs(array: array.map({ __item in __item }))
+      let __resultCpp = { () -> bridge.std__vector_Person_ in
+        var __vector = bridge.create_std__vector_Person_(__result.count)
+        for __item in __result {
+          __vector.push_back(__item)
+        }
+        return __vector
+      }()
       return bridge.create_Result_std__vector_Person__(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()


### PR DESCRIPTION
- Fixes #930
- Fixes https://github.com/mrousavy/nitro/issues/922
- Fixes the breaking test that was added in https://github.com/mrousavy/nitro/pull/937