### PR TITLE
docs(seo): add Margelo LinkedIn metadata references

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -118,6 +118,13 @@ const config: Config = {
           href: 'https://api.fontshare.com/css?f[]=satoshi@500,600,700&display=swap',
         },
       },
+      {
+        tagName: 'link',
+        attributes: {
+          rel: 'me',
+          href: 'https://linkedin.com/company/margelo',
+        },
+      },
     ],
     colorMode: {
       defaultMode: 'light',
@@ -264,6 +271,10 @@ const config: Config = {
       {
         property: 'twitter:creator',
         content: '@mrousavy',
+      },
+      {
+        property: 'article:publisher',
+        content: 'https://linkedin.com/company/margelo',
       },
     ],
     prism: {


### PR DESCRIPTION
### Motivation
- Associate the documentation site with Margelo's LinkedIn company profile for improved SEO and social attribution.

### Description
- Added a `rel="me"` head link referencing `https://linkedin.com/company/margelo` in `docs/docusaurus.config.ts` to provide an explicit profile link for crawlers and identity verification.
- Added an Open Graph style metadata entry `article:publisher` pointing to `https://linkedin.com/company/margelo` in the `metadata` array to surface publisher attribution in social previews where supported.
- Changes are limited to `docs/docusaurus.config.ts` and do not modify existing `og:image` or other social metadata.

### Testing
- Ran type checking with `cd docs && npm run typecheck`, which completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e143245c38832bb8ec971959af897a)