### PR TITLE
android: replace prefab cache-busting hack with deterministic task wiring

### DIFF
--- a/packages/react-native-nitro-modules/android/fix-prefab.gradle
+++ b/packages/react-native-nitro-modules/android/fix-prefab.gradle
@@ -1,19 +1,16 @@
 tasks.configureEach { task ->
   // Make sure that we generate our prefab publication file only after having built the native library
   // so that not a header publication file, but a full configuration publication will be generated, which
-  // will include the .so file
-
+  // will include the .so file.
   def prefabConfigurePattern = ~/^prefab(.+)ConfigurePackage$/
   def matcher = task.name =~ prefabConfigurePattern
   if (matcher.matches()) {
     def variantName = matcher[0][1]
-    task.outputs.upToDateWhen { false }
     task.dependsOn("externalNativeBuild${variantName}")
   }
 }
 
 afterEvaluate {
-  def abis = reactNativeArchitectures()
   rootProject.allprojects.each { proj ->
     if (proj === rootProject) return
 
@@ -29,23 +26,22 @@ afterEvaluate {
     }
 
     def variants = proj.android.hasProperty('applicationVariants') ? proj.android.applicationVariants : proj.android.libraryVariants
-    // Touch the prefab_config.json files to ensure that in ExternalNativeJsonGenerator.kt we will re-trigger the prefab CLI to
-    // generate a libnameConfig.cmake file that will contain our native library (.so).
-    // See this condition: https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/ExternalNativeJsonGenerator.kt;l=207-219?q=createPrefabBuildSystemGlue
+
+    // Wire dependent native builds to prefab packaging task outputs instead of mutating .cxx files.
+    // This keeps Gradle inputs deterministic and avoids blanket cache invalidation.
     variants.all { variant ->
-      def variantName = variant.name
-      abis.each { abi ->
-        def searchDir = new File(proj.projectDir, ".cxx/${variantName}")
-        if (!searchDir.exists()) return
-        def matches = []
-        searchDir.eachDir { randomDir ->
-          def prefabFile = new File(randomDir, "${abi}/prefab_config.json")
-          if (prefabFile.exists()) matches << prefabFile
-        }
-        matches.each { prefabConfig ->
-          prefabConfig.setLastModified(System.currentTimeMillis())
-        }
-      }
+      def capitalizedVariant = variant.name.substring(0, 1).toUpperCase() + variant.name.substring(1)
+      def consumerNativeTaskName = "externalNativeBuild${capitalizedVariant}"
+      def producerPrefabTaskName = "prefab${capitalizedVariant}ConfigurePackage"
+
+      def consumerNativeTask = proj.tasks.findByName(consumerNativeTaskName)
+      def producerPrefabTask = project.tasks.findByName(producerPrefabTaskName)
+
+      if (consumerNativeTask == null || producerPrefabTask == null) return
+
+      consumerNativeTask.dependsOn(producerPrefabTask)
+      consumerNativeTask.inputs.files(producerPrefabTask.outputs.files)
+        .withPathSensitivity(org.gradle.api.tasks.PathSensitivity.RELATIVE)
     }
   }
 }

--- a/packages/react-native-nitro-test-external/android/fix-prefab.gradle
+++ b/packages/react-native-nitro-test-external/android/fix-prefab.gradle
@@ -1,19 +1,16 @@
 tasks.configureEach { task ->
   // Make sure that we generate our prefab publication file only after having built the native library
   // so that not a header publication file, but a full configuration publication will be generated, which
-  // will include the .so file
-
+  // will include the .so file.
   def prefabConfigurePattern = ~/^prefab(.+)ConfigurePackage$/
   def matcher = task.name =~ prefabConfigurePattern
   if (matcher.matches()) {
     def variantName = matcher[0][1]
-    task.outputs.upToDateWhen { false }
     task.dependsOn("externalNativeBuild${variantName}")
   }
 }
 
 afterEvaluate {
-  def abis = reactNativeArchitectures()
   rootProject.allprojects.each { proj ->
     if (proj === rootProject) return
 
@@ -29,23 +26,22 @@ afterEvaluate {
     }
 
     def variants = proj.android.hasProperty('applicationVariants') ? proj.android.applicationVariants : proj.android.libraryVariants
-    // Touch the prefab_config.json files to ensure that in ExternalNativeJsonGenerator.kt we will re-trigger the prefab CLI to
-    // generate a libnameConfig.cmake file that will contain our native library (.so).
-    // See this condition: https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/ExternalNativeJsonGenerator.kt;l=207-219?q=createPrefabBuildSystemGlue
+
+    // Wire dependent native builds to prefab packaging task outputs instead of mutating .cxx files.
+    // This keeps Gradle inputs deterministic and avoids blanket cache invalidation.
     variants.all { variant ->
-      def variantName = variant.name
-      abis.each { abi ->
-        def searchDir = new File(proj.projectDir, ".cxx/${variantName}")
-        if (!searchDir.exists()) return
-        def matches = []
-        searchDir.eachDir { randomDir ->
-          def prefabFile = new File(randomDir, "${abi}/prefab_config.json")
-          if (prefabFile.exists()) matches << prefabFile
-        }
-        matches.each { prefabConfig ->
-          prefabConfig.setLastModified(System.currentTimeMillis())
-        }
-      }
+      def capitalizedVariant = variant.name.substring(0, 1).toUpperCase() + variant.name.substring(1)
+      def consumerNativeTaskName = "externalNativeBuild${capitalizedVariant}"
+      def producerPrefabTaskName = "prefab${capitalizedVariant}ConfigurePackage"
+
+      def consumerNativeTask = proj.tasks.findByName(consumerNativeTaskName)
+      def producerPrefabTask = project.tasks.findByName(producerPrefabTaskName)
+
+      if (consumerNativeTask == null || producerPrefabTask == null) return
+
+      consumerNativeTask.dependsOn(producerPrefabTask)
+      consumerNativeTask.inputs.files(producerPrefabTask.outputs.files)
+        .withPathSensitivity(org.gradle.api.tasks.PathSensitivity.RELATIVE)
     }
   }
 }

--- a/packages/template/android/fix-prefab.gradle
+++ b/packages/template/android/fix-prefab.gradle
@@ -1,19 +1,16 @@
 tasks.configureEach { task ->
   // Make sure that we generate our prefab publication file only after having built the native library
   // so that not a header publication file, but a full configuration publication will be generated, which
-  // will include the .so file
-
+  // will include the .so file.
   def prefabConfigurePattern = ~/^prefab(.+)ConfigurePackage$/
   def matcher = task.name =~ prefabConfigurePattern
   if (matcher.matches()) {
     def variantName = matcher[0][1]
-    task.outputs.upToDateWhen { false }
     task.dependsOn("externalNativeBuild${variantName}")
   }
 }
 
 afterEvaluate {
-  def abis = reactNativeArchitectures()
   rootProject.allprojects.each { proj ->
     if (proj === rootProject) return
 
@@ -29,23 +26,22 @@ afterEvaluate {
     }
 
     def variants = proj.android.hasProperty('applicationVariants') ? proj.android.applicationVariants : proj.android.libraryVariants
-    // Touch the prefab_config.json files to ensure that in ExternalNativeJsonGenerator.kt we will re-trigger the prefab CLI to
-    // generate a libnameConfig.cmake file that will contain our native library (.so).
-    // See this condition: https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/ExternalNativeJsonGenerator.kt;l=207-219?q=createPrefabBuildSystemGlue
+
+    // Wire dependent native builds to prefab packaging task outputs instead of mutating .cxx files.
+    // This keeps Gradle inputs deterministic and avoids blanket cache invalidation.
     variants.all { variant ->
-      def variantName = variant.name
-      abis.each { abi ->
-        def searchDir = new File(proj.projectDir, ".cxx/${variantName}")
-        if (!searchDir.exists()) return
-        def matches = []
-        searchDir.eachDir { randomDir ->
-          def prefabFile = new File(randomDir, "${abi}/prefab_config.json")
-          if (prefabFile.exists()) matches << prefabFile
-        }
-        matches.each { prefabConfig ->
-          prefabConfig.setLastModified(System.currentTimeMillis())
-        }
-      }
+      def capitalizedVariant = variant.name.substring(0, 1).toUpperCase() + variant.name.substring(1)
+      def consumerNativeTaskName = "externalNativeBuild${capitalizedVariant}"
+      def producerPrefabTaskName = "prefab${capitalizedVariant}ConfigurePackage"
+
+      def consumerNativeTask = proj.tasks.findByName(consumerNativeTaskName)
+      def producerPrefabTask = project.tasks.findByName(producerPrefabTaskName)
+
+      if (consumerNativeTask == null || producerPrefabTask == null) return
+
+      consumerNativeTask.dependsOn(producerPrefabTask)
+      consumerNativeTask.inputs.files(producerPrefabTask.outputs.files)
+        .withPathSensitivity(org.gradle.api.tasks.PathSensitivity.RELATIVE)
     }
   }
 }


### PR DESCRIPTION
### Motivation
- The old `fix-prefab.gradle` globally disabled up-to-date checks and mutated generated `.cxx/**/prefab_config.json` timestamps, causing broad Gradle cache invalidation and repeated native reconfiguration/builds.
- The intent was to ensure prefab packaging runs when the native `.so` exists for consuming modules; this should be modeled in the Gradle task graph rather than by mutating generated files.

### Description
- Removed the unconditional `task.outputs.upToDateWhen { false }` override from `prefab*ConfigurePackage` tasks to avoid forcing non-incremental behavior.
- Removed logic that touched `.cxx/.../prefab_config.json` timestamps that caused blanket cache invalidation.
- Added deterministic wiring so each consumer module's `externalNativeBuild<Variant>` task depends on this library's `prefab<Variant>ConfigurePackage` task and declares the prefab task outputs as explicit inputs with `PathSensitivity.RELATIVE`.
- Applied these changes to `packages/react-native-nitro-modules/android/fix-prefab.gradle`, `packages/template/android/fix-prefab.gradle`, and `packages/react-native-nitro-test-external/android/fix-prefab.gradle`.

### Testing
- Verified the diff with `git diff` and inspected the patched files with `nl` to confirm changes applied; these commands succeeded.
- Staged and committed the changes with `git add` and `git commit`; the commit succeeded with message `android: replace prefab cache-busting hack with task input wiring`.
- Created the PR metadata via the repo helper (`make_pr`) to record the change; that operation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d90da2100832b87730560290c72d4)