### PR TITLE
fix(docs): update docs to reflect new autolinking syntax

### DIFF
--- a/docs/docs/guides/view-components.md
+++ b/docs/docs/guides/view-components.md
@@ -101,8 +101,14 @@ Just like any other Hybrid Object, add the Hybrid View to your `nitro.json`'s au
   // ...
   "autolinking": {
     "CameraView": {
-      "swift": "HybridCameraView",
-      "kotlin": "HybridCameraView"
+      "ios": {
+        "language": "swift",
+        "implementationClassName": "HybridCameraView"
+      },
+      "android": {
+        "language": "kotlin",
+        "implementationClassName": "HybridCameraView"
+      }
     }
   }
 }


### PR DESCRIPTION
This PR updates [this part of the docs](https://nitro.margelo.com/docs/guides/view-components#4-autolink) to relfect the new autolinking syntax