### PR TITLE
fix: Reset Kotlin C++ state in `dispose()`

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1537,9 +1537,11 @@ export function getTests(
         const baselineAllocations =
           NitroModules.debug_getTotalAllocatedHybridObjects()
 
+        // We test 51_201, because JNI's max global_ref allocations is 51200,
+        // so if this test goes green, it properly deletes jni::global_refs.
+        // If there would be a memory leak, this test will likely crash in C++.
+        const TOTAL_ALLOCATIONS = 51_201
         const BATCH_SIZE = 1000
-        const LOOP_COUNT = 10
-        const TOTAL_ALLOCATIONS = BATCH_SIZE * LOOP_COUNT
 
         const objects: Array<TestObjectCpp | TestObjectSwiftKotlin> = []
         for (let i = 0; i < TOTAL_ALLOCATIONS; i++) {

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1532,56 +1532,76 @@ export function getTests(
         .didNotThrow()
         .equals(10_000)
     ),
-    createTest('HybridObjects dont leak memory', () =>
-      it(() => {
-        const baselineAllocations =
-          NitroModules.debug_getTotalAllocatedHybridObjects()
+    createTest(
+      'HybridObjects dont leak memory with automatic YoungGen GC',
+      () =>
+        it(() => {
+          const baselineAllocations =
+            NitroModules.debug_getTotalAllocatedHybridObjects()
+          const TOTAL_ALLOCATIONS = 10_000
+          const BATCH_SIZE = 1000
 
-        // We test 51_201, because JNI's max global_ref allocations is 51200,
-        // so if this test goes green, it properly deletes jni::global_refs.
-        // If there would be a memory leak, this test will likely crash in C++.
-        const TOTAL_ALLOCATIONS = 51_201
+          const objects: Array<TestObjectCpp | TestObjectSwiftKotlin> = []
+          for (let i = 0; i < TOTAL_ALLOCATIONS; i++) {
+            const object = testObject.newTestObject()
+            object.numberValue = i
+            objects.push(object)
+
+            if (objects.length >= BATCH_SIZE) {
+              objects.length = 0
+              gc()
+            }
+          }
+
+          objects.length = 0
+          gc()
+          gc()
+          gc()
+
+          const currentAllocations =
+            NitroModules.debug_getTotalAllocatedHybridObjects()
+          const remainingAllocations = currentAllocations - baselineAllocations
+          // make sure that less than 10% of the total allocations are remaining, indicating GC ran for most of it.
+          const didDeleteMostObjects =
+            remainingAllocations < TOTAL_ALLOCATIONS * 0.1
+          const result: {
+            baselineAllocations: number
+            currentAllocations: number
+            isEqual?: boolean
+          } = {
+            baselineAllocations: baselineAllocations,
+            currentAllocations: currentAllocations,
+            isEqual: didDeleteMostObjects,
+          }
+          if (!didDeleteMostObjects) {
+            delete result.isEqual
+          }
+          return result
+        })
+          .didNotThrow()
+          .toContain('isEqual')
+    ),
+    createTest('HybridObjects dont leak memory with manual dispose()', () =>
+      it(() => {
+        // We test 55_000 allocations, because JNI's max global_ref count
+        // is 51200, so if this test goes green, it properly deletes
+        // jni::global_refs. If there would be a memory leak, this test
+        // will likely crash in C++.
+        const TOTAL_ALLOCATIONS = 55_000
         const BATCH_SIZE = 1000
 
-        const objects: Array<TestObjectCpp | TestObjectSwiftKotlin> = []
         for (let i = 0; i < TOTAL_ALLOCATIONS; i++) {
           const object = testObject.newTestObject()
-          object.numberValue = i
-          objects.push(object)
+          object.dispose()
 
-          if (objects.length >= BATCH_SIZE) {
-            objects.length = 0
+          if ((i + 1) % BATCH_SIZE === 0) {
             gc()
           }
         }
 
-        objects.length = 0
         gc()
-        gc()
-        gc()
-
-        const currentAllocations =
-          NitroModules.debug_getTotalAllocatedHybridObjects()
-        const remainingAllocations = currentAllocations - baselineAllocations
-        // make sure that less than 10% of the total allocations are remaining, indicating GC ran for most of it.
-        const didDeleteMostObjects =
-          remainingAllocations < TOTAL_ALLOCATIONS * 0.1
-        const result: {
-          baselineAllocations: number
-          currentAllocations: number
-          isEqual?: boolean
-        } = {
-          baselineAllocations: baselineAllocations,
-          currentAllocations: currentAllocations,
-          isEqual: didDeleteMostObjects,
-        }
-        if (!didDeleteMostObjects) {
-          delete result.isEqual
-        }
-        return result
-      })
-        .didNotThrow()
-        .toContain('isEqual')
+        return TOTAL_ALLOCATIONS
+      }).didNotThrow()
     ),
     createTest('callWithOptional(undefined)', async () =>
       (

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObject.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObject.kt
@@ -39,13 +39,15 @@ abstract class HybridObject {
    * If this method is never manually called, a `HybridObject` is expected to disposes its
    * resources as usual via the object's destructor (`~HybridObject()`, `deinit` or `finalize()`).
    *
-   * By default, this method does nothing. It can be overridden to perform actual disposing/cleanup
-   * if required.
+   * By default, this method only destroys the connected C++ part.
+   * It can be overridden to perform actual disposing/cleanup if required.
    * This method must not throw.
    */
   @DoNotStrip
   @Keep
-  open fun dispose() { }
+  open fun dispose() {
+    cxxPartCache?.get()?.destroy()
+  }
 
   /**
    * Get a string representation of this `HybridObject` - useful for logging or debugging.
@@ -94,6 +96,10 @@ abstract class HybridObject {
 
     init {
       mHybridData = initHybrid()
+    }
+
+    open fun destroy() {
+      mHybridData.resetNative()
     }
 
     protected open external fun initHybrid(): HybridData

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObject.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/HybridObject.kt
@@ -1,5 +1,6 @@
 package com.margelo.nitro.core
 
+import androidx.annotation.CallSuper
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
@@ -45,8 +46,10 @@ abstract class HybridObject {
    */
   @DoNotStrip
   @Keep
+  @CallSuper
   open fun dispose() {
     cxxPartCache?.get()?.destroy()
+    cxxPartCache = null
   }
 
   /**
@@ -98,7 +101,7 @@ abstract class HybridObject {
       mHybridData = initHybrid()
     }
 
-    open fun destroy() {
+    fun destroy() {
       mHybridData.resetNative()
     }
 

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -628,6 +628,7 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
   }
 
   override fun dispose() {
+    super.dispose()
     this.optionalCallback?.let { callback ->
       callback(13.0)
     }


### PR DESCRIPTION

`dispose()` calls into the platform implemented `dispose()` method (C++, Swift or Kotlin), and then unlinks the `jsi::NativeState` from the `jsi::Object`.

This works fine for ref-counted languages like C++ or Swift, as if no more references are being held, it deletes all associated objects pretty much instantly.

For Kotlin, this is a bit different. The Kotlin HybridObject is garbage-collected, but its `CxxPart` also owns a `HybridData`, and fbjni keeps a JNI `global_ref` around for the Java CxxPart.

So the structure is roughly like this:

```txt
Java/Kotlin CxxPart
  ├── javaPart: Kotlin HybridObject
  └── mHybridData: HybridData
          │
          ▼
C++ JHybridX::CxxPart
  └── _cxxJavaPart: global_ref<Java/Kotlin CxxPart>
          │
          └──────────────▶ Java/Kotlin CxxPart
```

If we only dispose the JS/C++ HybridObject state, the Kotlin/Java CxxPart can stay around and keep JNI global refs alive. After enough manual `dispose()` calls this can crash with:

```txt
JNI ERROR (app bug): global reference table overflow (max=51200)
```

Reported in:
- https://github.com/mrousavy/react-native-vision-camera/issues/3879
- https://github.com/mrousavy/react-native-vision-camera/issues/3824#issuecomment-4475912523

To fix this, Kotlin `HybridObject.dispose()` now eagerly destroys the connected `CxxPart` by calling `HybridData.resetNative()`, and then clears the cached CxxPart reference.

I also added `@CallSuper` to `dispose()`, made `CxxPart.destroy()` non-overridable, and fixed our own Kotlin test object to call `super.dispose()`.

The Harness now also has a manual `dispose()` memory test that creates/disposes 55k HybridObjects, because JNI's global ref limit is 51200. The old Harness test only covered automatic GC cleanup, not this repeated manual `dispose()` path.
