### PR TITLE
fix: Also use `defineProperty(...)` for Prototype Methods

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1575,6 +1575,16 @@ export function getTests(
         .didNotThrow()
         .equals('Child')
     ),
+    createTest('createChild() has overridden toString()', () =>
+      it(() => testObject.createChild().toString())
+        .didNotThrow()
+        .equals('HybridChild custom toString() :)')
+    ),
+    createTest('createBaseActualChild() has overridden toString()', () =>
+      it(() => testObject.createBaseActualChild().toString())
+        .didNotThrow()
+        .equals('HybridChild custom toString() :)')
+    ),
     createTest('createBaseActualChild() has name "Child"', () =>
       it(() => testObject.createBaseActualChild().name)
         .didNotThrow()

--- a/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
+++ b/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
@@ -43,6 +43,7 @@ jsi::Value HybridObjectPrototype::createPrototype(jsi::Runtime& runtime, const s
 
   // 4. Add all Hybrid Methods to it
   for (const auto& method : prototype->getMethods()) {
+    // method()
     const std::string& name = method.first;
     ObjectUtils::defineProperty(runtime, object, name.c_str(),
                                 PlainPropertyDescriptor{

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridChild.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridChild.kt
@@ -14,4 +14,8 @@ class HybridChild : HybridChildSpec() {
   override fun bounceVariant(variant: NamedVariant): NamedVariant {
     return variant
   }
+
+  override fun toString(): String {
+    return "HybridChild custom toString() :)"
+  }
 }

--- a/packages/react-native-nitro-test/cpp/HybridChild.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridChild.hpp
@@ -29,6 +29,10 @@ public:
   std::variant<std::string, Car> bounceVariant(const std::variant<std::string, Car>& variant) override {
     return variant;
   }
+
+  std::string toString() override {
+    return "HybridChild custom toString() :)";
+  }
 };
 
 }; // namespace margelo::nitro::test

--- a/packages/react-native-nitro-test/ios/HybridChild.swift
+++ b/packages/react-native-nitro-test/ios/HybridChild.swift
@@ -18,4 +18,8 @@ class HybridChild: HybridChildSpec {
   func bounceVariant(variant: NamedVariant) throws -> NamedVariant {
     return variant
   }
+
+  func toString() -> String {
+    return "HybridChild custom toString() :)"
+  }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridChildSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridChildSpec.cpp
@@ -66,5 +66,10 @@ namespace margelo::nitro::test {
     auto __result = method(_javaPart, JNamedVariant::fromCpp(variant));
     return __result->toCpp();
   }
+  std::string JHybridChildSpec::toString() {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("toString");
+    auto __result = method(_javaPart);
+    return __result->toStdString();
+  }
 
 } // namespace margelo::nitro::test

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridChildSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridChildSpec.hpp
@@ -56,6 +56,7 @@ namespace margelo::nitro::test {
   public:
     // Methods
     std::variant<std::string, Car> bounceVariant(const std::variant<std::string, Car>& variant) override;
+    std::string toString() override;
 
   private:
     friend HybridBase;

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridChildSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridChildSpec.kt
@@ -45,6 +45,10 @@ abstract class HybridChildSpec: HybridBaseSpec() {
   @DoNotStrip
   @Keep
   abstract fun bounceVariant(variant: NamedVariant): NamedVariant
+  
+  @DoNotStrip
+  @Keep
+  abstract fun toString(): String
 
   private external fun initHybrid(): HybridData
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridChildSpecSwift.hpp
@@ -82,6 +82,14 @@ namespace margelo::nitro::test {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline std::string toString() override {
+      auto __result = _swiftPart.toString();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
 
   private:
     NitroTest::HybridChildSpec_cxx _swiftPart;

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec.swift
@@ -15,6 +15,7 @@ public protocol HybridChildSpec_protocol: HybridObject, HybridBaseSpec_protocol 
 
   // Methods
   func bounceVariant(variant: NamedVariant) throws -> NamedVariant
+  func toString() throws -> String
 }
 
 /// See ``HybridChildSpec``

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
@@ -147,4 +147,16 @@ open class HybridChildSpec_cxx : HybridBaseSpec_cxx {
       return bridge.create_Result_std__variant_std__string__Car__(__exceptionPtr)
     }
   }
+  
+  @inline(__always)
+  public final func toString() -> bridge.Result_std__string_ {
+    do {
+      let __result = try self.__implementation.toString()
+      let __resultCpp = std.string(__result)
+      return bridge.create_Result_std__string_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__string_(__exceptionPtr)
+    }
+  }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridChildSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridChildSpec.cpp
@@ -17,6 +17,7 @@ namespace margelo::nitro::test {
     registerHybrids(this, [](Prototype& prototype) {
       prototype.registerHybridGetter("childValue", &HybridChildSpec::getChildValue);
       prototype.registerHybridMethod("bounceVariant", &HybridChildSpec::bounceVariant);
+      prototype.registerHybridMethod("toString", &HybridChildSpec::toString);
     });
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridChildSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridChildSpec.hpp
@@ -56,6 +56,7 @@ namespace margelo::nitro::test {
     public:
       // Methods
       virtual std::variant<std::string, Car> bounceVariant(const std::variant<std::string, Car>& variant) = 0;
+      virtual std::string toString() = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -300,4 +300,6 @@ export interface Child extends Base {
   readonly childValue: number
   // tests if the same variant can be used in a different HybridObject
   bounceVariant(variant: NamedVariant): NamedVariant
+  // we override toString() here
+  toString(): string
 }


### PR DESCRIPTION
Fixes an issue where getting the prototype failed if the HybridObject had a method that used the same name as the method in the base prototype (e.g. if the user overrides `toString()` in his HybridObject + prototype).

The issue in that case would be that the `.toString()` method already exists further up the prototype chain, and just using `object.setProperty("toString", ...)` would try to write to that property.
Instead, we now use `Object::defineProperty(...)`, which does not walk the prototype chain and instead defines it on the given object directly, which is much safer and allows truly overriding the methods.