### PR TITLE
feat(nitrogen): add error summary on generation failure

### DIFF
--- a/packages/nitrogen/src/Logger.ts
+++ b/packages/nitrogen/src/Logger.ts
@@ -30,11 +30,6 @@ function getIndentation(): string {
   return string
 }
 
-export interface GenerationError {
-  typeName: string
-  error: string
-}
-
 export const Logger = {
   withIndented(callback: () => void) {
     try {
@@ -64,31 +59,5 @@ export const Logger = {
     if (isAtLeast('error')) {
       console.error(getIndentation() + message, ...extra)
     }
-  },
-
-  summary: {
-    success(successCount: number, totalCount: number) {
-      console.log(
-        `\n✅  All specs generated successfully (${successCount}/${totalCount})\n`
-      )
-    },
-
-    failure(errors: GenerationError[], successCount: number) {
-      console.log(`\n❌  Nitrogen generation failed\n`)
-
-      for (const { typeName, error } of errors) {
-        const errorPreview =
-          (error ?? 'Unknown error').split('\n')[0]?.substring(0, 80) ??
-          'Unknown error'
-        console.log(`    • ${typeName}: ${errorPreview}`)
-      }
-
-      if (successCount > 0) {
-        console.log(
-          `\n    ${successCount} spec${successCount === 1 ? '' : 's'} succeeded`
-        )
-      }
-      console.log('')
-    },
   },
 }


### PR DESCRIPTION
Adds a clear summary at the end of nitrogen output when specs fail to generate, making failures harder to miss.

## Output comparison

|  | Success | Failure |
|--|---------|---------|
| **Before** | `...`<br>`🎉 Generated 13/13 HybridObjects...` | `...`<br>`⚙️ Generating specs for "RiveFile"...`<br>`    ❌ Failed to generate spec for RiveFile!`<br><br>`...` *(many more specs)* `...`<br><br>`🎉 Generated 12/13 HybridObjects...` |
| **After** | `...`<br>`✅ All specs generated successfully (13/13)`<br>`🎉 Generated 13/13 HybridObjects...` | `...`<br>`⚙️ Generating specs for "RiveFile"...`<br>`    ❌ Failed to generate spec for RiveFile!`<br><br>`...` *(many more specs)* `...`<br><br>`❌ Nitrogen generation failed`<br>`    • RiveFile: Error: The TypeScript type "any"...`<br>`    12 specs succeeded`<br>`🎉 Generated 12/13 HybridObjects...` |

The problem was that failures were easy to miss - the error appeared inline during generation and could scroll by unnoticed when processing many specs. Now there's always a clear summary at the end.