### PR TITLE
fix: Run `ThreadUtils::setThreadName(...)` under `jni::ThreadScope`

### DIFF
--- a/packages/react-native-nitro-modules/android/src/main/cpp/platform/ThreadUtils.cpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/platform/ThreadUtils.cpp
@@ -25,8 +25,10 @@ std::string ThreadUtils::getThreadName() {
 }
 
 void ThreadUtils::setThreadName(const std::string& name) {
-  auto jName = jni::make_jstring(name);
-  JThreadUtils::setCurrentThreadName(jName);
+  jni::ThreadScope::WithClassLoader([&]() {
+    auto jName = jni::make_jstring(name);
+    JThreadUtils::setCurrentThreadName(jName);
+  });
 }
 
 bool ThreadUtils::isUIThread() {


### PR DESCRIPTION
This fixes a crash on Android.