### PR TITLE
perf:- preallocate size during AnyMap::make() . ~12% faster

### DIFF
--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+AnyMap.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+AnyMap.hpp
@@ -47,7 +47,7 @@ struct JSIConverter<std::shared_ptr<AnyMap>> final {
     jsi::Object object = arg.asObject(runtime);
     jsi::Array propNames = object.getPropertyNames(runtime);
     size_t size = propNames.size(runtime);
-    std::shared_ptr<AnyMap> map = AnyMap::make();
+    std::shared_ptr<AnyMap> map = AnyMap::make(size);
     for (size_t i = 0; i < size; i++) {
       std::string jsKey = propNames.getValueAtIndex(runtime, i).getString(runtime).utf8(runtime);
       jsi::Value jsValue = object.getProperty(runtime, PropNameIDCache::get(runtime, jsKey));

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -272,7 +272,7 @@ std::shared_ptr<AnyMap> HybridTestObjectCpp::mergeMaps(const std::shared_ptr<Any
 
 std::shared_ptr<AnyMap> HybridTestObjectCpp::copyAnyMap(const std::shared_ptr<AnyMap>& map) {
   auto keys = map->getAllKeys();
-  auto newMap = AnyMap::make();
+  auto newMap = AnyMap::make(keys.size());
   for (const auto& key : keys) {
     auto any = map->getAny(key);
     newMap->setAny(key, any);


### PR DESCRIPTION
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/a210f394-4a46-47e0-a751-f122f21403a3" />
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/fb4a0724-b9f7-49dc-9936-526ab11c0ef8" />


To be honest I was lucky here to get this difference (when I took this screenshot) . After that I tried few more times. This was around 12%-15%faster