### PR TITLE
fix: map `null` value to `std::nullopt` for optional types

### DIFF
--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Optional.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+Optional.hpp
@@ -25,9 +25,14 @@ struct JSIConverter<std::optional<TInner>> final {
   static inline std::optional<TInner> fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
     if (arg.isUndefined()) {
       return std::nullopt;
-    } else {
-      return JSIConverter<TInner>::fromJSI(runtime, arg);
     }
+    if (arg.isNull()) {
+      if (JSIConverter<TInner>::canConvert(runtime, arg)) {
+        return JSIConverter<TInner>::fromJSI(runtime, arg);
+      }
+      return std::nullopt;
+    }
+    return JSIConverter<TInner>::fromJSI(runtime, arg);
   }
   static inline jsi::Value toJSI(jsi::Runtime& runtime, const std::optional<TInner>& arg) {
     if (arg == std::nullopt) {
@@ -37,7 +42,7 @@ struct JSIConverter<std::optional<TInner>> final {
     }
   }
   static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
-    if (value.isUndefined()) {
+    if (value.isUndefined() || value.isNull()) {
       return true;
     }
     if (JSIConverter<TInner>::canConvert(runtime, value)) {


### PR DESCRIPTION
Fixes #1184

When a prop on a fabric view is removed it's value returns `null` rather than `undefined`, this causes issues on optional types in Nitro where only `undefined` and explicitly specified values are accepted

These changes allow an optional to accept a `null` value which will be mapped to `std::nullopt`

If an optional has `null` specified as an accepted type then this will not be affected by these changes and you will still have distinction between `null` and `undefined` values if needed