### PR TITLE
perf: Use ASCII instead of UTF8 for PropNames

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/BoxedHybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/BoxedHybridObject.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "BoxedHybridObject.hpp"
+#include "PropNameIDCache.hpp"
 
 namespace margelo::nitro {
 
@@ -18,7 +19,7 @@ jsi::Value BoxedHybridObject::get(jsi::Runtime& runtime, const jsi::PropNameID& 
 
   if (name == "unbox") {
     return jsi::Function::createFromHostFunction(
-        runtime, jsi::PropNameID::forUtf8(runtime, "unbox"), 0,
+        runtime, PropNameIDCache::get(runtime, "unbox"), 0,
         [hybridObject = _hybridObject](jsi::Runtime& runtime, const jsi::Value&, const jsi::Value*, size_t) -> jsi::Value {
           return hybridObject->toObject(runtime);
         });

--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -91,7 +91,7 @@ jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
                                             // .configurable has to be true because this property is non-frozen
                                             .configurable = true,
                                             .enumerable = true,
-                                            .value = jsi::String::createFromUtf8(runtime, typeName),
+                                            .value = jsi::String::createFromAscii(runtime, typeName),
                                             .writable = false,
                                         });
 #endif

--- a/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
+++ b/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
@@ -83,7 +83,7 @@ jsi::Value HybridObjectPrototype::createPrototype(jsi::Runtime& runtime, const s
                                         PlainPropertyDescriptor{
                                             .configurable = false,
                                             .enumerable = true,
-                                            .value = jsi::String::createFromUtf8(runtime, prototypeName),
+                                            .value = jsi::String::createFromAscii(runtime, prototypeName),
                                             .writable = false,
                                         });
 #endif

--- a/packages/react-native-nitro-modules/cpp/utils/PropNameIDCache.cpp
+++ b/packages/react-native-nitro-modules/cpp/utils/PropNameIDCache.cpp
@@ -24,7 +24,7 @@ const jsi::PropNameID& PropNameIDCache::get(jsi::Runtime& runtime, const std::st
   }
 
   // not cached - create the jsi::PropNameID...
-  auto propName = jsi::PropNameID::forUtf8(runtime, value);
+  auto propName = jsi::PropNameID::forAscii(runtime, value);
   auto jsiCache = JSICache::getOrCreateCache(runtime);
   auto sharedPropName = jsiCache.makeShared(std::move(propName));
 

--- a/packages/react-native-nitro-modules/cpp/utils/PropNameIDCache.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/PropNameIDCache.hpp
@@ -31,8 +31,9 @@ public:
 
   /**
    * Get a `jsi::PropNameID` for the given `std::string` value.
-   * The `jsi::PropNameID` is only valid within the callee's current
-   * synchronous scope, and must be non-escaping.
+   * - The `std::string` must be an ASCII string.
+   * - The `jsi::PropNameID` is only valid within the callee's current
+   *   synchronous scope, and must be non-escaping.
    */
   static const jsi::PropNameID& get(jsi::Runtime& runtime, const std::string& value);
 


### PR DESCRIPTION
Prop Names (that's method and property names) were previously converted to- and from UTF8 `std::string`s.

It is rather rate (and theoretically also unsupported in C++) to have non-ASCII names for properties or methods, so I now replaced that with ASCII methods for slightly faster performance, as no UTF8 conversion needs to happen.

Nothing has been measured.