### PR TITLE
chore: Upgrade Kotlin to 2.1.21

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.1.20"
+        kotlinVersion = "2.1.21"
     }
     repositories {
         google()

--- a/packages/react-native-nitro-modules/android/gradle.properties
+++ b/packages/react-native-nitro-modules/android/gradle.properties
@@ -1,4 +1,4 @@
-Nitro_kotlinVersion=2.1.20
+Nitro_kotlinVersion=2.1.21
 Nitro_minSdkVersion=23
 Nitro_targetSdkVersion=36
 Nitro_compileSdkVersion=36

--- a/packages/react-native-nitro-test-external/android/gradle.properties
+++ b/packages/react-native-nitro-test-external/android/gradle.properties
@@ -1,4 +1,4 @@
-NitroTestExternal_kotlinVersion=2.1.20
+NitroTestExternal_kotlinVersion=2.1.21
 NitroTestExternal_minSdkVersion=23
 NitroTestExternal_targetSdkVersion=36
 NitroTestExternal_compileSdkVersion=36

--- a/packages/react-native-nitro-test/android/gradle.properties
+++ b/packages/react-native-nitro-test/android/gradle.properties
@@ -1,4 +1,4 @@
-Nitro_kotlinVersion=2.1.20
+Nitro_kotlinVersion=2.1.21
 Nitro_minSdkVersion=23
 Nitro_targetSdkVersion=36
 Nitro_compileSdkVersion=36

--- a/packages/template/android/gradle.properties
+++ b/packages/template/android/gradle.properties
@@ -1,4 +1,4 @@
-$$androidCxxLibName$$_kotlinVersion=2.1.20
+$$androidCxxLibName$$_kotlinVersion=2.1.21
 $$androidCxxLibName$$_minSdkVersion=23
 $$androidCxxLibName$$_targetSdkVersion=36
 $$androidCxxLibName$$_compileSdkVersion=36


### PR DESCRIPTION
## Summary
- Upgrade the Android Kotlin version from 2.1.20 to 2.1.21 across the example app, packages, and template.

## Validation
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' bun example build:android`

## Notes
- Kotlin 2.3.21 is the current stable Kotlin release, but it is not a safe upgrade for this React Native stack yet: the published React Native Gradle plugin still compiles itself with Kotlin 2.1.20, and Android dependencies hit Kotlin metadata incompatibilities when the app resolves 2.3.x stdlib.
- Gradle 9.4.1 and 9.5.1 were also tested and blocked by the same React Native Gradle plugin Kotlin 2.1 compiler path.
- Release history checked: https://kotlinlang.org/docs/releases.html