### PR TITLE
fix: Safely wrap/copy `ByteBuffer` without modifying cursor state

### DIFF
--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt
@@ -252,8 +252,7 @@ class ArrayBuffer {
     fun copy(byteArray: ByteArray): ArrayBuffer {
       val byteBuffer = ByteBuffer.allocateDirect(byteArray.size)
       byteBuffer.put(byteArray)
-      byteBuffer.flip()
-      return ArrayBuffer(byteBuffer)
+      return ArrayBuffer.wrap(byteBuffer)
     }
 
     /**

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt
@@ -10,6 +10,15 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.utils.HardwareBufferUtils
 import dalvik.annotation.optimization.FastNative
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+private fun ByteBuffer.arrayBufferView(): ByteBuffer {
+  val view = duplicate()
+  view.order(ByteOrder.nativeOrder())
+  // This only resets the view's cursor; it does not clear or overwrite bytes.
+  view.clear()
+  return view
+}
 
 // AHardwareBuffer* needs to be boxed in jobject*
 typealias BoxedHardwareBuffer = Any
@@ -76,9 +85,13 @@ class ArrayBuffer {
    * @param copyIfNeeded If this `ArrayBuffer` is not holding a `ByteBuffer` (`isByteBuffer == false`),
    * the foreign data needs to be either _wrapped_, or _copied_ to be represented as a `ByteBuffer`.
    * This flag controls that behaviour.
+   *
+   * The returned `ByteBuffer` shares the underlying bytes, uses native byte order, but has its own
+   * cursor state. Reading from or writing to the returned buffer can change the bytes, but changing
+   * its `position`, `limit`, or `mark` will not affect the `ArrayBuffer`'s internal `ByteBuffer`.
    */
   fun getBuffer(copyIfNeeded: Boolean): ByteBuffer {
-    return getByteBuffer(copyIfNeeded)
+    return getByteBuffer(copyIfNeeded).arrayBufferView()
   }
 
   /**
@@ -95,13 +108,14 @@ class ArrayBuffer {
    * Copies the underlying data into a `ByteArray`.
    * If this `ArrayBuffer` is backed by a GPU-HardwareBuffer,
    * this performs a GPU-download.
+   * This does not mutate the underlying `ByteBuffer`'s cursor state.
    */
   fun toByteArray(): ByteArray {
     val buffer = this.getBuffer(false)
     if (buffer.hasArray()) {
       // It's a CPU-backed array - we can return this directly if the size matches
       val array = buffer.array()
-      if (array.size == this.size) {
+      if (array.size == this.size && buffer.arrayOffset() == 0) {
         // The ByteBuffer is 1:1 mapped to a byte array - return as is!
         return array
       }
@@ -109,10 +123,10 @@ class ArrayBuffer {
       // This might be because the ArrayBuffer has a smaller view of the data, so we need
       // to resort back to a good ol' copy.
     }
-    // It's not a 1:1 mapped array (e.g. HardwareBuffer) - we need to copy to the CPU
-    val copy = ByteBuffer.allocate(buffer.capacity())
-    copy.put(buffer)
-    return copy.array()
+    // It's not a 1:1 mapped array (e.g. HardwareBuffer) - we need to copy to the CPU.
+    val copy = ByteArray(this.size)
+    buffer.get(copy)
+    return copy
   }
 
   /**
@@ -214,18 +228,20 @@ class ArrayBuffer {
 
     /**
      * Copy the given `ByteBuffer` into a new **owning** `ArrayBuffer`.
+     * This copies from the start of the buffer up to its current `limit`, and does not mutate the
+     * given `ByteBuffer`'s cursor state.
      */
     fun copy(byteBuffer: ByteBuffer): ArrayBuffer {
       // 1. Find out size
-      byteBuffer.rewind()
-      val size = byteBuffer.remaining()
+      val source = byteBuffer.duplicate()
+      source.rewind()
+      val size = source.remaining()
       // 2. Create a new buffer with the same size as the other
       val newBuffer = ByteBuffer.allocateDirect(size)
       // 3. Copy over the source buffer into the new buffer
-      newBuffer.put(byteBuffer)
-      // 4. Rewind both buffers again to index 0
-      newBuffer.rewind()
-      byteBuffer.rewind()
+      newBuffer.put(source)
+      // 4. Flip the new buffer for reads
+      newBuffer.flip()
       // 5. Create a new `ArrayBuffer`
       return ArrayBuffer(newBuffer)
     }
@@ -236,7 +252,8 @@ class ArrayBuffer {
     fun copy(byteArray: ByteArray): ArrayBuffer {
       val byteBuffer = ByteBuffer.allocateDirect(byteArray.size)
       byteBuffer.put(byteArray)
-      return ArrayBuffer.wrap(byteBuffer)
+      byteBuffer.flip()
+      return ArrayBuffer(byteBuffer)
     }
 
     /**
@@ -250,10 +267,11 @@ class ArrayBuffer {
 
     /**
      * Wrap the given `ByteBuffer` in a new **owning** `ArrayBuffer`.
+     * This wraps the whole direct buffer capacity, and does not mutate the given `ByteBuffer`'s
+     * cursor state.
      */
     fun wrap(byteBuffer: ByteBuffer): ArrayBuffer {
-      byteBuffer.rewind()
-      return ArrayBuffer(byteBuffer)
+      return ArrayBuffer(byteBuffer.arrayBufferView())
     }
 
     /**


### PR DESCRIPTION

`ArrayBuffer` can be backed by a `ByteBuffer`, but some of our Kotlin interop APIs were directly operating on that same `ByteBuffer` instance.

This meant calls like `toByteArray()`, `ArrayBuffer.copy(byteBuffer)`, or `ArrayBuffer.wrap(byteBuffer)` could mutate the buffer cursor state (`position`, `limit`, `mark`) by doing `rewind()`, `put(...)`, etc.

That is pretty unexpected, since users might still hold the original `ByteBuffer` and assume its cursor state stays untouched.

To fix this, `getBuffer(...)` now returns a duplicated `ByteBuffer` view. It still shares the same underlying bytes, but has independent cursor state and always uses `ByteOrder.nativeOrder()`.

`copy(ByteBuffer)` and `wrap(ByteBuffer)` now also operate on duplicated views, so they do not mutate the caller-owned `ByteBuffer`.

`toByteArray()` also copies through a `ByteArray` instead of draining the returned buffer into another `ByteBuffer`.
