### PR TITLE
fix: Throw if trying to use a complex type as an interface

### DIFF
--- a/packages/nitrogen/src/syntax/createType.ts
+++ b/packages/nitrogen/src/syntax/createType.ts
@@ -218,7 +218,7 @@ export function createType(
         .getTupleElements()
         .map((t) => createType(language, t, t.isNullable()))
       return new TupleType(itemTypes)
-    } else if (type.getCallSignatures().length > 0 && !type.isObject()) {
+    } else if (type.getCallSignatures().length > 0) {
       // It's a function!
       const callSignature = getFunctionCallSignature(type)
       const funcReturnType = callSignature.getReturnType()
@@ -330,6 +330,11 @@ export function createType(
     } else if (type.isInterface()) {
       // It is an `interface T { ... }`, which is a `struct`
       const typename = type.getSymbolOrThrow().getName()
+      if (type.getConstructSignatures().length > 0) {
+        throw new Error(
+          `Type ${typename} has constructor signatures - this type cannot be represented in native. (From ${type.getText()})`
+        )
+      }
       const properties = getInterfaceProperties(language, type)
       return new StructType(typename, properties)
     } else if (type.isObject()) {


### PR DESCRIPTION
Interfaces are simple flat types - they are not stateful and don't have constructors - if you pass a type with a constructor to nitrogen, you likely made a mistake.
If you need constructible or stateful types, use HybridObjects.

So we throw here.