### PR TITLE
fix: Make `JNull` hold a `global_ref` instead of an `alias_ref` for static field `NULL`

### DIFF
--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/JNull.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/JNull.hpp
@@ -21,11 +21,12 @@ public:
   static constexpr auto kJavaDescriptor = "Lcom/margelo/nitro/core/NullType;";
 
 public:
-  static jni::alias_ref<JNull> null() {
+  static jni::global_ref<JNull> null() {
     static const auto clazz = javaClassStatic();
     static const auto nullField = clazz->getStaticField<JNull>("NULL");
     static const auto nullValue = clazz->getStaticFieldValue(nullField);
-    return nullValue;
+    static const auto globalNullValue = jni::make_global(nullValue);
+    return globalNullValue;
   }
 };
 


### PR DESCRIPTION
No idea why, but apparently there was a crash where the `JNull::null()` return value (`jni::alias_ref<JNull>`) was an invalid reference, even tho it points to a constant static field from Java.
How can this be null?

Whatever - we make it a global_ref, now it's always safe in memory.