### PR TITLE
 fix: prevent crash when Promise is resolved or rejected more than once

### DIFF
--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
@@ -3,6 +3,7 @@ package com.margelo.nitro.core
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -145,6 +146,10 @@ class Promise<T> {
         try {
           val result = run()
           promise.resolve(result)
+        } catch (e: CancellationException) {
+          // Rethrow to preserve structured concurrency.
+          // See: https://kotlinlang.org/docs/cancellation-and-timeouts.html
+          throw e
         } catch (e: Throwable) {
           promise.reject(e)
         }

--- a/packages/react-native-nitro-modules/cpp/core/Promise.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.cpp
@@ -53,9 +53,9 @@ std::shared_ptr<Promise<void>> Promise<void>::rejected(const std::exception_ptr&
 
 void Promise<void>::resolve() {
   std::unique_lock lock(_mutex);
-#ifdef NITRO_DEBUG
-  assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
-#endif
+  if (!isPending()) [[unlikely]] {
+    return;
+  }
   _isResolved = true;
   for (const auto& onResolved : _onResolvedListeners) {
     onResolved();
@@ -69,9 +69,9 @@ void Promise<void>::reject(const std::exception_ptr& exception) {
   }
 
   std::unique_lock lock(_mutex);
-#ifdef NITRO_DEBUG
-  assertPromiseState(*this, PromiseTask::WANTS_TO_REJECT);
-#endif
+  if (!isPending()) [[unlikely]] {
+    return;
+  }
   _error = exception;
   for (const auto& onRejected : _onRejectedListeners) {
     onRejected(exception);

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "AssertPromiseState.hpp"
 #include "NitroDefines.hpp"
 #include "NitroTypeInfo.hpp"
 #include "ThreadPool.hpp"
@@ -99,9 +98,9 @@ public:
    */
   void resolve(TResult&& result) {
     std::unique_lock lock(_mutex);
-#ifdef NITRO_DEBUG
-    assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
-#endif
+    if (!isPending()) [[unlikely]] {
+      return;
+    }
     _state = std::move(result);
     for (const auto& onResolved : _onResolvedListeners) {
       onResolved(std::get<TResult>(_state));
@@ -110,9 +109,9 @@ public:
   }
   void resolve(const TResult& result) {
     std::unique_lock lock(_mutex);
-#ifdef NITRO_DEBUG
-    assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
-#endif
+    if (!isPending()) [[unlikely]] {
+      return;
+    }
     _state = result;
     for (const auto& onResolved : _onResolvedListeners) {
       onResolved(std::get<TResult>(_state));
@@ -129,9 +128,9 @@ public:
     }
 
     std::unique_lock lock(_mutex);
-#ifdef NITRO_DEBUG
-    assertPromiseState(*this, PromiseTask::WANTS_TO_REJECT);
-#endif
+    if (!isPending()) [[unlikely]] {
+      return;
+    }
     _state = exception;
     for (const auto& onRejected : _onRejectedListeners) {
       onRejected(exception);


### PR DESCRIPTION
This PR adds a mechanism to detect if a Promise has been resolved or rejected to avoid doing either of those operations again.

Without this, when setting the zoom value in VisionCamera as shown below(I deleted styles for brevity):

```typescript
import { useCallback, useEffect, useRef } from 'react'
import { type GestureResponderEvent, Pressable, StyleSheet, Text, View } from 'react-native'
import {
  Camera,
  type CameraRef,
  type CameraViewProps,
} from 'react-native-vision-camera'
import { useSharedValue } from 'react-native-reanimated'

type Props = Omit<
  CameraViewProps,
  'ref' | 'style' | 'enableNativeZoomGesture' | 'enableNativeTapToFocusGesture' | 'zoom'
>

export function CameraView({ device, constraints, ...props }: Props) {
  const camera = useRef<CameraRef>(null)
  const zoom = useSharedValue(1)

  useEffect(() => {
    if (typeof device === 'string') {
      console.log(`Device changed: "${device}"`)
    } else {
      console.log(`Device changed: ${device.localizedName}`)
      console.log(`  - Supported Pixel Formats:`, device.supportedPixelFormats)
      console.log(
        `  - Supported Photo Resolutions:`,
        device.getSupportedResolutions('photo'),
      )
      console.log(
        `  - Supported Video Resolutions:`,
        device.getSupportedResolutions('video'),
      )
      console.log(`  - Supported FPS Ranges:`, device.supportedFPSRanges)
      console.log(
        `  - Supported Dynamic Ranges:`,
        device.supportedVideoDynamicRanges,
      )
    }
  }, [device])

  const onZoomPress = useCallback(() => {
    zoom.value = 1 + Math.random() * 3
  }, [zoom])

  const onPress = useCallback(async (event: GestureResponderEvent) => {
    if (camera.current == null) throw new Error(`Camera ref is not yet ready!`)

    const point = {
      x: event.nativeEvent.locationX,
      y: event.nativeEvent.locationY,
    }

    try {
      const start = performance.now()
      console.log(`Focusing to (${point.x}, ${point.y})...`)
      await camera.current.focusTo(point, {
        adaptiveness: 'continuous',
        autoResetAfter: 3,
        responsiveness: 'snappy',
      })
      const end = performance.now()
      console.log(`Focusing completed after ${(end - start).toFixed(2)}ms!`)
    } catch (error) {
      console.error(`Failed to focus!`, error)
    }
  }, [])

  return (
    <View style={styles.flex} onTouchEnd={onPress}>
      <Camera
        {...props}
        ref={camera}
        style={styles.camera}
        device={device}
        constraints={constraints}
        zoom={zoom}
        onSubjectAreaChanged={() => {
          console.log(`Subject Area Changed! Resetting Focus...`)
          camera.current?.resetFocus()
        }}
        onSessionConfigSelected={(config) => {
          console.log(`Given Constraints:`, constraints)
          console.log(`Resolved SessionConfig:`, config.toString())
        }}
      />
      <Pressable style={styles.zoomButton} onPress={onZoomPress}>
        <Text style={styles.zoomText}>Zoom</Text>
      </Pressable>
    </View>
  )
}
```

 I get this crash:

```
FATAL EXCEPTION: DefaultDispatcher-worker-4
  java.lang.RuntimeException: Cannot reject Promise<void> - it is already resolved!
      at com.margelo.nitro.core.Promise.nativeReject(Native Method)
      at com.margelo.nitro.core.Promise.reject(Promise.kt:59)
      at com.margelo.nitro.core.Promise$Companion$async$1.invokeSuspend(Promise.kt:149)
```

patching `node_modules` with this PR fixed it locally