### PR TITLE
chore: Reproduce trailing optional boolean bug

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -655,6 +655,16 @@ export function getTests(
         .didNotThrow()
         .equals(undefined)
     ),
+    createTest('tryTrailingOptional(...)', () =>
+      it(() => testObject.tryTrailingOptional(0, '', false))
+        .didNotThrow()
+        .equals(false)
+    ),
+    createTest('tryTrailingOptional(...)', () =>
+      it(() => testObject.tryTrailingOptional(0, '', true))
+        .didNotThrow()
+        .equals(true)
+    ),
 
     // Variants tests
     createTest('set someVariant to 55', () =>

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -142,6 +142,11 @@ class HybridTestObjectKotlin: HybridTestObjectSwiftKotlinSpec() {
         return value
     }
 
+
+    override fun tryTrailingOptional(num: Double, str: String, boo: Boolean?): Boolean {
+        return boo ?: false
+    }
+
     override fun bounceMap(map: Map<String, Variant_Double_Boolean>): Map<String, Variant_Double_Boolean> {
         return map
     }

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -250,6 +250,10 @@ std::optional<Powertrain> HybridTestObjectCpp::tryOptionalEnum(std::optional<Pow
   return value;
 }
 
+bool HybridTestObjectCpp::tryTrailingOptional(double /* num */, const std::string& /* str */, std::optional<bool> boo) {
+  return boo.has_value() ? boo.value() : false;
+}
+
 std::chrono::system_clock::time_point HybridTestObjectCpp::add1Hour(std::chrono::system_clock::time_point date) {
   return date + std::chrono::hours(1);
 }

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -93,6 +93,7 @@ public:
   std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) override;
   std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) override;
   std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) override;
+  bool tryTrailingOptional(double num, const std::string& str, std::optional<bool> boo) override;
   std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) override;
   std::chrono::system_clock::time_point currentDate() override;
   std::variant<std::string, double>

--- a/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
@@ -198,6 +198,10 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
     return value
   }
 
+  func tryTrailingOptional(num: Double, str: String, boo: Bool?) throws -> Bool {
+    return boo ?? false
+  }
+
   func add1Hour(date: Date) throws -> Date {
     let oneHourInSeconds = 1.0 * 60 * 60
     return date + oneHourInSeconds
@@ -420,7 +424,7 @@ class HybridTestObjectSwift : HybridTestObjectSwiftKotlinSpec {
       optionalCallback(13.0)
     }
   }
-  
+
   private let formatter: NumberFormatter = {
     let formatter = NumberFormatter()
     formatter.minimumFractionDigits = 0

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -510,6 +510,11 @@ namespace margelo::nitro::test {
     auto __result = method(_javaPart, value.has_value() ? JPowertrain::fromCpp(value.value()) : nullptr);
     return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
+  bool JHybridTestObjectSwiftKotlinSpec::tryTrailingOptional(double num, const std::string& str, std::optional<bool> boo) {
+    static const auto method = javaClassStatic()->getMethod<jboolean(double /* num */, jni::alias_ref<jni::JString> /* str */, jni::alias_ref<jni::JBoolean> /* boo */)>("tryTrailingOptional");
+    auto __result = method(_javaPart, num, jni::make_jstring(str), boo.has_value() ? jni::JBoolean::valueOf(boo.value()) : nullptr);
+    return static_cast<bool>(__result);
+  }
   std::chrono::system_clock::time_point JHybridTestObjectSwiftKotlinSpec::add1Hour(std::chrono::system_clock::time_point date) {
     static const auto method = javaClassStatic()->getMethod<jni::local_ref<JInstant>(jni::alias_ref<JInstant> /* date */)>("add1Hour");
     auto __result = method(_javaPart, JInstant::fromChrono(date));

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -102,6 +102,7 @@ namespace margelo::nitro::test {
     std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) override;
     std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) override;
     std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) override;
+    bool tryTrailingOptional(double num, const std::string& str, std::optional<bool> boo) override;
     std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) override;
     std::chrono::system_clock::time_point currentDate() override;
     int64_t calculateFibonacciSync(double value) override;

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
@@ -228,6 +228,10 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun tryTrailingOptional(num: Double, str: String, boo: Boolean?): Boolean
+  
+  @DoNotStrip
+  @Keep
   abstract fun add1Hour(date: java.time.Instant): java.time.Instant
   
   @DoNotStrip

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -1279,6 +1279,15 @@ namespace margelo::nitro::test::bridge::swift {
     return Result<std::optional<Powertrain>>::withError(error);
   }
   
+  // pragma MARK: Result<bool>
+  using Result_bool_ = Result<bool>;
+  inline Result_bool_ create_Result_bool_(bool value) noexcept {
+    return Result<bool>::withValue(std::move(value));
+  }
+  inline Result_bool_ create_Result_bool_(const std::exception_ptr& error) noexcept {
+    return Result<bool>::withError(error);
+  }
+  
   // pragma MARK: Result<std::chrono::system_clock::time_point>
   using Result_std__chrono__system_clock__time_point_ = Result<std::chrono::system_clock::time_point>;
   inline Result_std__chrono__system_clock__time_point_ create_Result_std__chrono__system_clock__time_point_(std::chrono::system_clock::time_point value) noexcept {
@@ -1349,15 +1358,6 @@ namespace margelo::nitro::test::bridge::swift {
   }
   inline Result_Car_ create_Result_Car_(const std::exception_ptr& error) noexcept {
     return Result<Car>::withError(error);
-  }
-  
-  // pragma MARK: Result<bool>
-  using Result_bool_ = Result<bool>;
-  inline Result_bool_ create_Result_bool_(bool value) noexcept {
-    return Result<bool>::withValue(std::move(value));
-  }
-  inline Result_bool_ create_Result_bool_(const std::exception_ptr& error) noexcept {
-    return Result<bool>::withError(error);
   }
   
   // pragma MARK: Result<std::optional<Person>>

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -386,6 +386,14 @@ namespace margelo::nitro::test {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline bool tryTrailingOptional(double num, const std::string& str, std::optional<bool> boo) override {
+      auto __result = _swiftPart.tryTrailingOptional(std::forward<decltype(num)>(num), str, boo);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) override {
       auto __result = _swiftPart.add1Hour(date);
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -51,6 +51,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func tryOptionalParams(num: Double, boo: Bool, str: String?) throws -> String
   func tryMiddleParam(num: Double, boo: Bool?, str: String) throws -> String
   func tryOptionalEnum(value: Powertrain?) throws -> Powertrain?
+  func tryTrailingOptional(num: Double, str: String, boo: Bool?) throws -> Bool
   func add1Hour(date: Date) throws -> Date
   func currentDate() throws -> Date
   func calculateFibonacciSync(value: Double) throws -> Int64

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -793,6 +793,18 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
   }
   
   @inline(__always)
+  public final func tryTrailingOptional(num: Double, str: std.string, boo: bridge.std__optional_bool_) -> bridge.Result_bool_ {
+    do {
+      let __result = try self.__implementation.tryTrailingOptional(num: num, str: String(str), boo: boo.value)
+      let __resultCpp = __result
+      return bridge.create_Result_bool_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_bool_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func add1Hour(date: margelo.nitro.chrono_time) -> bridge.Result_std__chrono__system_clock__time_point_ {
     do {
       let __result = try self.__implementation.add1Hour(date: Date(fromChrono: date))

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -70,6 +70,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("tryOptionalParams", &HybridTestObjectCppSpec::tryOptionalParams);
       prototype.registerHybridMethod("tryMiddleParam", &HybridTestObjectCppSpec::tryMiddleParam);
       prototype.registerHybridMethod("tryOptionalEnum", &HybridTestObjectCppSpec::tryOptionalEnum);
+      prototype.registerHybridMethod("tryTrailingOptional", &HybridTestObjectCppSpec::tryTrailingOptional);
       prototype.registerHybridMethod("add1Hour", &HybridTestObjectCppSpec::add1Hour);
       prototype.registerHybridMethod("currentDate", &HybridTestObjectCppSpec::currentDate);
       prototype.registerHybridMethod("calculateFibonacciSync", &HybridTestObjectCppSpec::calculateFibonacciSync);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -161,6 +161,7 @@ namespace margelo::nitro::test {
       virtual std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) = 0;
       virtual std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) = 0;
       virtual std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) = 0;
+      virtual bool tryTrailingOptional(double num, const std::string& str, std::optional<bool> boo) = 0;
       virtual std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) = 0;
       virtual std::chrono::system_clock::time_point currentDate() = 0;
       virtual int64_t calculateFibonacciSync(double value) = 0;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -64,6 +64,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("tryOptionalParams", &HybridTestObjectSwiftKotlinSpec::tryOptionalParams);
       prototype.registerHybridMethod("tryMiddleParam", &HybridTestObjectSwiftKotlinSpec::tryMiddleParam);
       prototype.registerHybridMethod("tryOptionalEnum", &HybridTestObjectSwiftKotlinSpec::tryOptionalEnum);
+      prototype.registerHybridMethod("tryTrailingOptional", &HybridTestObjectSwiftKotlinSpec::tryTrailingOptional);
       prototype.registerHybridMethod("add1Hour", &HybridTestObjectSwiftKotlinSpec::add1Hour);
       prototype.registerHybridMethod("currentDate", &HybridTestObjectSwiftKotlinSpec::currentDate);
       prototype.registerHybridMethod("calculateFibonacciSync", &HybridTestObjectSwiftKotlinSpec::calculateFibonacciSync);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -153,6 +153,7 @@ namespace margelo::nitro::test {
       virtual std::string tryOptionalParams(double num, bool boo, const std::optional<std::string>& str) = 0;
       virtual std::string tryMiddleParam(double num, std::optional<bool> boo, const std::string& str) = 0;
       virtual std::optional<Powertrain> tryOptionalEnum(std::optional<Powertrain> value) = 0;
+      virtual bool tryTrailingOptional(double num, const std::string& str, std::optional<bool> boo) = 0;
       virtual std::chrono::system_clock::time_point add1Hour(std::chrono::system_clock::time_point date) = 0;
       virtual std::chrono::system_clock::time_point currentDate() = 0;
       virtual int64_t calculateFibonacciSync(double value) = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -136,6 +136,7 @@ interface SharedTestObjectProps {
   tryOptionalParams(num: number, boo: boolean, str?: string): string
   tryMiddleParam(num: number, boo: boolean | undefined, str: string): string
   tryOptionalEnum(value?: Powertrain): Powertrain | undefined
+  tryTrailingOptional(num: number, str: string, boo?: boolean): boolean
 
   // Variants
   someVariant: number | string


### PR DESCRIPTION
Reproduces the bug reported in https://github.com/mrousavy/nitro/issues/876, where a trailing optional boolean holds the wrong value in release builds.

Here it is failing in release:

<img width="564" height="1062" alt="image" src="https://github.com/user-attachments/assets/a973bcca-5cf5-48ab-bb35-31c76288b366" />
