### PR TITLE
chore: Move `Promise<void>` implementation to .cpp

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/Promise.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.cpp
@@ -121,21 +121,11 @@ std::future<void> Promise<void>::await() {
   return promise->get_future();
 }
 
-inline const std::exception_ptr& Promise<void>::getError() {
+const std::exception_ptr& Promise<void>::getError() {
   if (!isRejected()) {
     throw std::runtime_error("Cannot get error when Promise<void> is not yet rejected!");
   }
   return _error;
-}
-
-inline bool Promise<void>::isResolved() const noexcept {
-  return _isResolved;
-}
-inline bool Promise<void>::isRejected() const noexcept {
-  return _error != nullptr;
-}
-inline bool Promise<void>::isPending() const noexcept {
-  return !isResolved() && !isRejected();
 }
 
 void Promise<void>::didFinish() noexcept {

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -297,12 +297,18 @@ public:
   std::future<void> await();
 
 public:
-  inline const std::exception_ptr& getError();
+  const std::exception_ptr& getError();
 
 public:
-  inline bool isResolved() const noexcept;
-  inline bool isRejected() const noexcept;
-  inline bool isPending() const noexcept;
+  inline bool isResolved() const noexcept {
+    return _isResolved;
+  }
+  inline bool isRejected() const noexcept {
+    return _error != nullptr;
+  }
+  inline bool isPending() const noexcept {
+    return !isResolved() && !isRejected();
+  }
 
 private:
   void didFinish() noexcept;


### PR DESCRIPTION
Makes the `Promise<T>` header nicer to read :)