### PR TITLE
fix: Detect newArchEnabled at subproject scope on Android

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -73,7 +73,7 @@ def enableProguardInReleaseBuilds = true
 def jscFlavor = 'org.webkit:android-jsc:+'
 
 def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+  return project.hasProperty("newArchEnabled") && project.getProperty("newArchEnabled") == "true"
 }
 logger.warn("Building with newArchEnabled = ${isNewArchitectureEnabled()}...")
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -27,13 +27,6 @@ android.useAndroidX=true
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
 reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 
-# Use this property to enable support to the new architecture.
-# This will allow you to use TurboModules and the Fabric render in
-# your application. You should enable this flag either if you want
-# to write custom TurboModules/Fabric components OR use libraries that
-# are providing them.
-newArchEnabled=true
-
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true

--- a/packages/react-native-nitro-modules/android/build.gradle
+++ b/packages/react-native-nitro-modules/android/build.gradle
@@ -17,7 +17,7 @@ def reactNativeArchitectures() {
 }
 
 def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+  return project.hasProperty("newArchEnabled") && project.getProperty("newArchEnabled") == "true"
 }
 
 apply plugin: "com.android.library"

--- a/packages/react-native-nitro-test-external/android/build.gradle
+++ b/packages/react-native-nitro-test-external/android/build.gradle
@@ -15,7 +15,7 @@ def reactNativeArchitectures() {
 }
 
 def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+  return project.hasProperty("newArchEnabled") && project.getProperty("newArchEnabled") == "true"
 }
 
 apply plugin: "com.android.library"

--- a/packages/react-native-nitro-test/android/build.gradle
+++ b/packages/react-native-nitro-test/android/build.gradle
@@ -15,7 +15,7 @@ def reactNativeArchitectures() {
 }
 
 def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+  return project.hasProperty("newArchEnabled") && project.getProperty("newArchEnabled") == "true"
 }
 
 apply plugin: "com.android.library"

--- a/packages/template/android/build.gradle
+++ b/packages/template/android/build.gradle
@@ -15,7 +15,7 @@ def reactNativeArchitectures() {
 }
 
 def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+  return project.hasProperty("newArchEnabled") && project.getProperty("newArchEnabled") == "true"
 }
 
 apply plugin: "com.android.library"


### PR DESCRIPTION
## What I changed

I switched `isNewArchitectureEnabled()` from `rootProject.hasProperty(...)` to `project.hasProperty(...)` in the four bundled `android/build.gradle` files (`react-native-nitro-modules`, the Nitrogen `packages/template`, and both test packages), plus the example app's helper.

I also dropped `newArchEnabled=true` from `example/android/gradle.properties` to pin the regression — `build-android.yml` now exercises the same code path real consumers hit.

## Why

I hit this on a fresh React Native 0.83 / Expo SDK 55 dev-client app with `react-native-nitro-modules` and `react-native-mmkv@^4` installed. `bun android` failed at `:app:configureCMakeDebug[arm64-v8a]`:

```
CMake Error at .../Android-autolinking.cmake:
  add_subdirectory given source
  ".../node_modules/react-native-nitro-modules/android/build/generated/source/codegen/jni/"
  which is not an existing directory.
```

After digging in: on RN >= 0.82 the new architecture is mandatory and `newArchEnabled` is no longer required to live in `gradle.properties`. React Native's `ReactRootProjectPlugin` instead sets the property on each subproject's `extraProperties` (see [`ReactRootProjectPlugin.kt`](https://github.com/facebook/react-native/blob/main/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactRootProjectPlugin.kt) — the `subprojects { ... }` block sets `extraProperties.newArchEnabled = "true"` per subproject; the root project itself is not touched). The current rootProject-scoped check misses that path — the bundled libs skip `apply plugin: "com.facebook.react"`, no codegen tasks register, and the consumer build dies during CMake configure.

I think this is the same root cause as #1031 — the reporter there worked around it by regenerating `android/` from a fresh template (which re-introduced `newArchEnabled=true` in `gradle.properties` and masked the gate), so the issue got closed before the underlying bug was pinned. It's also reproducible after a stale, non-`--clean` Expo prebuild, where the existing `gradle.properties` stays put and never picks up the new template's content.

`project.hasProperty(...)` covers all three cases without dropping legacy-arch support:

- **RN >= 0.82** — finds the property via `ReactRootProjectPlugin`'s subproject `extraProperties`.
- **Legacy RN with explicit opt-in** — `gradle.properties` values propagate to every project, so `project.hasProperty(...)` still returns `true`.
- **Legacy RN without opt-in** — neither scope carries the property, the gate stays closed, and the `src/oldarch` source path is preserved.

I considered going the more aggressive route and deleting the gate entirely (mirroring [callstack/react-native-pager-view#1047](https://github.com/callstack/react-native-pager-view/pull/1047)), but Nitro's `peerDependencies` are still permissive (`react-native: "*"`) and `src/oldarch` is non-empty, so the conservative fix felt right. Happy to switch if you'd prefer the harder line.

## Scope — what this PR does **not** fix

To be upfront about this: my reproduction scenario in the "Why" section above mentions both `react-native-nitro-modules` and `react-native-mmkv@^4`. This PR only fixes `nitro` itself. **It does not fix consumer apps that already depend on a published version of `react-native-mmkv` (or any other Nitrogen-bootstrapped library)**, because:

- The fix to `packages/template/android/build.gradle` only affects libraries that bootstrap from the template **after this PR lands**. Existing libraries carry a copy of the gate baked into their own published `build.gradle` at the time they were created, not regenerated by Nitrogen on each build.
- `react-native-mmkv@4.x`'s `packages/react-native-mmkv/android/build.gradle` (line 18 on `main`) still reads `rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"`.
- For the user-reported scenario (RN 0.83 + nitro + mmkv) to actually build green without a `withGradleProperties` config-plugin workaround, **`react-native-mmkv` and any other downstream Nitrogen-bootstrapped library need their own follow-up PRs that mirror this change**. I'll send those separately and will link them here.

The Nitrogen *generator* itself ([`createGradleExtension.ts`](https://github.com/mrousavy/nitro/blob/main/packages/nitrogen/src/autolinking/android/createGradleExtension.ts)) does not emit the gate — verified by inspection — so once this PR lands, newly-bootstrapped Nitro modules will pick up the fix from `packages/template`.

## Test plan

I removed `newArchEnabled=true` from `example/android/gradle.properties`, so the existing `build-android.yml` workflow now fails on `main` (the bundled libs skip codegen) and passes with this PR. I verified locally with the same Gradle invocation CI uses:

```
cd example/android
./gradlew :app:assembleDebug -PreactNativeArchitectures=x86_64
```

Result: `BUILD SUCCESSFUL in 2m 34s`. `generateCodegenArtifactsFromSchema` and `configureCMakeDebug[x86_64]` ran for `react-native-nitro-modules`, `react-native-nitro-test`, `react-native-nitro-test-external` and the app, and `:app:assembleDebug` completed.

The Gradle build cache (`actions/cache` in `build-android.yml`) cannot mask the regression: cache key hashes `**/*.gradle*` (which this PR modifies), and per-library `build/generated/source/codegen/jni/` outputs aren't in the cache key, so a stale cache hit can't paper over a missing codegen task.

Other checks I ran:
- `bun install` (postinstall builds nitro, nitrogen and both test packages) — green.
- `bun typecheck` — green.
- `bun lint` — green.
- `bun specs` not run; no nitrogen output changes.

## Notes

- Targets `main`. No nitrogen spec changes, no spec/test removals, no unrelated edits.
- References #1031 (same root cause; closed without the underlying bug being pinned).