### PR TITLE
test: add failing test case for self-referential struct types

### DIFF
--- a/packages/react-native-nitro-test/src/specs/Cyclic.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/Cyclic.nitro.ts
@@ -1,0 +1,10 @@
+import type { HybridObject } from 'react-native-nitro-modules'
+
+export interface Node {
+  node?: Node
+}
+
+export interface Cyclic
+  extends HybridObject<{ ios: 'swift'; android: 'kotlin' }> {
+  node?: Node
+}


### PR DESCRIPTION
Demonstrates that Nitrogen crashes with "Maximum call stack size exceeded" when parsing self-referential struct types like `Node { node?: Node }`.