### PR TITLE
fix: Fix `AnyMap` not overwriting keys

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/AnyMap.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/AnyMap.cpp
@@ -164,28 +164,28 @@ AnyValue AnyMap::getAny(const std::string& key) const {
 
 // Set
 void AnyMap::setNull(const std::string& key) {
-  _map.emplace(key, nitro::null);
+  _map.insert_or_assign(key, nitro::null);
 }
 void AnyMap::setDouble(const std::string& key, double value) {
-  _map.emplace(key, value);
+  _map.insert_or_assign(key, value);
 }
 void AnyMap::setBoolean(const std::string& key, bool value) {
-  _map.emplace(key, value);
+  _map.insert_or_assign(key, value);
 }
 void AnyMap::setBigInt(const std::string& key, int64_t value) {
-  _map.emplace(key, value);
+  _map.insert_or_assign(key, value);
 }
 void AnyMap::setString(const std::string& key, const std::string& value) {
-  _map.emplace(key, value);
+  _map.insert_or_assign(key, value);
 }
 void AnyMap::setArray(const std::string& key, const AnyArray& value) {
-  _map.emplace(key, value);
+  _map.insert_or_assign(key, value);
 }
 void AnyMap::setObject(const std::string& key, const AnyObject& value) {
-  _map.emplace(key, value);
+  _map.insert_or_assign(key, value);
 }
 void AnyMap::setAny(const std::string& key, const AnyValue& value) {
-  _map.emplace(key, value);
+  _map.insert_or_assign(key, value);
 }
 
 // C++ getter

--- a/packages/react-native-nitro-modules/cpp/prototype/Prototype.hpp
+++ b/packages/react-native-nitro-modules/cpp/prototype/Prototype.hpp
@@ -60,16 +60,12 @@ public:
   static std::shared_ptr<Prototype> get(const NativeInstanceId& typeId, const std::shared_ptr<Prototype>& base = nullptr) {
     static std::unordered_map<NativeInstanceId, std::shared_ptr<Prototype>> _prototypesCache;
 
-    const auto& found = _prototypesCache.find(typeId);
-    if (found != _prototypesCache.end()) {
-      // We know this C++ type ID / Prototype - return it!
-      return found->second;
-    } else {
+    auto [it, inserted] = cache.try_emplace(typeId);
+    if (inserted) {
       // This is the first time we see this C++ type ID - create a new base Prototype for this.
-      auto prototype = std::shared_ptr<Prototype>(new Prototype(typeId, base));
-      _prototypesCache.emplace(typeId, prototype);
-      return prototype;
+      it->second = std::shared_ptr<Prototype>(new Prototype(typeId, base));
     }
+    return it->second;
   }
 
 public:

--- a/packages/react-native-nitro-modules/cpp/threading/ThreadPool.cpp
+++ b/packages/react-native-nitro-modules/cpp/threading/ThreadPool.cpp
@@ -64,12 +64,12 @@ void ThreadPool::run(std::function<void()>&& task) {
   }
   // New scope because of RAII lock
   {
-    // lock on the mutex - we want to emplace the task back in the queue
+    // lock on the mutex - we want to push the task back in the queue
     std::unique_lock<std::mutex> lock(_queueMutex);
     if (!_isAlive) {
       throw std::runtime_error("Cannot queue the given task - the ThreadPool has already been stopped!");
     }
-    _tasks.emplace(std::move(task));
+    _tasks.push(std::move(task));
   }
   // Notify about a new task - one of the workers will pick it up
   _condition.notify_one();


### PR DESCRIPTION
Fixes the usage of `emplace` in `AnyMap`; we want to use `insert_or_assign` instead so it can actually overwrite keys.