### PR TITLE
fix(example): add dark mode text colors to test screens

### DIFF
--- a/example/src/components/TestCase.tsx
+++ b/example/src/components/TestCase.tsx
@@ -28,9 +28,9 @@ export function TestCase({
       ]}
     >
       <View style={styles.testBox}>
-        <Text style={styles.testName}>{test.runner.name}</Text>
+        <Text style={[styles.testName, { color: colors.text }]}>{test.runner.name}</Text>
         <View style={styles.smallVSpacer} />
-        <Text style={styles.testStatus} numberOfLines={6}>
+        <Text style={[styles.testStatus, { color: colors.textSecondary }]} numberOfLines={6}>
           {test.state} ({test.extraMessage})
         </Text>
       </View>

--- a/example/src/screens/HybridObjectTestsScreen.tsx
+++ b/example/src/screens/HybridObjectTestsScreen.tsx
@@ -203,7 +203,7 @@ export function HybridObjectTestsScreen() {
     <View style={[styles.container, { paddingTop: safeArea.top }]}>
       <KeyboardDismissBackground />
 
-      <Text style={styles.header}>HybridObject Tests</Text>
+      <Text style={[styles.header, { color: colors.text }]}>HybridObject Tests</Text>
       <View style={styles.topControls}>
         <SegmentedControl
           style={styles.segmentedControl}
@@ -214,15 +214,12 @@ export function HybridObjectTestsScreen() {
           }}
         />
         <View style={styles.flex} />
-        <Text style={styles.buildTypeText}>{NitroModules.buildType}</Text>
+        <Text style={[styles.buildTypeText, { color: colors.text }]}>{NitroModules.buildType}</Text>
       </View>
 
       <View style={styles.searchContainer}>
         <TextInput
-          style={[
-            styles.searchInput,
-            { color: colors.text, borderColor: colors.border },
-          ]}
+          style={[styles.searchInput, { color: colors.text, borderColor: colors.border }]}
           placeholder="Search tests..."
           placeholderTextColor={colors.textSecondary}
           value={searchQuery}
@@ -232,7 +229,7 @@ export function HybridObjectTestsScreen() {
           clearButtonMode="while-editing"
         />
         {searchQuery.length > 0 && (
-          <Text style={styles.searchResultsText}>
+          <Text style={[styles.searchResultsText, { color: colors.textSecondary }]}>
             Showing {searchFilteredTests.length} of {unfilteredTests.length}{' '}
             tests
           </Text>
@@ -255,7 +252,7 @@ export function HybridObjectTestsScreen() {
         keyExtractor={(test) => test.runner.name}
         ListEmptyComponent={
           <View style={styles.emptyContainer}>
-            <Text>Nothing selected.</Text>
+            <Text style={{ color: colors.textSecondary }}>Nothing selected.</Text>
           </View>
         }
         renderItem={({ item: test, index }) => (
@@ -268,7 +265,7 @@ export function HybridObjectTestsScreen() {
       />
 
       <View style={[styles.bottomView, { backgroundColor: colors.background }]}>
-        <Text style={styles.resultText} numberOfLines={2}>
+        <Text style={[styles.resultText, { color: colors.text }]} numberOfLines={2}>
           {status}
         </Text>
         <View style={styles.flex} />


### PR DESCRIPTION
## Summary
Text was invisible on dark backgrounds in the example app. Add dynamic text colors using the existing `useColors()` hook to support both light and dark modes.

## Test plan
- [x] Verified text is visible in dark mode on iOS
- [x] Verified text is visible in dark mode on Android