### PR TITLE
fix: Catch enum-literals and single-value-enums in nitrogen

### DIFF
--- a/packages/nitrogen/src/syntax/createType.ts
+++ b/packages/nitrogen/src/syntax/createType.ts
@@ -189,8 +189,17 @@ export function createType(
       return new BooleanType()
     } else if (type.isNumber() || type.isNumberLiteral()) {
       if (type.isEnumLiteral()) {
-        // enum literals are technically just numbers - but we treat them differently in C++.
-        return createType(language, type.getBaseTypeOfLiteralType(), isOptional)
+        // An enum is just a number, that's why it's a number literal.
+        // Get the base of the literal, which would be our enum's definition.
+        const baseType = type.getBaseTypeOfLiteralType()
+        if (!baseType.isEnum()) {
+          // The base of the literal is not the enum definition, we need to throw.
+          throw new Error(
+            `The enum "${type.getLiteralValue()}" (${type.getText()}) is either a single-value-enum, or an enum-literal. Use a separately defined enum with at least 2 cases instead!`
+          )
+        }
+        // Call createType(...) now with the enum type.
+        return createType(language, baseType, isOptional)
       }
       return new NumberType()
     } else if (type.isString()) {


### PR DESCRIPTION
When the user defines an enum with just one value, it will cause a recursion error since TypeScript inlines the enum definition to a number.
We cannot easily get the declaration of the enum, so we just now bail out and throw an error to give the user a hint that he needs to properly define an enum with at least 2 cases, and also not inline it.

Fixes https://github.com/mrousavy/nitro/issues/959