### PR TITLE
fix: shadow properties on dispose to prevent React DEV crash

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -44,13 +44,56 @@ std::shared_ptr<HybridObject> HybridObject::shared() {
   throw std::runtime_error(std::string("HybridObject \"") + _name + "\" is not managed inside a std::shared_ptr - cannot access shared()!");
 }
 
+void HybridObject::shadowPropertiesForDispose(jsi::Runtime& runtime, jsi::Object& object) {
+  // Shadow all enumerable prototype properties with non-enumerable own properties
+  // so that `for...in` no longer iterates them after dispose.
+  // This prevents React DEV profiling (addObjectDiffToProperties) and
+  // deepFreezeAndThrowOnMutationInDev from accessing properties on a disposed object.
+  jsi::Value protoValue = getPrototype(runtime);
+  if (protoValue.isObject()) {
+    jsi::Object proto = protoValue.asObject(runtime);
+    jsi::Array names = proto.getPropertyNames(runtime);
+    size_t length = names.length(runtime);
+    for (size_t i = 0; i < length; i++) {
+      std::string name = names.getValueAtIndex(runtime, i).asString(runtime).utf8(runtime);
+      if (name == "__type") {
+        continue;
+      }
+      CommonGlobals::Object::defineProperty(runtime, object, name.c_str(),
+                                            PlainPropertyDescriptor{
+                                                .configurable = true,
+                                                .enumerable = false,
+                                                .value = jsi::Value::undefined(),
+                                                .writable = false,
+                                            });
+    }
+  }
+  // Mark the object as disposed so debuggers/devtools can see it
+  CommonGlobals::Object::defineProperty(runtime, object, "__disposed",
+                                        PlainPropertyDescriptor{
+                                            .configurable = false,
+                                            .enumerable = true,
+                                            .value = jsi::Value(true),
+                                            .writable = false,
+                                        });
+}
+
 jsi::Value HybridObject::disposeRaw(jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value*, size_t) {
   // 1. Dispose any resources - this might be overridden by child classes to perform manual cleanup.
   dispose();
-  // 2. Remove the NativeState from `this`
+  // 2. Shadow prototype properties so for...in iteration is safe after NativeState is removed.
+  //    This fails silently on frozen objects (where setNativeState will also fail).
   jsi::Object thisObject = thisArg.asObject(runtime);
+  try {
+    shadowPropertiesForDispose(runtime, thisObject);
+  } catch (...) {
+    // Object is frozen (e.g. by React's deepFreezeAndThrowOnMutationInDev) —
+    // we can't shadow properties, but setNativeState below will also fail,
+    // so NativeState stays valid and property access remains safe.
+  }
+  // 3. Remove the NativeState from `this`
   thisObject.setNativeState(runtime, nullptr);
-  // 3. Clear our object cache
+  // 4. Clear our object cache
   _objectCache.clear();
 
   return jsi::Value::undefined();

--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.hpp
@@ -113,6 +113,13 @@ private:
    * This needs to be a raw JSI function as we remove the NativeState here.
    */
   jsi::Value disposeRaw(jsi::Runtime& runtime, const jsi::Value& thisArg, const jsi::Value* NON_NULL args, size_t count);
+  /**
+   * Shadow all enumerable prototype properties (getters, methods) with non-enumerable
+   * own properties on the instance, and define `__disposed = true`.
+   * This prevents React DEV tooling (`for...in` iteration) from accessing properties
+   * on a disposed object whose NativeState has been nulled.
+   */
+  void shadowPropertiesForDispose(jsi::Runtime& runtime, jsi::Object& object);
 
 protected:
   /**


### PR DESCRIPTION
Before nulling NativeState in dispose(), shadow all enumerable prototype properties with non-enumerable own properties and define \`__disposed = true\`. This prevents React DEV tooling (\`for...in\` iteration in \`addObjectDiffToProperties\` and \`deepFreezeAndThrowOnMutationInDev\`) from accessing getters on a disposed object, which would throw and crash Fabric's scheduler.

On frozen objects the shadowing fails silently, which is consistent — \`setNativeState(nullptr)\` also fails on frozen objects, so NativeState stays valid and property access remains safe.

Fixes #1296

**Library-level workaround:** Libraries can work around this without waiting for this fix by shadowing properties from JS before calling \`dispose()\`. See [rive-app/rive-nitro-react-native#227](https://github.com/rive-app/rive-nitro-react-native/pull/227) for an example \`callDispose()\` helper.