### PR TITLE
chore: Upgrade Bun to 1.3.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro",
-  "packageManager": "bun@1.3.6",
+  "packageManager": "bun@1.3.14",
   "private": true,
   "version": "0.35.9",
   "repository": "https://github.com/mrousavy/nitro.git",


### PR DESCRIPTION
## Summary
- Update the workspace `packageManager` pin from Bun 1.3.6 to 1.3.14.

## Validation
- `bun --version`
- `bun install --ignore-scripts --frozen-lockfile`

## Notes
- No lockfile changes were needed.
- Release notes checked: https://bun.sh/blog/bun-v1.3.14