### PR TITLE
fix(android): prepare Nitro prefab headers before native clean

### DIFF
--- a/packages/react-native-nitro-modules/android/fix-prefab.gradle
+++ b/packages/react-native-nitro-modules/android/fix-prefab.gradle
@@ -14,6 +14,12 @@ tasks.configureEach { task ->
 
 afterEvaluate {
   def abis = reactNativeArchitectures()
+  def prepareHeadersTask = tasks.named("prepareHeaders")
+
+  prepareHeadersTask.configure {
+    mustRunAfter(tasks.named("clean"))
+  }
+
   rootProject.allprojects.each { proj ->
     if (proj === rootProject) return
 
@@ -26,6 +32,12 @@ afterEvaluate {
 
     if (!proj.plugins.hasPlugin('com.android.application') && !proj.plugins.hasPlugin('com.android.library')) {
       return
+    }
+
+    if (proj != project) {
+      proj.tasks.matching { it.name.startsWith("externalNativeBuildClean") }.configureEach { cleanTask ->
+        cleanTask.dependsOn(prepareHeadersTask)
+      }
     }
 
     def variants = proj.android.hasProperty('applicationVariants') ? proj.android.applicationVariants : proj.android.libraryVariants


### PR DESCRIPTION
## Summary

Draft PR to discuss a narrow Android clean-ordering fix for `react-native-nitro-modules`.

`react-native-nitro-modules` publishes its Android prefab target with headers under:

```text
android/build/headers/nitromodules
```

Those headers are produced by the Gradle `prepareHeaders` task. During native clean flows, `clean` can remove `android/build/headers`, then dependent Android projects may still run `externalNativeBuildClean*` and read the `react-native-nitro-modules::NitroModules` prefab target. At that point CMake can fail because the target's include directory no longer exists:

```text
Imported target "react-native-nitro-modules::NitroModules" includes
non-existent path ".../react-native-nitro-modules/android/build/headers/nitromodules"
```

This patch keeps the scope limited to `packages/react-native-nitro-modules`:

- `prepareHeaders` must run after this project's `clean` task when both are in the graph;
- dependent Android projects' `externalNativeBuildClean*` tasks depend on `prepareHeaders`, so Nitro prefab headers exist before native clean reads the prefab metadata.

This intentionally targets native clean. It does not claim to be a complete fresh Gradle Sync fix.

## Test plan

```sh
git diff --check
```

Result: passed.

## Notes for review

The contribution guide requires bug fixes to include a test. This PR is opened as a draft because this behavior depends on a consumer Gradle task graph (`externalNativeBuildClean*` reading another project's prefab metadata after `clean` removes generated headers). I would like maintainer guidance on the preferred regression coverage for that scenario before requesting review.
