### PR TITLE
feat: Add `companion object` to Kotlin enums/structs

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinEnum.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinEnum.ts
@@ -24,6 +24,8 @@ import com.facebook.proguard.annotations.DoNotStrip
 @Keep
 enum class ${enumType.enumName}(@DoNotStrip @Keep val value: Int) {
   ${indent(members.join(',\n'), '  ')};
+
+  companion object
 }
   `.trim()
 

--- a/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
@@ -64,7 +64,7 @@ data class ${structType.structName}(
 ) {
   ${indent(secondaryConstructor, '  ')}
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Car.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Car.kt
@@ -53,7 +53,7 @@ data class Car(
 ) {
   /* primary constructor */
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/ColorScheme.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/ColorScheme.kt
@@ -18,4 +18,6 @@ import com.facebook.proguard.annotations.DoNotStrip
 enum class ColorScheme(@DoNotStrip @Keep val value: Int) {
   LIGHT(0),
   DARK(1);
+
+  companion object
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/ExternalObjectStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/ExternalObjectStruct.kt
@@ -23,7 +23,7 @@ data class ExternalObjectStruct(
 ) {
   /* primary constructor */
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
@@ -30,7 +30,7 @@ data class JsStyleStruct(
   constructor(value: Double, onChanged: (num: Double) -> Unit):
          this(value, Func_void_double_java(onChanged))
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/MapWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/MapWrapper.kt
@@ -26,7 +26,7 @@ data class MapWrapper(
 ) {
   /* primary constructor */
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OldEnum.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OldEnum.kt
@@ -19,4 +19,6 @@ enum class OldEnum(@DoNotStrip @Keep val value: Int) {
   FIRST(0),
   SECOND(1),
   THIRD(2);
+
+  companion object
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalCallback.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalCallback.kt
@@ -23,7 +23,7 @@ data class OptionalCallback(
 ) {
   /* primary constructor */
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalWrapper.kt
@@ -26,7 +26,7 @@ data class OptionalWrapper(
 ) {
   /* primary constructor */
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/PartialPerson.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/PartialPerson.kt
@@ -26,7 +26,7 @@ data class PartialPerson(
 ) {
   /* primary constructor */
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Person.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Person.kt
@@ -26,7 +26,7 @@ data class Person(
 ) {
   /* primary constructor */
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Powertrain.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Powertrain.kt
@@ -19,4 +19,6 @@ enum class Powertrain(@DoNotStrip @Keep val value: Int) {
   ELECTRIC(0),
   GAS(1),
   HYBRID(2);
+
+  companion object
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/SecondMapWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/SecondMapWrapper.kt
@@ -23,7 +23,7 @@ data class SecondMapWrapper(
 ) {
   /* primary constructor */
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WeirdNumbersEnum.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WeirdNumbersEnum.kt
@@ -19,4 +19,6 @@ enum class WeirdNumbersEnum(@DoNotStrip @Keep val value: Int) {
   A(0),
   B(32),
   C(64);
+
+  companion object
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WrappedJsStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WrappedJsStruct.kt
@@ -26,7 +26,7 @@ data class WrappedJsStruct(
 ) {
   /* primary constructor */
 
-  private companion object {
+  companion object {
     /**
      * Constructor called from C++
      */


### PR DESCRIPTION
This allows extending Kotlin `struct`s and `enum`s with "static" methods and values in user-code, for example:

```kt
fun MyCustomEnum.Companion.parseFromOtherValue(value: Int): MyCustomEnum {
  return when (value) { ... }
}
```

Or:

```kt
val MyCustomEnum.Companion.defaultValue: MyCustomEnum = MyCustomEnum.FIRST
```

This was already possible in Swift via `static` method/property extensions.