### PR TITLE
fix: Check cached global if it's still safe

### DIFF
--- a/packages/react-native-nitro-modules/cpp/utils/ObjectUtils.cpp
+++ b/packages/react-native-nitro-modules/cpp/utils/ObjectUtils.cpp
@@ -145,9 +145,12 @@ BorrowingReference<jsi::Function> ObjectUtils::getGlobalFunction(jsi::Runtime& r
     std::string stringKey = key;
     auto iterator = functionCache.find(stringKey);
     if (iterator != functionCache.end()) {
-      // We found it! Copy & return the reference
+      // We found it! Let's check if the reference is still valid...
       BorrowingReference<jsi::Function> function = iterator->second;
-      return function;
+      if (function != nullptr) [[likely]] {
+        // It's still alive - let's use it from cache!
+        return function;
+      }
     }
   }
   // We haven't found the function with the given key in cache - so let's get it:


### PR DESCRIPTION
We previously cached global functions like `Object.create` and just used them - but we should also acount for the fact that the Runtime can hot-reload, in which case they might no longer be alive.
So let's just do an additional null-check to be sure