### PR TITLE
chore: Fix NitroExample release build after RN 0.83 upgrade on Android

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -45,7 +45,7 @@ react {
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
-    hermesCommand = "$rootDir/../../node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
+    hermesCommand = "$rootDir/../../node_modules/hermes-compiler/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]


### PR DESCRIPTION
In react-native 0.83 the path to `hermesc` changed. This PR fixes the issue to update the release build path.

My android build fails with this error.
<img width="1404" height="266" alt="image" src="https://github.com/user-attachments/assets/3a862aec-4dc4-4efd-b094-c4845e388c0d" />

I think this should fix this

