### PR TITLE
fix(example): prevent "Nitro linked twice" error in monorepo

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,12 +1,7 @@
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config')
 const path = require('path')
-const exclusionList = require('metro-config/private/defaults/exclusionList').default
-const escape = require('escape-string-regexp')
 
 const root = path.resolve(__dirname, '..')
-
-// Modules that should only be loaded once (from root), not duplicated
-const blockedModules = ['react-native-nitro-modules']
 
 /**
  * Metro configuration
@@ -20,12 +15,10 @@ const config = {
   // Block duplicate copies of react-native-nitro-modules from nested node_modules
   // to ensure the module is only loaded once (preventing "Nitro linked twice" error)
   resolver: {
-    blockList: exclusionList(
-      blockedModules.flatMap((m) => [
-        // Block from packages/*/node_modules (nested copies)
-        new RegExp(`^${escape(path.join(root, 'packages'))}/.*/node_modules/${escape(m)}\\/.*$`),
-      ])
-    ),
+    blockList: [
+      // Matches packages/*/node_modules/react-native-nitro-modules (uses [\/\\] for OS-agnostic separators)
+      /[\/\\]packages[\/\\][^\/\\]+[\/\\]node_modules[\/\\]react-native-nitro-modules[\/\\]/,
+    ],
   },
 
   transformer: {


### PR DESCRIPTION
## Summary
Use Metro's blockList to exclude duplicate copies of `react-native-nitro-modules` from nested `node_modules` in `packages/*/`. This ensures the module is only loaded once from the root, preventing the "NitroModules.install() was already called" error on Android.

Regression from 00513e5c which removed the exclusionList.

## Test plan
- [x] Verified Android example app runs without "Nitro linked twice" error
- [x] Verified iOS example app runs correctly