### PR TITLE
docs: Update Xcode version requirement to 16.4

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -25,7 +25,7 @@ You need:
 
 - [Bun](https://bun.sh)
 - [CocoaPods](https://cocoapods.org)
-- Xcode 16 or higher
+- Xcode 16.4 or higher
 - Android Studio
 
 ### 2. Clone the repo

--- a/docs/docs/minimum-requirements.md
+++ b/docs/docs/minimum-requirements.md
@@ -12,7 +12,7 @@ To use Nitro, make sure your app meets the minimum requirements:
 <Tabs groupId="platform">
   <TabItem value="ios" label="iOS" default>
     - react-native 0.75 or higher
-    - Xcode 16 or higher
+    - Xcode 16.4 or higher
   </TabItem>
   <TabItem value="android" label="Android">
     - react-native 0.75 or higher


### PR DESCRIPTION
Xcode 16.1 introduced build failures. The minimum is now 16.4 to ensure a reliable build.