### PR TITLE
chore: Use Kotlin method syntax again

### DIFF
--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/NitroModules.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/NitroModules.kt
@@ -23,7 +23,9 @@ class NitroModules internal constructor(
     applicationContext = context
   }
 
-  override fun getName(): String = NAME
+  override fun getName(): String {
+    return NAME
+  }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   override fun install(): String? {

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/NitroModulesPackage.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/NitroModulesPackage.kt
@@ -10,15 +10,16 @@ class NitroModulesPackage : TurboReactPackage() {
   override fun getModule(
     name: String,
     reactContext: ReactApplicationContext,
-  ): NativeModule? =
-    if (name == NitroModules.NAME) {
+  ): NativeModule? {
+    return if (name == NitroModules.NAME) {
       NitroModules(reactContext)
     } else {
       null
     }
+  }
 
-  override fun getReactModuleInfoProvider(): ReactModuleInfoProvider =
-    ReactModuleInfoProvider {
+  override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
+    return ReactModuleInfoProvider {
       val moduleInfos: MutableMap<String, ReactModuleInfo> = HashMap()
       val isTurboModule: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
       moduleInfos[NitroModules.NAME] =
@@ -33,4 +34,5 @@ class NitroModulesPackage : TurboReactPackage() {
         )
       moduleInfos
     }
+  }
 }

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt
@@ -76,7 +76,9 @@ class ArrayBuffer {
    * the foreign data needs to be either _wrapped_, or _copied_ to be represented as a `ByteBuffer`.
    * This flag controls that behaviour.
    */
-  fun getBuffer(copyIfNeeded: Boolean): ByteBuffer = getByteBuffer(copyIfNeeded)
+  fun getBuffer(copyIfNeeded: Boolean): ByteBuffer {
+    return getByteBuffer(copyIfNeeded)
+  }
 
   /**
    * Get the underlying `HardwareBuffer` if this `ArrayBuffer` was created with one.
@@ -206,6 +208,8 @@ class ArrayBuffer {
      * Wrap the given `HardwareBuffer` in a new **owning** `ArrayBuffer`.
      */
     @RequiresApi(Build.VERSION_CODES.O)
-    fun wrap(hardwareBuffer: HardwareBuffer): ArrayBuffer = ArrayBuffer(hardwareBuffer)
+    fun wrap(hardwareBuffer: HardwareBuffer): ArrayBuffer {
+      return ArrayBuffer(hardwareBuffer)
+    }
   }
 }

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
@@ -87,11 +87,12 @@ class Promise<T> {
    * otherwise it will asynchronously wait for a result or throw on a rejection.
    * This function can only be used from a coroutine context.
    */
-  suspend fun await(): T =
-    suspendCoroutine { continuation ->
+  suspend fun await(): T {
+    return suspendCoroutine { continuation ->
       then { result -> continuation.resume(result) }
       catch { error -> continuation.resumeWithException(error) }
     }
+  }
 
   // C++ functions
   private external fun nativeResolve(result: Any)
@@ -174,11 +175,15 @@ class Promise<T> {
     /**
      * Creates a new Promise that is already resolved with the given result.
      */
-    fun <T> resolved(result: T): Promise<T> = Promise<T>().apply { resolve(result) }
+    fun <T> resolved(result: T): Promise<T> {
+      return Promise<T>().apply { resolve(result) }
+    }
 
     /**
      * Creates a new Promise that is already rejected with the given error.
      */
-    fun <T> rejected(error: Throwable): Promise<T> = Promise<T>().apply { reject(error) }
+    fun <T> rejected(error: Throwable): Promise<T> {
+      return Promise<T>().apply { reject(error) }
+    }
   }
 }

--- a/packages/react-native-nitro-test-external/android/src/main/java/com/margelo/nitro/test/external/HybridSomeExternalObject.kt
+++ b/packages/react-native-nitro-test-external/android/src/main/java/com/margelo/nitro/test/external/HybridSomeExternalObject.kt
@@ -1,5 +1,7 @@
 package com.margelo.nitro.test.external
 
 class HybridSomeExternalObject : HybridSomeExternalObjectSpec() {
-  override fun getValue(): String = "Hello world!"
+  override fun getValue(): String {
+    return "Hello world!"
+  }
 }

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridChild.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridChild.kt
@@ -11,5 +11,7 @@ class HybridChild : HybridChildSpec() {
   override val childValue: Double
     get() = 30.0
 
-  override fun bounceVariant(variant: NamedVariant): NamedVariant = variant
+  override fun bounceVariant(variant: NamedVariant): NamedVariant {
+    return variant
+  }
 }

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridSomeInternalObject.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridSomeInternalObject.kt
@@ -5,5 +5,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.test.external.HybridSomeExternalObjectSpec
 
 class HybridSomeInternalObject : HybridSomeExternalObjectSpec() {
-  override fun getValue(): String = "This is overridden!"
+  override fun getValue(): String {
+    return "This is overridden!"
+  }
 }

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -119,9 +119,7 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
         "bigint" to AnyValue(bigintValue),
         "null" to AnyValue(),
         "array" to
-          AnyValue(
-            arrayOf(AnyValue(numberValue), AnyValue(boolValue), AnyValue(stringValue), AnyValue(bigintValue), AnyValue(array)),
-          ),
+          AnyValue(arrayOf(AnyValue(numberValue), AnyValue(boolValue), AnyValue(stringValue), AnyValue(bigintValue), AnyValue(array))),
       ),
     )
     return map


### PR DESCRIPTION
No one likes the single line `=` syntax for Kotlin Methods.