### PR TITLE
perf: Avoid locks in `JSICache`

### DIFF
--- a/example/ios/NitroExample.xcodeproj/xcshareddata/xcschemes/NitroExample.xcscheme
+++ b/example/ios/NitroExample.xcodeproj/xcshareddata/xcschemes/NitroExample.xcscheme
@@ -41,7 +41,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/example/src/screens/EvalScreen.tsx
+++ b/example/src/screens/EvalScreen.tsx
@@ -24,7 +24,34 @@ const NitroModules = globalThis.NitroModulesProxy;
 const DEFAULT_CODE = `
 const testObject = NitroModules.createHybridObject('TestObjectCpp')
 
-JSON.stringify(testObject)
+const start = performance.now()
+
+for (let i = 0; i < 100_000; i++) {
+    testObject.bounceCar({
+    year: 2006,
+    make: 'Mitsubishi',
+    model: 'Evolution IX',
+    power: 280,
+    powertrain: 'gas',
+    driver: {
+      age: 24,
+      name: 'Marc'
+    },
+    passengers: [
+      { age: 18, name: 'Lukas' },
+      { age: 23, name: 'Simon' },
+    ],
+    isFast: true,
+    favouriteTrack: 'the road',
+    performanceScores: [2, 5],
+    someVariant: 'hello!',
+  })
+}
+
+const end = performance.now()
+const time = \`\${(end - start).toFixed(2)}ms\`
+
+time
 `.trim()
 
 export function EvalScreen() {


### PR DESCRIPTION
Theoretically we don't need a lock in `JSICache`.

I'm still testing if this breaks under constant hot-reloads (or when runtimes tear down often, e.g. in react-native-worklets)