### PR TITLE
fix(nitrogen/ios): extend optional unwrapping workaround to struct types

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftCxxBridgedType.ts
@@ -467,9 +467,20 @@ export class SwiftCxxBridgedType implements BridgedType<'swift', 'c++'> {
             }
             // TODO: Remove this check for booleans/doubles once https://github.com/swiftlang/swift/issues/84848 is fixed.
             //       Right now, optionals of doubles or booleans (and who knows what else?) fail to compile when `.value` is used.
+            // Structs are also affected: Swift C++ interop's
+            // `std::optional<Struct>::value` accessor silently loses the payload at
+            // runtime — the JS-passed object arrives in Swift as `nil` (single-field
+            // struct) or as a struct shell with all fields empty (multi-field
+            // struct). Forcing the explicit `has_value`/`get` bridge helpers fixes
+            // it. Reproduces in any Nitro spec method that takes
+            // `options?: SomeStruct` — see e.g. `react-native-nitro-geolocation`
+            // v1.2.3 where `watchHeading(s, e, { headingFilter: 5 })` arrives as
+            // `options=nil` and `watchPosition`'s `LocationRequestOptions` arrives
+            // with every field as an empty optional.
             const swiftBug84848Workaround =
               optional.wrappingType.kind === 'boolean' ||
-              optional.wrappingType.kind === 'number'
+              optional.wrappingType.kind === 'number' ||
+              optional.wrappingType.kind === 'struct'
             if (!swiftBug84848Workaround) {
               if (!wrapping.needsSpecialHandling) {
                 return `${cppParameterName}.value`


### PR DESCRIPTION
## Summary

Extends [#1090](https://github.com/mrousavy/nitro/pull/1090) (and the related Swift Cxx-interop workaround for `bool`/`double` optionals around Swift issue [84848](https://github.com/swiftlang/swift/issues/84848)) to cover struct types.

Swift's C++ interop `std::optional<T>::value` accessor silently loses the payload at runtime for non-trivial struct types. The JS-passed object reaches the C++ optional correctly (the C++ JSI converter populates it just fine), but unwrapping it via `.value` in the generated Swift bridge yields garbage:

- **Single-field structs** (e.g. `HeadingOptions { headingFilter?: number }`) arrive in Swift as `nil` — even though the C++ optional has a value.
- **Multi-field structs** (e.g. `LocationRequestOptions` with ~16 optional fields) arrive as a struct shell with **every field as a default-constructed empty optional**, regardless of what JS passed.

This is the same family of Swift Cxx-interop bugs already worked around for `bool` and `double` optionals via #1090. Extending the same `bridge.has_value_*` / `bridge.get_*` unwrap path to struct types fixes it.

## Repro

Any Nitro spec method that takes `options?: SomeStruct` reproduces. Caught while debugging `react-native-nitro-geolocation` v1.2.3 on a real iOS device (RN 0.81 + bridgeless):

```ts
watchHeading(success, error, { headingFilter: 5 });
```

In Swift the resulting `options: HeadingOptions?` is observed as `nil` (instrumented in the package's `parse(from:)` to confirm). `manager.headingFilter` therefore stays at `kCLHeadingFilterNone` (-1) and CLHeading fires the delegate on every magnetometer tick — sub-degree firehose for stationary users. `watchPosition`'s `LocationRequestOptions` shows the empty-shell variant of the same bug; user-supplied config like `pausesLocationUpdatesAutomatically: false` and `activityType: 'fitness'` never reaches `CLLocationManager`. Symptoms aren't always user-visible because Apple's CL defaults coincidentally do something reasonable.

## Fix

Same shape as #1090, just adds `'struct'` to the workaround list:

```diff
 const swiftBug84848Workaround =
   optional.wrappingType.kind === 'boolean' ||
-  optional.wrappingType.kind === 'number'
+  optional.wrappingType.kind === 'number' ||
+  optional.wrappingType.kind === 'struct'
```

After regenerating, the affected packages emit the explicit unwrap pattern instead of `${cppParameterName}.value`:

```swift
options: { () -> SomeStruct? in
  if bridge.has_value_std__optional_SomeStruct_(options) {
    return bridge.get_std__optional_SomeStruct_(options)
  } else {
    return nil
  }
}()
```

## Verification

Verified locally by hand-applying the equivalent diff to `react-native-nitro-geolocation`'s already-generated `HybridNitroGeolocationSpec_cxx.swift` (`options.value` → `bridge.has_value_*`/`bridge.get_*` for `HeadingOptions`, `LocationRequestOptions`, and `LocationSettingsOptions` parameters across `requestLocationSettings`, `getCurrentPosition`, `getLastKnownPosition`, `watchHeading`, `watchPosition`). With the patch:

- `watchHeading(s, e, { headingFilter: 5 })` → `options=Optional(HeadingOptions(__headingFilter: optional(5.0)))` ✅
- `watchPosition` `LocationRequestOptions` fields populate from JS ✅
- `manager.headingFilter` correctly reflects caller value
- Sub-degree CLHeading firehose stops

## Test plan

- [ ] Regenerate `react-native-nitro-test` and `react-native-nitro-test-external` fixtures (similar to #1090's regen scope) — happy to push the regenerated files in this PR if preferred, didn't do it pre-emptively to keep the diff focused on the template change.
- [ ] CI green.

## Notes

- Builds on top of #1090 (numbers/booleans). Could be merged together if convenient.
- The fix is a pure superset — packages that don't use optional struct params are unaffected.
- Long-term, removing all of `swiftBug84848Workaround` once swiftlang/swift#84848 + #85735 land would be ideal; until then, the workaround list is the correct mitigation.