### PR TITLE
fix: Fix `PropNameIDCache` not overwriting stale values in cache

### DIFF
--- a/packages/react-native-nitro-modules/cpp/utils/PropNameIDCache.cpp
+++ b/packages/react-native-nitro-modules/cpp/utils/PropNameIDCache.cpp
@@ -33,7 +33,7 @@ const jsi::PropNameID& PropNameIDCache::get(jsi::Runtime& runtime, const std::st
   auto sharedPropName = jsiCache.makeShared(std::move(propName));
 
   // store it in cache...
-  cache.emplace(value, sharedPropName);
+  cache.insert_or_assign(value, sharedPropName);
 
   // return it!
   return *sharedPropName;


### PR DESCRIPTION
Addresses: #1150 

Its possible that a PropNameID becomes stale, but we wouldn't reassign the key in the cache map