### PR TITLE
add test for #977

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
     },
     "example": {
       "name": "react-native-nitro-example",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "dependencies": {
         "@react-native-segmented-control/segmented-control": "^2.5.7",
         "@react-navigation/bottom-tabs": "^7.4.5",
@@ -87,11 +87,11 @@
     },
     "packages/nitrogen": {
       "name": "nitrogen",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "bin": "./lib/index.js",
       "dependencies": {
         "chalk": "^5.3.0",
-        "react-native-nitro-modules": "^0.31.0",
+        "react-native-nitro-modules": "^0.31.1",
         "ts-morph": "^27.0.0",
         "yargs": "^18.0.0",
         "zod": "^4.0.5",
@@ -102,7 +102,7 @@
     },
     "packages/react-native-nitro-modules": {
       "name": "react-native-nitro-modules",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "devDependencies": {
         "@types/jest": "*",
         "@types/react": "*",
@@ -118,7 +118,7 @@
     },
     "packages/react-native-nitro-test": {
       "name": "react-native-nitro-test",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "devDependencies": {
         "@types/jest": "*",
         "@types/react": "*",
@@ -138,7 +138,7 @@
     },
     "packages/react-native-nitro-test-external": {
       "name": "react-native-nitro-test-external",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "devDependencies": {
         "@react-native/eslint-config": "0.82.0",
         "@types/jest": "^29.5.12",

--- a/example/ios/NitroExample.xcodeproj/project.pbxproj
+++ b/example/ios/NitroExample.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CJW62Q77E7;
+				DEVELOPMENT_TEAM = SCHCH5LRT6;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = NitroExample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Nitro Example";
@@ -424,7 +424,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CJW62Q77E7;
+				DEVELOPMENT_TEAM = SCHCH5LRT6;
 				INFOPLIST_FILE = NitroExample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Nitro Example";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.82.0):
     - hermes-engine/Pre-built (= 0.82.0)
   - hermes-engine/Pre-built (0.82.0)
-  - NitroModules (0.31.0):
+  - NitroModules (0.31.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -37,7 +37,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - NitroTest (0.31.0):
+  - NitroTest (0.31.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -68,7 +68,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - NitroTestExternal (0.31.0):
+  - NitroTestExternal (0.31.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2818,9 +2818,9 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 8642d8f14a548ab718ec112e9bebdfdd154138b5
-  NitroModules: 91f5ab1379c2ee6bef646adfcdca0e8185aeeb52
-  NitroTest: 656ed7b98b954af6ee7dceb99aea681f01111c1d
-  NitroTestExternal: 0b7a14330b40ce0fe79ec7da66005290451e2ef3
+  NitroModules: ca08efed5e586152f2a40dac4d875e165c553905
+  NitroTest: d9e16faa0300f39a062a4d35db13c1ebd5ce94ec
+  NitroTestExternal: 9dc6f714d74c6db14bcf819baea532ae357fc44f
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 22bf66112da540a7d40e536366ddd8557934fca1
   RCTRequired: a0ed4dc41b35f79fbb6d8ba320e06882a8c792cf
@@ -2894,4 +2894,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 205a5dcc178bd52bc8f2d549f38ecbb697373aaf
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1339,6 +1339,23 @@ export function getTests(
         .didNotThrow()
         .equals({ age: 24, name: 'marc' })
     ),
+    createTest('sumPerformanceScores', () =>
+      it(() =>
+        testObject.sumPerformanceScores({
+          make: 'Lamborghini',
+          year: 2018,
+          model: 'Huracan Performante',
+          power: 640,
+          passengers: [],
+          powertrain: 'gas',
+          driver: { age: 24, name: 'marc' },
+          isFast: true,
+          performanceScores: [100, 0],
+        })
+      )
+        .didNotThrow()
+        .equals(100)
+    ),
     createTest('jsStyleObjectAsParameters()', async () =>
       (
         await it(() => {

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -339,6 +339,15 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
     return car.driver
   }
 
+  override fun sumPerformanceScores(car: Car): Double {
+    car.performanceScores.forEach {
+      Log.d(TAG, "summing up $it")
+    }
+    val sum = car.performanceScores.sum()
+    Log.d(TAG, "sum $sum")
+    return sum
+  }
+
   override fun jsStyleObjectAsParameters(params: JsStyleStruct) {
     params.onChanged(params.value)
   }

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <sstream>
 #include <thread>
+#include <numeric>
 
 #include "HybridBase.hpp"
 #include "HybridChild.hpp"
@@ -473,6 +474,10 @@ std::optional<Person> HybridTestObjectCpp::getDriver(const Car& car) {
   } else {
     return std::nullopt;
   }
+}
+
+double HybridTestObjectCpp::sumPerformanceScores(const Car& car) {
+    return std::accumulate(car.performanceScores.begin(), car.performanceScores.end(), 0.0);
 }
 
 void HybridTestObjectCpp::jsStyleObjectAsParameters(const JsStyleStruct& params) {

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -153,6 +153,7 @@ public:
   Car getCar() override;
   bool isCarElectric(const Car& car) override;
   std::optional<Person> getDriver(const Car& car) override;
+  double sumPerformanceScores(const Car& car) override;
   void jsStyleObjectAsParameters(const JsStyleStruct& params) override;
   WrappedJsStruct bounceWrappedJsStyleStruct(const WrappedJsStruct& value) override;
   OptionalWrapper bounceOptionalWrapper(const OptionalWrapper& wrapper) override;

--- a/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
@@ -382,6 +382,15 @@ class HybridTestObjectSwift: HybridTestObjectSwiftKotlinSpec {
     return car.driver
   }
 
+  func sumPerformanceScores(car: Car) throws -> Double {
+    car.performanceScores.forEach {
+      print("summing up \($0)")
+    }
+    let sum = car.performanceScores.reduce(0, +)
+    print("sum \(sum)")
+    return sum
+  }
+
   func jsStyleObjectAsParameters(params: JsStyleStruct) throws {
     params.onChanged(params.value)
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -815,6 +815,11 @@ namespace margelo::nitro::test {
     auto __result = method(_javaPart, JCar::fromCpp(car));
     return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
+  double JHybridTestObjectSwiftKotlinSpec::sumPerformanceScores(const Car& car) {
+    static const auto method = javaClassStatic()->getMethod<double(jni::alias_ref<JCar> /* car */)>("sumPerformanceScores");
+    auto __result = method(_javaPart, JCar::fromCpp(car));
+    return __result;
+  }
   void JHybridTestObjectSwiftKotlinSpec::jsStyleObjectAsParameters(const JsStyleStruct& params) {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JJsStyleStruct> /* params */)>("jsStyleObjectAsParameters");
     method(_javaPart, JJsStyleStruct::fromCpp(params));

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -127,6 +127,7 @@ namespace margelo::nitro::test {
     Car getCar() override;
     bool isCarElectric(const Car& car) override;
     std::optional<Person> getDriver(const Car& car) override;
+    double sumPerformanceScores(const Car& car) override;
     void jsStyleObjectAsParameters(const JsStyleStruct& params) override;
     WrappedJsStruct bounceWrappedJsStyleStruct(const WrappedJsStruct& value) override;
     OptionalWrapper bounceOptionalWrapper(const OptionalWrapper& wrapper) override;

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
@@ -381,6 +381,10 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun sumPerformanceScores(car: Car): Double
+  
+  @DoNotStrip
+  @Keep
   abstract fun jsStyleObjectAsParameters(params: JsStyleStruct): Unit
   
   @DoNotStrip

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -577,6 +577,14 @@ namespace margelo::nitro::test {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline double sumPerformanceScores(const Car& car) override {
+      auto __result = _swiftPart.sumPerformanceScores(std::forward<decltype(car)>(car));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline void jsStyleObjectAsParameters(const JsStyleStruct& params) override {
       auto __result = _swiftPart.jsStyleObjectAsParameters(std::forward<decltype(params)>(params));
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -77,6 +77,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func getCar() throws -> Car
   func isCarElectric(car: Car) throws -> Bool
   func getDriver(car: Car) throws -> Person?
+  func sumPerformanceScores(car: Car) throws -> Double
   func jsStyleObjectAsParameters(params: JsStyleStruct) throws -> Void
   func bounceWrappedJsStyleStruct(value: WrappedJsStruct) throws -> WrappedJsStruct
   func bounceOptionalWrapper(wrapper: OptionalWrapper) throws -> OptionalWrapper

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -1452,6 +1452,18 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
   }
   
   @inline(__always)
+  public final func sumPerformanceScores(car: Car) -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.sumPerformanceScores(car: car)
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func jsStyleObjectAsParameters(params: JsStyleStruct) -> bridge.Result_void_ {
     do {
       try self.__implementation.jsStyleObjectAsParameters(params: params)

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -95,6 +95,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("getCar", &HybridTestObjectCppSpec::getCar);
       prototype.registerHybridMethod("isCarElectric", &HybridTestObjectCppSpec::isCarElectric);
       prototype.registerHybridMethod("getDriver", &HybridTestObjectCppSpec::getDriver);
+      prototype.registerHybridMethod("sumPerformanceScores", &HybridTestObjectCppSpec::sumPerformanceScores);
       prototype.registerHybridMethod("jsStyleObjectAsParameters", &HybridTestObjectCppSpec::jsStyleObjectAsParameters);
       prototype.registerHybridMethod("bounceWrappedJsStyleStruct", &HybridTestObjectCppSpec::bounceWrappedJsStyleStruct);
       prototype.registerHybridMethod("bounceOptionalWrapper", &HybridTestObjectCppSpec::bounceOptionalWrapper);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -185,6 +185,7 @@ namespace margelo::nitro::test {
       virtual Car getCar() = 0;
       virtual bool isCarElectric(const Car& car) = 0;
       virtual std::optional<Person> getDriver(const Car& car) = 0;
+      virtual double sumPerformanceScores(const Car& car) = 0;
       virtual void jsStyleObjectAsParameters(const JsStyleStruct& params) = 0;
       virtual WrappedJsStruct bounceWrappedJsStyleStruct(const WrappedJsStruct& value) = 0;
       virtual OptionalWrapper bounceOptionalWrapper(const OptionalWrapper& wrapper) = 0;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -89,6 +89,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("getCar", &HybridTestObjectSwiftKotlinSpec::getCar);
       prototype.registerHybridMethod("isCarElectric", &HybridTestObjectSwiftKotlinSpec::isCarElectric);
       prototype.registerHybridMethod("getDriver", &HybridTestObjectSwiftKotlinSpec::getDriver);
+      prototype.registerHybridMethod("sumPerformanceScores", &HybridTestObjectSwiftKotlinSpec::sumPerformanceScores);
       prototype.registerHybridMethod("jsStyleObjectAsParameters", &HybridTestObjectSwiftKotlinSpec::jsStyleObjectAsParameters);
       prototype.registerHybridMethod("bounceWrappedJsStyleStruct", &HybridTestObjectSwiftKotlinSpec::bounceWrappedJsStyleStruct);
       prototype.registerHybridMethod("bounceOptionalWrapper", &HybridTestObjectSwiftKotlinSpec::bounceOptionalWrapper);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -177,6 +177,7 @@ namespace margelo::nitro::test {
       virtual Car getCar() = 0;
       virtual bool isCarElectric(const Car& car) = 0;
       virtual std::optional<Person> getDriver(const Car& car) = 0;
+      virtual double sumPerformanceScores(const Car& car) = 0;
       virtual void jsStyleObjectAsParameters(const JsStyleStruct& params) = 0;
       virtual WrappedJsStruct bounceWrappedJsStyleStruct(const WrappedJsStruct& value) = 0;
       virtual OptionalWrapper bounceOptionalWrapper(const OptionalWrapper& wrapper) = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -200,6 +200,7 @@ interface SharedTestObjectProps {
   getCar(): Car
   isCarElectric(car: Car): boolean
   getDriver(car: Car): Person | undefined
+  sumPerformanceScores(car: Car): number
   jsStyleObjectAsParameters(params: JsStyleStruct): void
   bounceWrappedJsStyleStruct(value: WrappedJsStruct): WrappedJsStruct
   bounceOptionalWrapper(wrapper: OptionalWrapper): OptionalWrapper


### PR DESCRIPTION
This PR adds a failing/crashing swift test for https://github.com/mrousavy/nitro/issues/977 it works for c++ and kotlin though :)
Rarely it crashes, took me a few cold starts though to catch it.
<img width="2562" height="2132" alt="Bildschirmfoto 2025-10-24 um 14 04 04" src="https://github.com/user-attachments/assets/45f4d64b-f1f8-48a3-a9f3-572ef41ae6b0" />

But even when it does not crash the test fails, printing each value of the array reveals that there is something terrible wrong, even though I pass in [100, 0] all the time I see different values on each attempt.
<img width="991" height="389" alt="image" src="https://github.com/user-attachments/assets/2bd0068e-2596-41bb-bee8-7572fee14560" />

