### PR TITLE
fix: Override `equals(...)` and `hashCode()` to make all Kotlin structs equatable

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1722,6 +1722,16 @@ export function getTests(
         .didNotThrow()
         .equals(false)
     ),
+    createTest('areCarsEqual(...) same car', () =>
+      it(() => testObject.areCarsEqual(TEST_CAR, TEST_CAR))
+        .didNotThrow()
+        .equals(true)
+    ),
+    createTest('areCarsEqual(...) different cars', () =>
+      it(() => testObject.areCarsEqual(TEST_CAR, TEST_CAR_2))
+        .didNotThrow()
+        .equals(false)
+    ),
     createTest('getDriver(...) with no driver', () =>
       it(() =>
         testObject.getDriver({

--- a/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
@@ -45,6 +45,13 @@ val ${name}: ${type.getTypeCode('kotlin', false)}
 
   const secondaryConstructor = createKotlinConstructor(structType)
 
+  const equalityComparators = structType.properties.map(
+    (p) => `Objects.deepEquals(this.${p.escapedName}, other.${p.escapedName})`
+  )
+  const propertiesList = structType.properties
+    .map((p) => p.escapedName)
+    .join(',\n')
+
   const code = `
 ${createFileMetadataString(`${structType.structName}.kt`)}
 
@@ -52,6 +59,7 @@ package ${packageName}
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 ${extraImports.join('\n')}
 
 /**
@@ -63,6 +71,18 @@ data class ${structType.structName}(
   ${indent(properties, '  ')}
 ) {
   ${indent(secondaryConstructor, '  ')}
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return ${equalityComparators.join(`\n      && `)}
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      ${indent(propertiesList, '      ')}
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
@@ -74,7 +74,7 @@ data class ${structType.structName}(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is ${structType.structName}) return false
     return ${equalityComparators.join(`\n      && `)}
   }
 

--- a/packages/react-native-nitro-test-external/nitrogen/generated/android/kotlin/com/margelo/nitro/test/external/OptionalPrimitivesHolder.kt
+++ b/packages/react-native-nitro-test-external/nitrogen/generated/android/kotlin/com/margelo/nitro/test/external/OptionalPrimitivesHolder.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test.external
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 
 
 /**
@@ -35,6 +36,24 @@ data class OptionalPrimitivesHolder(
    */
   constructor(optionalNumber: Double?, optionalBoolean: Boolean?, optionalUInt64: ULong?, optionalInt64: Long?):
          this(optionalNumber, optionalBoolean, optionalUInt64?.let { it.toLong() }, optionalInt64)
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.optionalNumber, other.optionalNumber)
+      && Objects.deepEquals(this.optionalBoolean, other.optionalBoolean)
+      && Objects.deepEquals(this.optionalUInt64, other.optionalUInt64)
+      && Objects.deepEquals(this.optionalInt64, other.optionalInt64)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      optionalNumber,
+      optionalBoolean,
+      optionalUInt64,
+      optionalInt64
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test-external/nitrogen/generated/android/kotlin/com/margelo/nitro/test/external/OptionalPrimitivesHolder.kt
+++ b/packages/react-native-nitro-test-external/nitrogen/generated/android/kotlin/com/margelo/nitro/test/external/OptionalPrimitivesHolder.kt
@@ -39,7 +39,7 @@ data class OptionalPrimitivesHolder(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is OptionalPrimitivesHolder) return false
     return Objects.deepEquals(this.optionalNumber, other.optionalNumber)
       && Objects.deepEquals(this.optionalBoolean, other.optionalBoolean)
       && Objects.deepEquals(this.optionalUInt64, other.optionalUInt64)

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -424,6 +424,13 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
     return car.powertrain == Powertrain.ELECTRIC
   }
 
+  override fun areCarsEqual(
+    a: Car,
+    b: Car,
+  ): Boolean {
+    return a == b
+  }
+
   override fun getDriver(car: Car): Person? {
     return car.driver
   }

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -428,7 +428,17 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
     a: Car,
     b: Car,
   ): Boolean {
-    return a == b
+    return a.year == b.year &&
+      a.make == b.make &&
+      a.model == b.model &&
+      a.power == b.power &&
+      a.powertrain == b.powertrain &&
+      a.driver == b.driver &&
+      a.passengers.contentEquals(b.passengers) &&
+      a.isFast == b.isFast &&
+      a.favouriteTrack == b.favouriteTrack &&
+      a.performanceScores.contentEquals(b.performanceScores) &&
+      a.someVariant == b.someVariant
   }
 
   override fun getDriver(car: Car): Person? {

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -590,6 +590,10 @@ bool HybridTestObjectCpp::isCarElectric(const Car& car) {
   return car.powertrain == Powertrain::ELECTRIC;
 }
 
+bool HybridTestObjectCpp::areCarsEqual(const Car& a, const Car& b) {
+  return a == b;
+}
+
 std::optional<Person> HybridTestObjectCpp::getDriver(const Car& car) {
   if (car.driver.has_value()) {
     return car.driver.value();

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -186,6 +186,7 @@ public:
   std::shared_ptr<Promise<std::optional<double>>> promiseThatResolvesToUndefined() override;
   Car getCar() override;
   bool isCarElectric(const Car& car) override;
+  bool areCarsEqual(const Car& a, const Car& b) override;
   std::optional<Person> getDriver(const Car& car) override;
   Car bounceCar(const Car& car) override;
   void jsStyleObjectAsParameters(const JsStyleStruct& params) override;

--- a/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
@@ -460,6 +460,10 @@ class HybridTestObjectSwift: HybridTestObjectSwiftKotlinSpec {
     return car.powertrain == .electric
   }
 
+  func areCarsEqual(a: Car, b: Car) throws -> Bool {
+    return a == b
+  }
+
   func getDriver(car: Car) throws -> Person? {
     return car.driver
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -1127,6 +1127,11 @@ namespace margelo::nitro::test {
     auto __result = method(_javaPart, JCar::fromCpp(car));
     return static_cast<bool>(__result);
   }
+  bool JHybridTestObjectSwiftKotlinSpec::areCarsEqual(const Car& a, const Car& b) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean(jni::alias_ref<JCar> /* a */, jni::alias_ref<JCar> /* b */)>("areCarsEqual");
+    auto __result = method(_javaPart, JCar::fromCpp(a), JCar::fromCpp(b));
+    return static_cast<bool>(__result);
+  }
   std::optional<Person> JHybridTestObjectSwiftKotlinSpec::getDriver(const Car& car) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPerson>(jni::alias_ref<JCar> /* car */)>("getDriver");
     auto __result = method(_javaPart, JCar::fromCpp(car));

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -152,6 +152,7 @@ namespace margelo::nitro::test {
     std::shared_ptr<Promise<void>> getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) override;
     Car getCar() override;
     bool isCarElectric(const Car& car) override;
+    bool areCarsEqual(const Car& a, const Car& b) override;
     std::optional<Person> getDriver(const Car& car) override;
     Car bounceCar(const Car& car) override;
     void jsStyleObjectAsParameters(const JsStyleStruct& params) override;

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Car.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Car.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 
 
 /**
@@ -52,6 +53,38 @@ data class Car(
   val someVariant: Variant_String_Double?
 ) {
   /* primary constructor */
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.year, other.year)
+      && Objects.deepEquals(this.make, other.make)
+      && Objects.deepEquals(this.model, other.model)
+      && Objects.deepEquals(this.power, other.power)
+      && Objects.deepEquals(this.powertrain, other.powertrain)
+      && Objects.deepEquals(this.driver, other.driver)
+      && Objects.deepEquals(this.passengers, other.passengers)
+      && Objects.deepEquals(this.isFast, other.isFast)
+      && Objects.deepEquals(this.favouriteTrack, other.favouriteTrack)
+      && Objects.deepEquals(this.performanceScores, other.performanceScores)
+      && Objects.deepEquals(this.someVariant, other.someVariant)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      year,
+      make,
+      model,
+      power,
+      powertrain,
+      driver,
+      passengers,
+      isFast,
+      favouriteTrack,
+      performanceScores,
+      someVariant
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/ExternalObjectStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/ExternalObjectStruct.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 import com.margelo.nitro.test.external.HybridSomeExternalObjectSpec
 
 /**
@@ -22,6 +23,18 @@ data class ExternalObjectStruct(
   val someExternal: com.margelo.nitro.test.external.HybridSomeExternalObjectSpec
 ) {
   /* primary constructor */
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.someExternal, other.someExternal)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      someExternal
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/ExternalObjectStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/ExternalObjectStruct.kt
@@ -26,7 +26,7 @@ data class ExternalObjectStruct(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is ExternalObjectStruct) return false
     return Objects.deepEquals(this.someExternal, other.someExternal)
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
@@ -486,6 +486,10 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun areCarsEqual(a: Car, b: Car): Boolean
+  
+  @DoNotStrip
+  @Keep
   abstract fun getDriver(car: Car): Person?
   
   @DoNotStrip

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 
 
 /**
@@ -29,6 +30,20 @@ data class JsStyleStruct(
    */
   constructor(value: Double, onChanged: (num: Double) -> Unit):
          this(value, Func_void_double_java(onChanged))
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.value, other.value)
+      && Objects.deepEquals(this.onChanged, other.onChanged)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      value,
+      onChanged
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/JsStyleStruct.kt
@@ -33,7 +33,7 @@ data class JsStyleStruct(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is JsStyleStruct) return false
     return Objects.deepEquals(this.value, other.value)
       && Objects.deepEquals(this.onChanged, other.onChanged)
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/MapWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/MapWrapper.kt
@@ -29,7 +29,7 @@ data class MapWrapper(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is MapWrapper) return false
     return Objects.deepEquals(this.map, other.map)
       && Objects.deepEquals(this.secondMap, other.secondMap)
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/MapWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/MapWrapper.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 
 
 /**
@@ -25,6 +26,20 @@ data class MapWrapper(
   val secondMap: SecondMapWrapper
 ) {
   /* primary constructor */
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.map, other.map)
+      && Objects.deepEquals(this.secondMap, other.secondMap)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      map,
+      secondMap
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalCallback.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalCallback.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 
 
 /**
@@ -22,6 +23,18 @@ data class OptionalCallback(
   val callback: Variant_______Unit_Double?
 ) {
   /* primary constructor */
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.callback, other.callback)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      callback
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalCallback.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalCallback.kt
@@ -26,7 +26,7 @@ data class OptionalCallback(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is OptionalCallback) return false
     return Objects.deepEquals(this.callback, other.callback)
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalWrapper.kt
@@ -29,7 +29,7 @@ data class OptionalWrapper(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is OptionalWrapper) return false
     return Objects.deepEquals(this.optionalArrayBuffer, other.optionalArrayBuffer)
       && Objects.deepEquals(this.optionalString, other.optionalString)
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/OptionalWrapper.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 import com.margelo.nitro.core.ArrayBuffer
 
 /**
@@ -25,6 +26,20 @@ data class OptionalWrapper(
   val optionalString: String?
 ) {
   /* primary constructor */
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.optionalArrayBuffer, other.optionalArrayBuffer)
+      && Objects.deepEquals(this.optionalString, other.optionalString)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      optionalArrayBuffer,
+      optionalString
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/PartialPerson.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/PartialPerson.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 
 
 /**
@@ -25,6 +26,20 @@ data class PartialPerson(
   val age: Double?
 ) {
   /* primary constructor */
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.name, other.name)
+      && Objects.deepEquals(this.age, other.age)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      name,
+      age
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/PartialPerson.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/PartialPerson.kt
@@ -29,7 +29,7 @@ data class PartialPerson(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is PartialPerson) return false
     return Objects.deepEquals(this.name, other.name)
       && Objects.deepEquals(this.age, other.age)
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Person.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Person.kt
@@ -29,7 +29,7 @@ data class Person(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is Person) return false
     return Objects.deepEquals(this.name, other.name)
       && Objects.deepEquals(this.age, other.age)
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Person.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Person.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 
 
 /**
@@ -25,6 +26,20 @@ data class Person(
   val age: Double
 ) {
   /* primary constructor */
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.name, other.name)
+      && Objects.deepEquals(this.age, other.age)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      name,
+      age
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/SecondMapWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/SecondMapWrapper.kt
@@ -26,7 +26,7 @@ data class SecondMapWrapper(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is SecondMapWrapper) return false
     return Objects.deepEquals(this.second, other.second)
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/SecondMapWrapper.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/SecondMapWrapper.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 
 
 /**
@@ -22,6 +23,18 @@ data class SecondMapWrapper(
   val second: Map<String, String>
 ) {
   /* primary constructor */
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.second, other.second)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      second
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WrappedJsStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WrappedJsStruct.kt
@@ -29,7 +29,7 @@ data class WrappedJsStruct(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Car) return false
+    if (other !is WrappedJsStruct) return false
     return Objects.deepEquals(this.value, other.value)
       && Objects.deepEquals(this.items, other.items)
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WrappedJsStruct.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/WrappedJsStruct.kt
@@ -9,6 +9,7 @@ package com.margelo.nitro.test
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import java.util.Objects
 
 
 /**
@@ -25,6 +26,20 @@ data class WrappedJsStruct(
   val items: Array<JsStyleStruct>
 ) {
   /* primary constructor */
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Car) return false
+    return Objects.deepEquals(this.value, other.value)
+      && Objects.deepEquals(this.items, other.items)
+  }
+
+  override fun hashCode(): Int {
+    return arrayOf(
+      value,
+      items
+    ).contentDeepHashCode()
+  }
 
   companion object {
     /**

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -734,6 +734,14 @@ namespace margelo::nitro::test {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline bool areCarsEqual(const Car& a, const Car& b) override {
+      auto __result = _swiftPart.areCarsEqual(std::forward<decltype(a)>(a), std::forward<decltype(b)>(b));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::optional<Person> getDriver(const Car& car) override {
       auto __result = _swiftPart.getDriver(std::forward<decltype(car)>(car));
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -95,6 +95,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func getValueFromJsCallback(callback: @escaping () -> Promise<String>, andThenCall: @escaping (_ valueFromJs: String) -> Void) throws -> Promise<Void>
   func getCar() throws -> Car
   func isCarElectric(car: Car) throws -> Bool
+  func areCarsEqual(a: Car, b: Car) throws -> Bool
   func getDriver(car: Car) throws -> Person?
   func bounceCar(car: Car) throws -> Car
   func jsStyleObjectAsParameters(params: JsStyleStruct) throws -> Void

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -1850,6 +1850,18 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
   }
   
   @inline(__always)
+  public final func areCarsEqual(a: Car, b: Car) -> bridge.Result_bool_ {
+    do {
+      let __result = try self.__implementation.areCarsEqual(a: a, b: b)
+      let __resultCpp = __result
+      return bridge.create_Result_bool_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_bool_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func getDriver(car: Car) -> bridge.Result_std__optional_Person__ {
     do {
       let __result = try self.__implementation.getDriver(car: car)

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -120,6 +120,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("getValueFromJsCallback", &HybridTestObjectCppSpec::getValueFromJsCallback);
       prototype.registerHybridMethod("getCar", &HybridTestObjectCppSpec::getCar);
       prototype.registerHybridMethod("isCarElectric", &HybridTestObjectCppSpec::isCarElectric);
+      prototype.registerHybridMethod("areCarsEqual", &HybridTestObjectCppSpec::areCarsEqual);
       prototype.registerHybridMethod("getDriver", &HybridTestObjectCppSpec::getDriver);
       prototype.registerHybridMethod("bounceCar", &HybridTestObjectCppSpec::bounceCar);
       prototype.registerHybridMethod("jsStyleObjectAsParameters", &HybridTestObjectCppSpec::jsStyleObjectAsParameters);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -220,6 +220,7 @@ namespace margelo::nitro::test {
       virtual std::shared_ptr<Promise<void>> getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) = 0;
       virtual Car getCar() = 0;
       virtual bool isCarElectric(const Car& car) = 0;
+      virtual bool areCarsEqual(const Car& a, const Car& b) = 0;
       virtual std::optional<Person> getDriver(const Car& car) = 0;
       virtual Car bounceCar(const Car& car) = 0;
       virtual void jsStyleObjectAsParameters(const JsStyleStruct& params) = 0;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -113,6 +113,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("getValueFromJsCallback", &HybridTestObjectSwiftKotlinSpec::getValueFromJsCallback);
       prototype.registerHybridMethod("getCar", &HybridTestObjectSwiftKotlinSpec::getCar);
       prototype.registerHybridMethod("isCarElectric", &HybridTestObjectSwiftKotlinSpec::isCarElectric);
+      prototype.registerHybridMethod("areCarsEqual", &HybridTestObjectSwiftKotlinSpec::areCarsEqual);
       prototype.registerHybridMethod("getDriver", &HybridTestObjectSwiftKotlinSpec::getDriver);
       prototype.registerHybridMethod("bounceCar", &HybridTestObjectSwiftKotlinSpec::bounceCar);
       prototype.registerHybridMethod("jsStyleObjectAsParameters", &HybridTestObjectSwiftKotlinSpec::jsStyleObjectAsParameters);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -208,6 +208,7 @@ namespace margelo::nitro::test {
       virtual std::shared_ptr<Promise<void>> getValueFromJsCallback(const std::function<std::shared_ptr<Promise<std::string>>()>& callback, const std::function<void(const std::string& /* valueFromJs */)>& andThenCall) = 0;
       virtual Car getCar() = 0;
       virtual bool isCarElectric(const Car& car) = 0;
+      virtual bool areCarsEqual(const Car& a, const Car& b) = 0;
       virtual std::optional<Person> getDriver(const Car& car) = 0;
       virtual Car bounceCar(const Car& car) = 0;
       virtual void jsStyleObjectAsParameters(const JsStyleStruct& params) = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -241,6 +241,7 @@ interface SharedTestObjectProps {
   // Objects
   getCar(): Car
   isCarElectric(car: Car): boolean
+  areCarsEqual(a: Car, b: Car): boolean
   getDriver(car: Car): Person | undefined
   bounceCar(car: Car): Car
   jsStyleObjectAsParameters(params: JsStyleStruct): void


### PR DESCRIPTION
Previously Kotlin structs relied on Kotlin's autogenerated `data class` helpers to be (deep-)equatable.

But this was problematic for `Array<T>`, as only `List<T>` is equatable and `Array<T>` isn't - so any structure that had an array in its properties was always `false` when compared with other instances.

This PR fixes this by overriding `equals` and `hashCode()` ourselves so that it actually compares the props (including Array equality)