### PR TITLE
perf: Cache properties in a Swift struct

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftStruct.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftStruct.ts
@@ -19,21 +19,22 @@ export function createSwiftStructBridge(
     .map((p) => {
       const bridge = new SwiftCxxBridgedType(p, true)
       const cppName = `self.__${p.escapedName}`
+      const cacheName = `self.__cache__${p.escapedName}`
       return `
-var ${p.escapedName}Cached: ${p.getCode('swift')}? = nil
+private var ${cacheName} ${p.getCode('swift')}? = nil
 var ${p.escapedName}: ${p.getCode('swift')} {
   @inline(__always)
   mutating get {
-    if let ${p.escapedName}Cached {
-      return ${p.escapedName}Cached
+    if let ${cacheName} {
+      return ${cacheName}
     }
     let __result = ${indent(bridge.parseFromCppToSwift(cppName, 'swift'), '    ')}
-    ${p.escapedName}Cached = __result
+    ${cacheName} = __result
     return __result
   }
   @inline(__always)
   set {
-    ${p.escapedName}Cached = newValue
+    ${cacheName} = newValue
     ${cppName} = ${indent(bridge.parseFromSwiftToCpp('newValue', 'swift'), '    ')}
   }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Car.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Car.swift
@@ -52,110 +52,110 @@ public extension Car {
     }())
   }
 
-  var yearCached: Double? = nil
+  private var self.__cache__year Double? = nil
   var year: Double {
     @inline(__always)
     mutating get {
-      if let yearCached {
-        return yearCached
+      if let self.__cache__year {
+        return self.__cache__year
       }
       let __result = self.__year
-      yearCached = __result
+      self.__cache__year = __result
       return __result
     }
     @inline(__always)
     set {
-      yearCached = newValue
+      self.__cache__year = newValue
       self.__year = newValue
     }
   }
   
-  var makeCached: String? = nil
+  private var self.__cache__make String? = nil
   var make: String {
     @inline(__always)
     mutating get {
-      if let makeCached {
-        return makeCached
+      if let self.__cache__make {
+        return self.__cache__make
       }
       let __result = String(self.__make)
-      makeCached = __result
+      self.__cache__make = __result
       return __result
     }
     @inline(__always)
     set {
-      makeCached = newValue
+      self.__cache__make = newValue
       self.__make = std.string(newValue)
     }
   }
   
-  var modelCached: String? = nil
+  private var self.__cache__model String? = nil
   var model: String {
     @inline(__always)
     mutating get {
-      if let modelCached {
-        return modelCached
+      if let self.__cache__model {
+        return self.__cache__model
       }
       let __result = String(self.__model)
-      modelCached = __result
+      self.__cache__model = __result
       return __result
     }
     @inline(__always)
     set {
-      modelCached = newValue
+      self.__cache__model = newValue
       self.__model = std.string(newValue)
     }
   }
   
-  var powerCached: Double? = nil
+  private var self.__cache__power Double? = nil
   var power: Double {
     @inline(__always)
     mutating get {
-      if let powerCached {
-        return powerCached
+      if let self.__cache__power {
+        return self.__cache__power
       }
       let __result = self.__power
-      powerCached = __result
+      self.__cache__power = __result
       return __result
     }
     @inline(__always)
     set {
-      powerCached = newValue
+      self.__cache__power = newValue
       self.__power = newValue
     }
   }
   
-  var powertrainCached: Powertrain? = nil
+  private var self.__cache__powertrain Powertrain? = nil
   var powertrain: Powertrain {
     @inline(__always)
     mutating get {
-      if let powertrainCached {
-        return powertrainCached
+      if let self.__cache__powertrain {
+        return self.__cache__powertrain
       }
       let __result = self.__powertrain
-      powertrainCached = __result
+      self.__cache__powertrain = __result
       return __result
     }
     @inline(__always)
     set {
-      powertrainCached = newValue
+      self.__cache__powertrain = newValue
       self.__powertrain = newValue
     }
   }
   
-  var driverCached: Person?? = nil
+  private var self.__cache__driver Person?? = nil
   var driver: Person? {
     @inline(__always)
     mutating get {
-      if let driverCached {
-        return driverCached
+      if let self.__cache__driver {
+        return self.__cache__driver
       }
       let __result = self.__driver.value
-      driverCached = __result
+      self.__cache__driver = __result
       return __result
     }
     @inline(__always)
     set {
-      driverCached = newValue
+      self.__cache__driver = newValue
       self.__driver = { () -> bridge.std__optional_Person_ in
         if let __unwrappedValue = newValue {
           return bridge.create_std__optional_Person_(__unwrappedValue)
@@ -166,20 +166,20 @@ public extension Car {
     }
   }
   
-  var passengersCached: [Person]? = nil
+  private var self.__cache__passengers [Person]? = nil
   var passengers: [Person] {
     @inline(__always)
     mutating get {
-      if let passengersCached {
-        return passengersCached
+      if let self.__cache__passengers {
+        return self.__cache__passengers
       }
       let __result = self.__passengers.map({ __item in __item })
-      passengersCached = __result
+      self.__cache__passengers = __result
       return __result
     }
     @inline(__always)
     set {
-      passengersCached = newValue
+      self.__cache__passengers = newValue
       self.__passengers = { () -> bridge.std__vector_Person_ in
         var __vector = bridge.create_std__vector_Person_(newValue.count)
         for __item in newValue {
@@ -190,12 +190,12 @@ public extension Car {
     }
   }
   
-  var isFastCached: Bool?? = nil
+  private var self.__cache__isFast Bool?? = nil
   var isFast: Bool? {
     @inline(__always)
     mutating get {
-      if let isFastCached {
-        return isFastCached
+      if let self.__cache__isFast {
+        return self.__cache__isFast
       }
       let __result = { () -> Bool? in
         if bridge.has_value_std__optional_bool_(self.__isFast) {
@@ -205,12 +205,12 @@ public extension Car {
           return nil
         }
       }()
-      isFastCached = __result
+      self.__cache__isFast = __result
       return __result
     }
     @inline(__always)
     set {
-      isFastCached = newValue
+      self.__cache__isFast = newValue
       self.__isFast = { () -> bridge.std__optional_bool_ in
         if let __unwrappedValue = newValue {
           return bridge.create_std__optional_bool_(__unwrappedValue)
@@ -221,12 +221,12 @@ public extension Car {
     }
   }
   
-  var favouriteTrackCached: String?? = nil
+  private var self.__cache__favouriteTrack String?? = nil
   var favouriteTrack: String? {
     @inline(__always)
     mutating get {
-      if let favouriteTrackCached {
-        return favouriteTrackCached
+      if let self.__cache__favouriteTrack {
+        return self.__cache__favouriteTrack
       }
       let __result = { () -> String? in
         if bridge.has_value_std__optional_std__string_(self.__favouriteTrack) {
@@ -236,12 +236,12 @@ public extension Car {
           return nil
         }
       }()
-      favouriteTrackCached = __result
+      self.__cache__favouriteTrack = __result
       return __result
     }
     @inline(__always)
     set {
-      favouriteTrackCached = newValue
+      self.__cache__favouriteTrack = newValue
       self.__favouriteTrack = { () -> bridge.std__optional_std__string_ in
         if let __unwrappedValue = newValue {
           return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
@@ -252,20 +252,20 @@ public extension Car {
     }
   }
   
-  var performanceScoresCached: [Double]? = nil
+  private var self.__cache__performanceScores [Double]? = nil
   var performanceScores: [Double] {
     @inline(__always)
     mutating get {
-      if let performanceScoresCached {
-        return performanceScoresCached
+      if let self.__cache__performanceScores {
+        return self.__cache__performanceScores
       }
       let __result = self.__performanceScores.map({ __item in __item })
-      performanceScoresCached = __result
+      self.__cache__performanceScores = __result
       return __result
     }
     @inline(__always)
     set {
-      performanceScoresCached = newValue
+      self.__cache__performanceScores = newValue
       self.__performanceScores = { () -> bridge.std__vector_double_ in
         var __vector = bridge.create_std__vector_double_(newValue.count)
         for __item in newValue {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/JsStyleStruct.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/JsStyleStruct.swift
@@ -25,30 +25,30 @@ public extension JsStyleStruct {
     }())
   }
 
-  var valueCached: Double? = nil
+  private var self.__cache__value Double? = nil
   var value: Double {
     @inline(__always)
     mutating get {
-      if let valueCached {
-        return valueCached
+      if let self.__cache__value {
+        return self.__cache__value
       }
       let __result = self.__value
-      valueCached = __result
+      self.__cache__value = __result
       return __result
     }
     @inline(__always)
     set {
-      valueCached = newValue
+      self.__cache__value = newValue
       self.__value = newValue
     }
   }
   
-  var onChangedCached: (_ num: Double) -> Void? = nil
+  private var self.__cache__onChanged (_ num: Double) -> Void? = nil
   var onChanged: (_ num: Double) -> Void {
     @inline(__always)
     mutating get {
-      if let onChangedCached {
-        return onChangedCached
+      if let self.__cache__onChanged {
+        return self.__cache__onChanged
       }
       let __result = { () -> (Double) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_double(self.__onChanged)
@@ -56,12 +56,12 @@ public extension JsStyleStruct {
           __wrappedFunction.call(__num)
         }
       }()
-      onChangedCached = __result
+      self.__cache__onChanged = __result
       return __result
     }
     @inline(__always)
     set {
-      onChangedCached = newValue
+      self.__cache__onChanged = newValue
       self.__onChanged = { () -> bridge.Func_void_double in
         let __closureWrapper = Func_void_double(newValue)
         return bridge.create_Func_void_double(__closureWrapper.toUnsafe())

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/MapWrapper.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/MapWrapper.swift
@@ -28,12 +28,12 @@ public extension MapWrapper {
     }(), secondMap)
   }
 
-  var mapCached: Dictionary<String, String>? = nil
+  private var self.__cache__map Dictionary<String, String>? = nil
   var map: Dictionary<String, String> {
     @inline(__always)
     mutating get {
-      if let mapCached {
-        return mapCached
+      if let self.__cache__map {
+        return self.__cache__map
       }
       let __result = { () -> Dictionary<String, String> in
         var __dictionary = Dictionary<String, String>(minimumCapacity: self.__map.size())
@@ -44,12 +44,12 @@ public extension MapWrapper {
         }
         return __dictionary
       }()
-      mapCached = __result
+      self.__cache__map = __result
       return __result
     }
     @inline(__always)
     set {
-      mapCached = newValue
+      self.__cache__map = newValue
       self.__map = { () -> bridge.std__unordered_map_std__string__std__string_ in
         var __map = bridge.create_std__unordered_map_std__string__std__string_(newValue.count)
         for (__k, __v) in newValue {
@@ -60,20 +60,20 @@ public extension MapWrapper {
     }
   }
   
-  var secondMapCached: SecondMapWrapper? = nil
+  private var self.__cache__secondMap SecondMapWrapper? = nil
   var secondMap: SecondMapWrapper {
     @inline(__always)
     mutating get {
-      if let secondMapCached {
-        return secondMapCached
+      if let self.__cache__secondMap {
+        return self.__cache__secondMap
       }
       let __result = self.__secondMap
-      secondMapCached = __result
+      self.__cache__secondMap = __result
       return __result
     }
     @inline(__always)
     set {
-      secondMapCached = newValue
+      self.__cache__secondMap = newValue
       self.__secondMap = newValue
     }
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/OptionalCallback.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/OptionalCallback.swift
@@ -38,12 +38,12 @@ public extension OptionalCallback {
     }())
   }
 
-  var callbackCached: Variant_______Void_Double?? = nil
+  private var self.__cache__callback Variant_______Void_Double?? = nil
   var callback: Variant_______Void_Double? {
     @inline(__always)
     mutating get {
-      if let callbackCached {
-        return callbackCached
+      if let self.__cache__callback {
+        return self.__cache__callback
       }
       let __result = { () -> Variant_______Void_Double? in
         if bridge.has_value_std__optional_std__variant_std__function_void_____double__(self.__callback) {
@@ -70,12 +70,12 @@ public extension OptionalCallback {
           return nil
         }
       }()
-      callbackCached = __result
+      self.__cache__callback = __result
       return __result
     }
     @inline(__always)
     set {
-      callbackCached = newValue
+      self.__cache__callback = newValue
       self.__callback = { () -> bridge.std__optional_std__variant_std__function_void_____double__ in
         if let __unwrappedValue = newValue {
           return bridge.create_std__optional_std__variant_std__function_void_____double__({ () -> bridge.std__variant_std__function_void_____double_ in

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/OptionalWrapper.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/OptionalWrapper.swift
@@ -34,12 +34,12 @@ public extension OptionalWrapper {
     }())
   }
 
-  var optionalArrayBufferCached: ArrayBuffer?? = nil
+  private var self.__cache__optionalArrayBuffer ArrayBuffer?? = nil
   var optionalArrayBuffer: ArrayBuffer? {
     @inline(__always)
     mutating get {
-      if let optionalArrayBufferCached {
-        return optionalArrayBufferCached
+      if let self.__cache__optionalArrayBuffer {
+        return self.__cache__optionalArrayBuffer
       }
       let __result = { () -> ArrayBuffer? in
         if bridge.has_value_std__optional_std__shared_ptr_ArrayBuffer__(self.__optionalArrayBuffer) {
@@ -49,12 +49,12 @@ public extension OptionalWrapper {
           return nil
         }
       }()
-      optionalArrayBufferCached = __result
+      self.__cache__optionalArrayBuffer = __result
       return __result
     }
     @inline(__always)
     set {
-      optionalArrayBufferCached = newValue
+      self.__cache__optionalArrayBuffer = newValue
       self.__optionalArrayBuffer = { () -> bridge.std__optional_std__shared_ptr_ArrayBuffer__ in
         if let __unwrappedValue = newValue {
           return bridge.create_std__optional_std__shared_ptr_ArrayBuffer__(__unwrappedValue.getArrayBuffer())
@@ -65,12 +65,12 @@ public extension OptionalWrapper {
     }
   }
   
-  var optionalStringCached: String?? = nil
+  private var self.__cache__optionalString String?? = nil
   var optionalString: String? {
     @inline(__always)
     mutating get {
-      if let optionalStringCached {
-        return optionalStringCached
+      if let self.__cache__optionalString {
+        return self.__cache__optionalString
       }
       let __result = { () -> String? in
         if bridge.has_value_std__optional_std__string_(self.__optionalString) {
@@ -80,12 +80,12 @@ public extension OptionalWrapper {
           return nil
         }
       }()
-      optionalStringCached = __result
+      self.__cache__optionalString = __result
       return __result
     }
     @inline(__always)
     set {
-      optionalStringCached = newValue
+      self.__cache__optionalString = newValue
       self.__optionalString = { () -> bridge.std__optional_std__string_ in
         if let __unwrappedValue = newValue {
           return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Person.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/Person.swift
@@ -22,38 +22,38 @@ public extension Person {
     self.init(std.string(name), age)
   }
 
-  var nameCached: String? = nil
+  private var self.__cache__name String? = nil
   var name: String {
     @inline(__always)
     mutating get {
-      if let nameCached {
-        return nameCached
+      if let self.__cache__name {
+        return self.__cache__name
       }
       let __result = String(self.__name)
-      nameCached = __result
+      self.__cache__name = __result
       return __result
     }
     @inline(__always)
     set {
-      nameCached = newValue
+      self.__cache__name = newValue
       self.__name = std.string(newValue)
     }
   }
   
-  var ageCached: Double? = nil
+  private var self.__cache__age Double? = nil
   var age: Double {
     @inline(__always)
     mutating get {
-      if let ageCached {
-        return ageCached
+      if let self.__cache__age {
+        return self.__cache__age
       }
       let __result = self.__age
-      ageCached = __result
+      self.__cache__age = __result
       return __result
     }
     @inline(__always)
     set {
-      ageCached = newValue
+      self.__cache__age = newValue
       self.__age = newValue
     }
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/SecondMapWrapper.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/SecondMapWrapper.swift
@@ -28,12 +28,12 @@ public extension SecondMapWrapper {
     }())
   }
 
-  var secondCached: Dictionary<String, String>? = nil
+  private var self.__cache__second Dictionary<String, String>? = nil
   var second: Dictionary<String, String> {
     @inline(__always)
     mutating get {
-      if let secondCached {
-        return secondCached
+      if let self.__cache__second {
+        return self.__cache__second
       }
       let __result = { () -> Dictionary<String, String> in
         var __dictionary = Dictionary<String, String>(minimumCapacity: self.__second.size())
@@ -44,12 +44,12 @@ public extension SecondMapWrapper {
         }
         return __dictionary
       }()
-      secondCached = __result
+      self.__cache__second = __result
       return __result
     }
     @inline(__always)
     set {
-      secondCached = newValue
+      self.__cache__second = newValue
       self.__second = { () -> bridge.std__unordered_map_std__string__std__string_ in
         var __map = bridge.create_std__unordered_map_std__string__std__string_(newValue.count)
         for (__k, __v) in newValue {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/WrappedJsStruct.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/WrappedJsStruct.swift
@@ -28,38 +28,38 @@ public extension WrappedJsStruct {
     }())
   }
 
-  var valueCached: JsStyleStruct? = nil
+  private var self.__cache__value JsStyleStruct? = nil
   var value: JsStyleStruct {
     @inline(__always)
     mutating get {
-      if let valueCached {
-        return valueCached
+      if let self.__cache__value {
+        return self.__cache__value
       }
       let __result = self.__value
-      valueCached = __result
+      self.__cache__value = __result
       return __result
     }
     @inline(__always)
     set {
-      valueCached = newValue
+      self.__cache__value = newValue
       self.__value = newValue
     }
   }
   
-  var itemsCached: [JsStyleStruct]? = nil
+  private var self.__cache__items [JsStyleStruct]? = nil
   var items: [JsStyleStruct] {
     @inline(__always)
     mutating get {
-      if let itemsCached {
-        return itemsCached
+      if let self.__cache__items {
+        return self.__cache__items
       }
       let __result = self.__items.map({ __item in __item })
-      itemsCached = __result
+      self.__cache__items = __result
       return __result
     }
     @inline(__always)
     set {
-      itemsCached = newValue
+      self.__cache__items = newValue
       self.__items = { () -> bridge.std__vector_JsStyleStruct_ in
         var __vector = bridge.create_std__vector_JsStyleStruct_(newValue.count)
         for __item in newValue {


### PR DESCRIPTION
Caches properties in a Swift struct.

Previously, accessing the same prop twice caused re-computation of the property (which essentially meant parsing from C++ to Swift again).
For large arrays, this meant a whole new deep copy of the entire array:
```swift
let first = myJSStruct.array
let second = myJSStruct.array
```

With this PR, the `second` will use the cached value from the first access.

Not sure if this is worth the complexity, just testing in a PR.