### PR TITLE
feat: Try importing `NativeComponentRegistry` the new way

### DIFF
--- a/packages/react-native-nitro-modules/src/views/ReactNativeComponentRegistry.ts
+++ b/packages/react-native-nitro-modules/src/views/ReactNativeComponentRegistry.ts
@@ -16,4 +16,4 @@ const registry: RegistryType | undefined =
 /**
  * `NativeComponentRegistry` from react-native core
  */
-export const NativeComponentRegistry = registry
+export const ReactNativeComponentRegistry = registry

--- a/packages/react-native-nitro-modules/src/views/getHostComponent.ts
+++ b/packages/react-native-nitro-modules/src/views/getHostComponent.ts
@@ -4,7 +4,7 @@ import type {
   HybridViewMethods,
   HybridViewProps,
 } from './HybridView'
-import { NativeComponentRegistry } from './NativeComponentRegistry'
+import { ReactNativeComponentRegistry } from './ReactNativeComponentRegistry'
 
 type AttributeValue<T, V = T> =
   | boolean
@@ -106,12 +106,12 @@ export function getHostComponent<
   name: string,
   getViewConfig: () => ViewConfig<Props>
 ): ReactNativeView<Props, Methods> {
-  if (NativeComponentRegistry == null) {
+  if (ReactNativeComponentRegistry == null) {
     throw new Error(
       `NativeComponentRegistry is not available on ${Platform.OS}!`
     )
   }
-  return NativeComponentRegistry.get(name, () => {
+  return ReactNativeComponentRegistry.get(name, () => {
     const config = getViewConfig()
     config.validAttributes = wrapValidAttributes(config.validAttributes)
     return config


### PR DESCRIPTION
react-native 0.82 added `NativeComponentRegistry` to the default `react-native` export.

Now we can import it like that.


We have a fallback in there for when calling this on older react-native versions.

Also, the types are undefined for whatever reason - I think they shipped types on main but not yet in react-native 0.82.