### PR TITLE
test: add SelfReferentialStruct test case

### DIFF
--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -88,6 +88,12 @@ interface MapWrapper {
   map: Record<string, string>
   secondMap: SecondMapWrapper
 }
+
+// Self-referential callback in struct (not cyclic - callback is a reference type)
+export interface SelfReferentialStruct {
+  transform?: (config: SelfReferentialStruct) => Promise<SelfReferentialStruct>
+}
+
 export type CustomString = CustomType<
   string,
   'CustomString',
@@ -234,6 +240,7 @@ interface SharedTestObjectProps {
   bounceWrappedJsStyleStruct(value: WrappedJsStruct): WrappedJsStruct
   bounceOptionalWrapper(wrapper: OptionalWrapper): OptionalWrapper
   bounceOptionalCallback(value: OptionalCallback): OptionalCallback
+  bounceSelfReferentialStruct(value: SelfReferentialStruct): SelfReferentialStruct
 
   // ArrayBuffers
   createArrayBuffer(): ArrayBuffer


### PR DESCRIPTION
Adds a struct with a callback that references the same struct type.

Currently fails with "Maximum call stack size exceeded" due to infinite recursion in nitrogen's type walker.