### PR TITLE
docs: Update ArrayBuffer isOwning documentation for clarity

### DIFF
--- a/docs/docs/types/array-buffers.md
+++ b/docs/docs/types/array-buffers.md
@@ -99,7 +99,7 @@ func doSomething(buffer: ArrayBuffer) {
 :::note
 Not every `ArrayBuffer` received from JS is **non-owning**, eg if the buffer was created in native and then did a JS-roundtrip it is still **owning**!
 
-Always check the `isOwning` to prevent unnecessary copies.
+Always check the `isOwning` property to prevent unnecessary copies.
 :::
 
 ## Threading


### PR DESCRIPTION
Clarify the definitions of owning and non-owning ArrayBuffers in the documentation.