### PR TITLE
fix: Disable `FastVectorCopy` for now (hide behind feature flag)

### DIFF
--- a/packages/react-native-nitro-modules/cpp/utils/FastVectorCopy.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/FastVectorCopy.hpp
@@ -39,8 +39,7 @@ std::vector<T> FastVectorCopy(const T* CONTIGUOUS_MEMORY NON_NULL data, size_t s
     return vector;
   } else {
     // SLOW: Type needs to be iterated to copy-construct it
-    std::span<const T> span(data, size);
-    return std::vector<T>(span.begin(), span.end());
+    return std::vector<T>(data, data + size);
   }
 }
 


### PR DESCRIPTION
As a replacement for https://github.com/mrousavy/nitro/pull/979, this hides `FastVectorCopy`'s fast path behind a feature flag, which is set to `false` for now.

In a future version of Swift we might be able to enable this, but I think for now Swift has issues with copying structs within structs and then mixing `std::vector` into the mix - might be a compiler bug (reported in https://github.com/mrousavy/nitro/issues/977)