### PR TITLE
Use correct import path for ReactNativeVersion.h

### DIFF
--- a/packages/react-native-nitro-modules/cpp/utils/ObjectUtils.cpp
+++ b/packages/react-native-nitro-modules/cpp/utils/ObjectUtils.cpp
@@ -10,8 +10,8 @@
 #include "JSIHelpers.hpp"
 #include "NitroDefines.hpp"
 
-#if __has_include(<React-cxxreact/cxxreact/ReactNativeVersion.h>)
-#include <React-cxxreact/cxxreact/ReactNativeVersion.h>
+#if __has_include(<cxxreact/ReactNativeVersion.h>)
+#include <cxxreact/ReactNativeVersion.h>
 #if REACT_NATIVE_VERSION_MINOR >= 78
 #define ENABLE_NATIVE_OBJECT_CREATE
 #endif


### PR DESCRIPTION
When building for iOS, importing `React-cxxreact/cxxreact/ReactNativeVersion.h` works as expected. On Android, this path is not configured. It doesn't error because of the `#if __has_include`.

This means that on Android the React Native version check does not work, and so `ENABLE_NATIVE_OBJECT_CREATE` is not defined on Android.

See https://github.com/mrousavy/nitro/issues/1107