### PR TITLE
fix: Fix trailing optional booleans never being `true`

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -449,7 +449,10 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
                 return `${cppParameterName}.has_value() ? ${cppParameterName}.pointee : nil`
               }
             }
-            if (!wrapping.needsSpecialHandling) {
+            // TODO: Remove this check for booleans once https://github.com/swiftlang/swift/issues/84848 is fixed.
+            const swiftBug84848Workaround =
+              optional.wrappingType.kind === 'boolean'
+            if (!wrapping.needsSpecialHandling && !swiftBug84848Workaround) {
               return `${cppParameterName}.value`
             }
             return `

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Car.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Car.swift
@@ -140,7 +140,14 @@ public extension Car {
   var isFast: Bool? {
     @inline(__always)
     get {
-      return self.__isFast.value
+      return { () -> Bool? in
+        if bridge.has_value_std__optional_bool_(self.__isFast) {
+          let __unwrapped = bridge.get_std__optional_bool_(self.__isFast)
+          return __unwrapped
+        } else {
+          return nil
+        }
+      }()
     }
     @inline(__always)
     set {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -765,7 +765,14 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func tryMiddleParam(num: Double, boo: bridge.std__optional_bool_, str: std.string) -> bridge.Result_std__string_ {
     do {
-      let __result = try self.__implementation.tryMiddleParam(num: num, boo: boo.value, str: String(str))
+      let __result = try self.__implementation.tryMiddleParam(num: num, boo: { () -> Bool? in
+        if bridge.has_value_std__optional_bool_(boo) {
+          let __unwrapped = bridge.get_std__optional_bool_(boo)
+          return __unwrapped
+        } else {
+          return nil
+        }
+      }(), str: String(str))
       let __resultCpp = std.string(__result)
       return bridge.create_Result_std__string_(__resultCpp)
     } catch (let __error) {
@@ -795,7 +802,14 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
   @inline(__always)
   public final func tryTrailingOptional(num: Double, str: std.string, boo: bridge.std__optional_bool_) -> bridge.Result_bool_ {
     do {
-      let __result = try self.__implementation.tryTrailingOptional(num: num, str: String(str), boo: boo.value)
+      let __result = try self.__implementation.tryTrailingOptional(num: num, str: String(str), boo: { () -> Bool? in
+        if bridge.has_value_std__optional_bool_(boo) {
+          let __unwrapped = bridge.get_std__optional_bool_(boo)
+          return __unwrapped
+        } else {
+          return nil
+        }
+      }())
       let __resultCpp = __result
       return bridge.create_Result_bool_(__resultCpp)
     } catch (let __error) {


### PR DESCRIPTION
- Fixes #876 
- Should be removed once the bug is fixed in the Swift compiler (https://github.com/swiftlang/swift/issues/84848)