### PR TITLE
fix: Freeze the Nitro globals in `__DEV__`

### DIFF
--- a/packages/react-native-nitro-modules/src/turbomodule/NativeNitroModules.ts
+++ b/packages/react-native-nitro-modules/src/turbomodule/NativeNitroModules.ts
@@ -47,9 +47,28 @@ if (__DEV__) {
   }
 }
 
+// Freeze the globals we need
+if (__DEV__) {
+  function protectGlobal(key: keyof typeof globalThis): void {
+    const value = globalThis[key]
+    if (value == null) return
+    Object.freeze(value)
+    Object.defineProperty(globalThis, key, {
+      value: value,
+      writable: false,
+      configurable: false,
+    })
+  }
+
+  protectGlobal('__nitroDispatcher')
+  protectGlobal('__nitroModulesJSICache')
+  protectGlobal('NitroModulesProxy')
+}
+
 declare global {
   var __nitroModulesJSICache: {}
   var __nitroDispatcher: {}
+  var NitroModulesProxy: {}
 }
 
 export function isRuntimeAlive() {


### PR DESCRIPTION
Better safe than sorry - we freeze `global.__nitroDispatcher`, `global.__nitroModulesJSICache` and `global.NitroModulesProxy` to prevent it being tampered with.