### PR TITLE
fix: Allow overriding base `Any` methods in Kotlin HybridObjects

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/isBaseObjectMethodName.ts
+++ b/packages/nitrogen/src/syntax/kotlin/isBaseObjectMethodName.ts
@@ -1,0 +1,12 @@
+import type { Method } from '../Method.js'
+
+const kotlinAnyMethodNames = ['equals', 'hashCode', 'toString']
+
+/**
+ * Returns `true` if the given {@linkcode method} is a
+ * method that exists in the base `Object` type in Java.
+ * If this is true, it needs an `override` modifier.
+ */
+export function isBaseObjectMethodName(method: Method): boolean {
+  return kotlinAnyMethodNames.includes(method.name)
+}

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridChildSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridChildSpec.kt
@@ -48,7 +48,7 @@ abstract class HybridChildSpec: HybridBaseSpec() {
   
   @DoNotStrip
   @Keep
-  abstract fun toString(): String
+  abstract override fun toString(): String
 
   private external fun initHybrid(): HybridData
 


### PR DESCRIPTION
Allows overriding methods from the base `Any`/`Object` type in Kotlin/Java.

This includes;

- `equals(..)`
- `hashCode()`
- `toString()` <-- probably the most commonly used one