### PR TITLE
docs: Add min NDK version r27 to minimum requirements

### DIFF
--- a/docs/docs/minimum-requirements.md
+++ b/docs/docs/minimum-requirements.md
@@ -13,9 +13,11 @@ To use Nitro, make sure your app meets the minimum requirements:
   <TabItem value="ios" label="iOS" default>
     - react-native 0.75 or higher
     - Xcode 16.4 or higher
+    - Swift 5.9 or higher
   </TabItem>
   <TabItem value="android" label="Android">
     - react-native 0.75 or higher
     - `compileSdkVersion` 34 or higher
+    - `ndkVersion` 27 or higher
   </TabItem>
 </Tabs>


### PR DESCRIPTION
NDK r27 is required for 16kb page sizes. It's a good practice to always be on the latest NDK (r28) anyways.

- Resolves https://github.com/mrousavy/nitro/issues/1087