### PR TITLE
fix: Remove `postinstall` hook from individual packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "docs"
   ],
   "scripts": {
+    "postinstall": "bun run build",
     "build": "bun nitro build && bun nitrogen build && bun nitro-test-external build && bun nitro-test build",
     "bootstrap": "bun i && bun run build && cd example && bundle install && bun pods",
     "typecheck": "bun --filter=\"**\" typecheck",

--- a/packages/nitrogen/package.json
+++ b/packages/nitrogen/package.json
@@ -26,7 +26,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "postinstall": "bun build || exit 0;",
     "build": "bun tsc",
     "start": "tsc && node lib/index.js",
     "typecheck": "tsc --noEmit",

--- a/packages/react-native-nitro-modules/package.json
+++ b/packages/react-native-nitro-modules/package.json
@@ -59,7 +59,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "postinstall": "bun build || exit 0;",
     "write-native-version": "version=$(node -p \"require('./package.json').version\") && sed -i '' \"s/#define NITRO_VERSION \\\".*\\\"/#define NITRO_VERSION \\\"$version\\\"/\" ./cpp/utils/NitroDefines.hpp",
     "postversion": "bun run write-native-version",
     "build": "rm -rf lib && bun typecheck && bob build",

--- a/packages/react-native-nitro-test-external/package.json
+++ b/packages/react-native-nitro-test-external/package.json
@@ -28,7 +28,6 @@
     "README.md"
   ],
   "scripts": {
-    "postinstall": "tsc || exit 0;",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf android/build node_modules/**/android/build lib",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",

--- a/packages/react-native-nitro-test/package.json
+++ b/packages/react-native-nitro-test/package.json
@@ -45,7 +45,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "postinstall": "bun build || exit 0;",
     "build": "bun tsc",
     "test": "jest",
     "typecheck": "tsc --noEmit",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -28,7 +28,6 @@
     "README.md"
   ],
   "scripts": {
-    "postinstall": "tsc || exit 0;",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf android/build node_modules/**/android/build lib",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",


### PR DESCRIPTION
This PR moves the `postinstall` hook into the root `package.json` (which is the monorepo, not a shipped package), as some users experienced issues with it when installing the package from npm.

- Fixes #1082 