### PR TITLE
fix(android): add NativeRunnable overload to ThreadUtils.runOnUIThread

### DIFF
--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/utils/ThreadUtils.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/utils/ThreadUtils.kt
@@ -39,5 +39,18 @@ class ThreadUtils {
     fun runOnUIThread(runnable: Runnable) {
       handler.post(runnable)
     }
+
+    // Overload taking NativeRunnable so the JNI method lookup in
+    // JThreadUtils.hpp (which requests signature
+    // `(Lcom/margelo/nitro/utils/NativeRunnable;)V`) resolves. Without this,
+    // Promise rejections routed through UIThreadDispatcher crash with
+    // NoSuchMethodError on Android at runtime (e.g. async work that rejects
+    // a Promise from a background thread).
+    @JvmStatic
+    @Keep
+    @DoNotStrip
+    fun runOnUIThread(runnable: NativeRunnable) {
+      handler.post(runnable)
+    }
   }
 }


### PR DESCRIPTION
## Problem

On Android, any time the C++ side calls `JThreadUtils::runOnUIThread`, we crash with `NoSuchMethodError`.

The C++ binding in [`JThreadUtils.hpp`](https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/android/src/main/cpp/utils/JThreadUtils.hpp) looks up the static method like this:

```cpp
static void runOnUIThread(jni::alias_ref<JNativeRunnable::javaobject> runnable) {
  static const auto method = javaClassStatic()->getStaticMethod<void(jni::alias_ref<JNativeRunnable::javaobject>)>("runOnUIThread");
  method(javaClassStatic(), runnable);
}
```

fbjni translates that template into a JNI method descriptor of `(Lcom/margelo/nitro/utils/NativeRunnable;)V`.

But the Kotlin companion in `ThreadUtils.kt` only declares:

```kotlin
fun runOnUIThread(runnable: Runnable)  // descriptor: (Ljava/lang/Runnable;)V
```

JNI method resolution is exact-match on descriptor — it does **not** perform polymorphic/covariant lookup. Even though `NativeRunnable : Runnable`, the descriptors don't match, so `getStaticMethod` throws `NoSuchMethodError` the first time it's invoked.

## Repro

Reproduced on **Pixel 8 (Android)** with **react-native-vision-camera 5.0.4** — pinch-to-zoom triggers the crash. The gesture ends up dispatching an async cancel/Promise-rejection through `UIThreadDispatcher` → `JThreadUtils::runOnUIThread`, which blows up because the Kotlin method with the `NativeRunnable` descriptor doesn't exist.

More generally, any Nitro flow that rejects a `Promise` from a background thread will hit this.

## Fix

Add a second `runOnUIThread(NativeRunnable)` overload so the JNI descriptor resolves. Both overloads just forward to `handler.post(...)` (which is fine because `NativeRunnable : Runnable`).

```kotlin
@JvmStatic
@Keep
@DoNotStrip
fun runOnUIThread(runnable: NativeRunnable) {
  handler.post(runnable)
}
```

## Alternatives considered

- **Change the C++ side to look up `(Ljava/lang/Runnable;)V`** — works, but `JThreadUtils.hpp` is strongly typed on `JNativeRunnable::javaobject` and matching a `Runnable` descriptor would lose that typing and require an `alias_ref<JObject>` cast. A Kotlin overload keeps the C++ side clean.
- **Replace the existing overload** — would break any downstream Java/Kotlin callers that pass a `Runnable`. Adding a second overload is strictly additive.

## Testing

Verified on Pixel 8 with react-native-vision-camera 5.0.4 that pinch-to-zoom no longer crashes with `NoSuchMethodError: no static method "runOnUIThread"`. No changes to iOS or JS behavior.