### PR TITLE
feat(nitrogen): Improve error message for cyclic struct references

### DIFF
--- a/docs/docs/types/custom-structs.md
+++ b/docs/docs/types/custom-structs.md
@@ -103,6 +103,25 @@ interface PartialPerson
 
 This way TypeScript always keeps the `interface` in-tact, allowing Nitrogen to properly process it.
 
+## Cyclic references are not supported
+
+Direct or indirect cyclic struct references are not supported:
+
+```ts title="Direct cycle ❌"
+interface Node {
+  child: Node
+}
+```
+
+```ts title="Indirect cycle ❌"
+interface A {
+  b: B
+}
+interface B {
+  a: A
+}
+```
+
 ## Structs are eagerly converted
 
 Since structs are just flat value types, each key/value is eagerly converted from a JS value to a native value (and vice-versa) when passing them between JS and native.

--- a/packages/nitrogen/src/utils.ts
+++ b/packages/nitrogen/src/utils.ts
@@ -35,6 +35,14 @@ export function errorToString(error: unknown): string {
   if (typeof error !== 'object') {
     return `${error}`
   }
+  if (error instanceof RangeError && error.message.includes('Maximum call stack size exceeded')) {
+    return (
+      `${error.name}: ${error.message}\n` +
+      `This is likely caused by a direct or indirect cyclic struct reference ` +
+      `(e.g. \`interface Node { child: Node }\` or \`interface A { b: B }\` and \`interface B { a: A }\`).\n` +
+      `See: https://nitro.margelo.com/docs/types/custom-structs#cyclic-references-are-not-supported`
+    )
+  }
   if (error instanceof Error) {
     let message = `${error.name}: ${error.message}`
     if (error.cause != null) {


### PR DESCRIPTION
  - Adds a helpful error message when Nitrogen encounters a stack overflow possibly due to cyclic struct references
  - Documents the limitation in the custom-structs docs with examples of direct and indirect cycles
  - Links the error message to the docs for more info