### PR TITLE
feat: Add explicit type for better TypeScript errors on wrapped callbacks on Nitro views

### DIFF
--- a/packages/react-native-nitro-modules/src/views/getHostComponent.ts
+++ b/packages/react-native-nitro-modules/src/views/getHostComponent.ts
@@ -58,6 +58,7 @@ interface DefaultHybridViewProps<RefType> {
  * because RN converts them to booleans (`true`). As a workaround,
  * Nitro requires you to wrap each function using `callback(...)`,
  * which bypasses React Native's conversion.
+ * Please see the [Callbacks have to be wrapped](https://nitro.margelo.com/docs/view-components#callbacks-have-to-be-wrapped) section for more information.
  *
  * @type {Object} NitroViewWrappedCallback
  * @property {T} f - The wrapped callback function


### PR DESCRIPTION
This PR simply wraps the type for wrapped callbacks (`{ f: T }`) in an explicit type, that improves TypeScript errors shown to the user, when a callback prop is not wrapped in `callback(...)`

The typescript will therefore change slightly, allowing for a better developer experience:

_Example: A `onMeasurement` callback prop on `TtiMeasurementView`_

**Before**

```
Type '(measurement: TtiMeasurementValue) => void' is not assignable to type '{ f: (measurement: TtiMeasurementValue) => void; }'.ts(2322)
```

**After**

```
Type '(measurement: TtiMeasurementValue) => void' is not assignable to type 'NitroViewWrappedCallback<(measurement: TtiMeasurementValue) => void>'.ts(2322)
```

As seen above, the developer will now see an explicit `NitroViewWrappedCallback` type, which the they can look up for further necessary steps.