### PR TITLE
fix: Improve 16kb page size compatibility on android for NDK < 27

### DIFF
--- a/packages/react-native-nitro-modules/android/CMakeLists.txt
+++ b/packages/react-native-nitro-modules/android/CMakeLists.txt
@@ -47,6 +47,11 @@ find_library(LOG_LIB log)
 find_package(fbjni REQUIRED NitroConfig)
 find_package(ReactAndroid REQUIRED NitroConfig)
 
+# Set max page size to 16KB for older NDK versions
+if(CMAKE_ANDROID_NDK_VERSION VERSION_LESS "27")
+    target_link_options(NitroModules PRIVATE "-Wl,-z,max-page-size=16384")
+endif()
+
 # Link all libraries together
 target_link_libraries(
         NitroModules


### PR DESCRIPTION
I found that some Android environments using older NDK versions may encounter 16 KB page size issues due to incompatible default page sizes. Explicitly setting a 16 KB maximum page size improves compatibility across different NDK versions.
https://developer.android.com/guide/practices/page-sizes#compile-r26-lower

<img width="990" height="181" alt="image" src="https://github.com/user-attachments/assets/a1f83f6d-d3a1-4302-94b5-5885289d5396" />
