### PR TITLE
chore: Upgrade CocoaPods to 1.16.2

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -3,11 +3,11 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-# Exclude problematic versions of cocoapods and activesupport that causes build failures.
-gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
-gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
-gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'
+# CocoaPods 1.16.2 requires xcodeproj 1.27+ for current Xcode project
+# generation fixes.
+gem 'cocoapods', '~> 1.16', '>= 1.16.2'
+gem 'activesupport', '>= 6.1.7.5', '< 8'
+gem 'xcodeproj', '>= 1.27.0', '< 2.0'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,30 +1,34 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.7)
+    CFPropertyList (3.0.9)
+    activesupport (7.1.6)
       base64
-      nkf
-      rexml
-    activesupport (6.1.7.10)
+      benchmark (>= 0.3)
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
-    base64 (0.2.0)
+    base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     claide (1.1.0)
-    cocoapods (1.15.2)
+    cocoapods (1.16.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.15.2)
+      cocoapods-core (= 1.16.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -38,8 +42,8 @@ GEM
       molinillo (~> 0.8.0)
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.15.2)
+      xcodeproj (>= 1.27.0, < 2.0)
+    cocoapods-core (1.16.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -59,54 +63,56 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.6)
+    connection_pool (2.5.5)
+    drb (2.2.3)
     escape (0.0.4)
-    ethon (0.16.0)
+    ethon (0.18.0)
       ffi (>= 1.15.0)
-    ffi (1.17.0)
+      logger
+    ffi (1.17.4)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    httpclient (2.8.3)
+    httpclient (2.9.0)
+      mutex_m
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    json (2.7.6)
+    json (2.19.5)
     logger (1.7.0)
     minitest (5.25.1)
     molinillo (0.8.0)
     mutex_m (0.3.0)
-    nanaimo (0.3.0)
+    nanaimo (0.4.0)
     nap (1.1.0)
     netrc (0.11.0)
-    nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.4.2)
+    rexml (3.4.4)
     ruby-macho (2.5.1)
-    typhoeus (1.4.1)
-      ethon (>= 0.9.0)
+    securerandom (0.3.2)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.25.1)
+    xcodeproj (1.27.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
+      nanaimo (~> 0.4.0)
       rexml (>= 3.3.6, < 4.0)
-    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 6.1.7.5, != 7.1.0)
+  activesupport (>= 6.1.7.5, < 8)
   benchmark
   bigdecimal
-  cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
-  concurrent-ruby (< 1.3.4)
+  cocoapods (~> 1.16, >= 1.16.2)
   logger
   mutex_m
-  xcodeproj (< 1.26.0)
+  xcodeproj (>= 1.27.0, < 2.0)
 
 RUBY VERSION
    ruby 3.3.0p0

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2218,84 +2218,84 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FBLazyVector: 7c1d69992204c5ec452eeefa4a24b0ff311709c8
   hermes-engine: b69aade2dcf59e8c2203c748ca79c7fa4c875053
-  NitroModules: 62af0d110a4aa4f4027e6ee18f5dea25f759ed83
-  NitroTest: 3b4df8b727aba0198007a1b57c80f695b2cda860
-  NitroTestExternal: 7553501a6940b8f891fb0662ebc56817a4658639
+  NitroModules: 7b5ab273abd90ab15d69f4ac1272e34e368051af
+  NitroTest: f6e5d16d0886f9781640471eaa533f022e47d1d4
+  NitroTestExternal: 0ef9988ac511f24afe69ff3eff9e4db02c6e77a5
   RCTDeprecation: dbbb85eae640e3b43cc16462d0476b00ca5959ae
   RCTRequired: 7047b18af29a76069818fd3fa0f4df423483abab
   RCTSwiftUI: 5928f7ca7e9e2f1a82d85d4c79ea3065137ad81c
-  RCTSwiftUIWrapper: 1d538f86a38b18a6d5f70a94afa696242f46f5e5
+  RCTSwiftUIWrapper: 8ff2f9da84b47db66d11ece1589d8e5515c0ab8b
   RCTTypeSafety: 0416f31c41f9a792a9287543c6c30bd605c2eed0
   React: f6f8fc5c01e77349cdfaf49102bcb928ac31d8ed
   React-callinvoker: 3e62a849bda1522c6422309c02f5dc3210bc5359
-  React-Core: 0b765bc7c2b83dff178c2b03ed8a0390df26f18c
-  React-Core-prebuilt: 1ed3b91c7035f715bf741f1b8a2c87e94d126d38
-  React-CoreModules: 55b932564ba696301cb683a86385be6a6f137e57
-  React-cxxreact: 5bfb95256fde56cc0f9ce425f38cfaa085e71ad2
+  React-Core: 107092273c9178bb015aee2af302ed1340e59da3
+  React-Core-prebuilt: 82aea6b595ea6ccf200767cff5f62bfc5c028d14
+  React-CoreModules: 0b3b55b0b3954812ee0d67d85960bd7b42268336
+  React-cxxreact: a76c6a3b36b20e777542946c20bebf67acbb631c
   React-debug: f9dda2791d3ebe2078bc6102641edab77917efb7
-  React-defaultsnativemodule: 5eaa2ee83604301aa7cc3105e0233e2b01bb5193
-  React-domnativemodule: 2657e4c584804cba76af46ba721a98028316c8ad
-  React-Fabric: ba81e0c49a35d914a8eaba7cd04fe1a6989b52c6
-  React-FabricComponents: c3501f8ab7c84d71b44fa54c89973b0518a4213a
-  React-FabricImage: ebb79551d37c01c9f10c33cb9295fb3d87e3c252
-  React-featureflags: b76aac763fa62dc13bbe1c2738ba0b34c1d5dc16
-  React-featureflagsnativemodule: fbf8c0d91e5b2fd4e85aff56c1cba88f2ba66667
-  React-graphics: a25fddc60b9d952693209cfb3dd9a556a160479d
-  React-hermes: 99530187adfc1a61013c59ab4b1bbccf97401eca
-  React-idlecallbacksnativemodule: dbf0b339acba04a51ae4e3ed115bb3f079dcea6e
-  React-ImageManager: d9f4d473c4118b65ceb9e2596eaa69efc6027a0e
-  React-intersectionobservernativemodule: 4c538efb01719c6d5f85566716e394cd9419d491
-  React-jserrorhandler: 2e48ec8f8185694e7e5a00d9b56e58b590ad962b
-  React-jsi: 1fa4798a7b2ad40a2e79d86d0ed2f16a0d66f3aa
-  React-jsiexecutor: c4832a641fd43beb451bc782dd08f85daaa143d6
-  React-jsinspector: 6c2123456e5cbd2e18e890fc7c4c20904ab5e115
-  React-jsinspectorcdp: 178b8ce658f64e1b13f0a69ecac3812e30dbe560
-  React-jsinspectornetwork: 31076e7a183121c8b8e4098d43a18a21cb1f807b
-  React-jsinspectortracing: b5809b947d0f1b3fa5029428c98072982fa7abab
-  React-jsitooling: ec0ad10664b6a943121f5b5b009927453b19b953
-  React-jsitracing: 65bd1ce61ba8fc3bbf90fe005d417472275a6cd4
-  React-logger: 64d31a75111596bd023ae653c0eabf32be3c9302
-  React-Mapbuffer: 7055b634a07b9f9e84ee5660ef52cf42658174b7
-  React-microtasksnativemodule: 0154a544879e6afeadef9525b0cb17cacf4a93bd
-  react-native-safe-area-context: 53f796cb6c814661bbe99fbdfd0585d07b996cdd
-  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
-  React-NativeModulesApple: 943be0fedffc361db7c2ea7b1e54b8d53c6ab178
-  React-networking: da2682b36bf57ed5428ef3f06824d8b30f617202
+  React-defaultsnativemodule: 23c3714471bebf777a6adfeeb0862010d6c3dd41
+  React-domnativemodule: ba499975e32cec21aa364cbd9589d4cf5ffdcc02
+  React-Fabric: 805d412fd56fd688491b58780fb4434a8f7d51fa
+  React-FabricComponents: 0b5df5e7de2b944f888f2ada793e47c940a7082c
+  React-FabricImage: 9382e3b2be7d0445ea38bd72b0cffedd701973ac
+  React-featureflags: f5fc732f8511f90f531e59a1177356f1e9bdde67
+  React-featureflagsnativemodule: d1c9fba207214180ef6e9fa26b92d7b71909dbf0
+  React-graphics: 69211395982fa1a3fc0b22be8abc032e53f58bd5
+  React-hermes: ed6172652de7168bcc1a3ad1b7ee73694910ef83
+  React-idlecallbacksnativemodule: 2ccc9360969e239cc150dd69cd09537c388bc36d
+  React-ImageManager: 705e657487ceeb63a184a65f20422c5f597133c5
+  React-intersectionobservernativemodule: 3807d7631efd891e5ac1b1d7c0265622d8735348
+  React-jserrorhandler: a3d99c0c15376e6de71e33ccab0cb1bd8b99eb22
+  React-jsi: 78c5e479d87a3c037865e8977b8c5d99a248f245
+  React-jsiexecutor: a054806b8ea1ad1dc6ad65234b60c9d790c7773c
+  React-jsinspector: a796aadf3fa7efddf65141bae9955d1b3b5d38ad
+  React-jsinspectorcdp: 2add8d4116b31f3c844f9f882698e79a9308c4f4
+  React-jsinspectornetwork: 99643cec64fcb448ade11450e540798d625dea87
+  React-jsinspectortracing: 007b7cd9d8fc46c4a1601346e6002cbaf99aabd9
+  React-jsitooling: d6c400dfc2155de637718b9eee44c7776473b06e
+  React-jsitracing: 3f211ad2131ae6bf599b8de219f97e6fa971d27f
+  React-logger: d6b4e3af2a51d5c1c8ebb7914637b86bbec93564
+  React-Mapbuffer: 019786f44ee5f1556493e01a72eca223a2d46356
+  React-microtasksnativemodule: 5855ca396a2748042ea1b856e628d9c6a740f6c6
+  react-native-safe-area-context: 37e680fc4cace3c0030ee46e8987d24f5d3bdab2
+  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
+  React-NativeModulesApple: de8b90a262c3e13e950b645186a47c3ff667052d
+  React-networking: 70fca7678ef2673d9ff1f8cc0e1f809e1be954ce
   React-oscompat: f3eb52b3be9b08bf8ca8ba0c616fd9905f4c7391
-  React-perflogger: 72d6cde25962a72b6d82545ec08c931b972a4d05
-  React-performancecdpmetrics: 962d5ca8fa55505823205175a831cda0623b2ab9
-  React-performancetimeline: 517eb467150b4979379391548b71ce53cd4466f3
+  React-perflogger: 21748e5dc4ba3d3d5157db1ec1c026b3ca2671f6
+  React-performancecdpmetrics: add513368e6f997ba0d78820d7a848000c68fc69
+  React-performancetimeline: e52281d68535985313f9d5a2b3830756cc4ebc4b
   React-RCTActionSheet: a8bff6e75c7a18f653297fb14571043ae79431f6
-  React-RCTAnimation: ab5556952f003338d4d86ee9eda2c26aba3cce95
-  React-RCTAppDelegate: 75f34302bb80c076d97a19642400d5d2d940023f
-  React-RCTBlob: c4fb179f4d1076cc63a5918c41d766533b0f2147
-  React-RCTFabric: 50214f12555bcc510b2b1c4dcea803add50a6a78
-  React-RCTFBReactNativeSpec: 7ee95f43e325c85bec0856d9ec9541e682fd705e
-  React-RCTImage: 61cd308df71c9966b3bb847df1bc1415eed07121
-  React-RCTLinking: 6d5ce1137762668fcf1f298e17485bd04129e6d3
-  React-RCTNetwork: 404dc3ab815ec5f4eb69770b333980adf36a3fa4
-  React-RCTRuntime: 0d6c40687e504ed2c08ceb020c06cbbfabedd3b7
-  React-RCTSettings: b8b43aa0b6f0fafcd828c8888fb10e82ad0f5145
-  React-RCTText: a583a49fc866aa200e492969a2378256bde7e2bb
-  React-RCTVibration: 3337cff4d1efae05e289cfcf90a70d24d361b1c3
+  React-RCTAnimation: 5a25c557763c321028856b0b0d35e12280759783
+  React-RCTAppDelegate: 5a3cdb389f8f1e4c2bb88459b6027c087964301d
+  React-RCTBlob: f0f6305c164356f61ce444af0d12857b855e2645
+  React-RCTFabric: ef9c6a3ca6edf8f8e829a27f4b063fa71fe5759b
+  React-RCTFBReactNativeSpec: dd05f61b5283ad14c1dc10fe466a36530dcbcab1
+  React-RCTImage: ec2705a7eb15cf09d8d4978956159d95f6a8abf5
+  React-RCTLinking: dd9aef1181fbdc286c50bb96c61f52e725d267d3
+  React-RCTNetwork: 654f40ca7ea62a00592eda5c94155bb322cb22e1
+  React-RCTRuntime: 270c5022ae7820302fd8bbac529780be1c99ce71
+  React-RCTSettings: f3a808b3d707abef5e7f7308e93405068b6535ca
+  React-RCTText: e0e652329e2bede240664c1e75476037cb778b85
+  React-RCTVibration: 65e1183edfd95293f769bf8486bbd7b0e82e5b4b
   React-rendererconsistency: ff227146777b3733c2f4c601ec68267955447e27
-  React-renderercss: 811e6190dfd7813a7227b55fedecda40ae300d14
-  React-rendererdebug: 19340e07e6963e63827ec8261cf38e3fd1577981
-  React-RuntimeApple: 8fb9a4caa272c0543564906b84c333e1a455b0a1
-  React-RuntimeCore: b7bedbf160e2221982c8231ecf6d89237a3e76a1
-  React-runtimeexecutor: dacc8c00d03929a760e98ad40b45cc4ba4c7db15
-  React-RuntimeHermes: bf7a82a690ecd2436837c8d19070590b83f4b84d
-  React-runtimescheduler: d890bf0a8b417bcadbb3e6cdd1b5cd03ef5e724e
-  React-timing: dcef343f98d0548d06b5af7ba9c9a55fd251967f
-  React-utils: 4297fe617437d27671a924bfcaed667201bd99fe
-  React-webperformancenativemodule: 0e31939496e1df9e80703b786b7513132e76b3b0
-  ReactAppDependencyProvider: 23e2bca1661f8781e55fcc05a151fc1df97bc1fb
-  ReactCodegen: c049d7e966ed24be56d8e21cb1b8880316975e76
-  ReactCommon: 89ccc6cb100ca5a0303b46483037ef8f3e06e2e0
+  React-renderercss: 28bc4de38c9f9d3f70113c6dcb4f859dab726c3d
+  React-rendererdebug: ca2d43838d5210c9625f3a8fe4caef34e1240375
+  React-RuntimeApple: c79c05a004c1cb95476ad0ef01d4fddb1b083122
+  React-RuntimeCore: 7eb439050ec80ac61fdcf193edce77ab75e5399c
+  React-runtimeexecutor: f801ae52e36376b637dad78aaea5e2564a3c655e
+  React-RuntimeHermes: 4bb4a0a392e16351fe44257460f8aa693ba5f057
+  React-runtimescheduler: 4a94d1c2fc29384beac270ba331a8b2c95fcf058
+  React-timing: 9ad4ede53c5d42fc6cd2334ed76b73d374619f8f
+  React-utils: 8d6d63b3ab6c08fd730d737798ce10da4be604eb
+  React-webperformancenativemodule: 02c3929320f3f839467a55b1d2e202206c8e3196
+  ReactAppDependencyProvider: ebcf3a78dc1bcdf054c9e8d309244bade6b31568
+  ReactCodegen: a5ccf47d3f937ad2add6e69b2b7e28f9f63ce646
+  ReactCommon: e22f6e537e566de4c61121da2139a1980caff948
   ReactNativeDependencies: 69de62c8a59d21e7b6af8bdfb62b61e798f65351
-  RNScreens: dd61bc3a3e6f6901ad833efa411917d44827cf51
+  RNScreens: d8d6f1792f6e7ac12b0190d33d8d390efc0c1845
   Yoga: 21f482cbc18b56cdc477cd3a0c5b8c2c83ac27ce
 
 PODFILE CHECKSUM: cc2ab22c5169410d8739c73db2747f1617e7eaf0
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary
- Upgrade CocoaPods from 1.15.2 to 1.16.2.
- Replace the old `xcodeproj < 1.26.0` workaround with CocoaPods 1.16.2's required `xcodeproj >= 1.27.0` range.
- Let `concurrent-ruby` move to 1.3.6 and ActiveSupport move to 7.1.6, removing the old compatibility pin.
- Regenerate the iOS `Podfile.lock` under CocoaPods 1.16.2; the React Native pod versions remain on 0.83.0.

## Validation
- `RBENV_VERSION=2.7.6 /Users/mrousavy/.rbenv/shims/bundle _2.3.22_ update cocoapods xcodeproj activesupport concurrent-ruby --conservative`
- `RBENV_VERSION=2.7.6 /Users/mrousavy/.rbenv/shims/bundle _2.3.22_ exec pod update React-Core-prebuilt ReactNativeDependencies hermes-engine --no-repo-update`
- `RBENV_VERSION=2.7.6 /Users/mrousavy/.rbenv/shims/bundle _2.3.22_ exec pod --version`
- `bun example build:ios`

## Notes
- CocoaPods 1.16.2 release notes mention the xcodeproj 1.27.0 minimum for reverting breaking build setting changes.
- Release notes checked: https://github.com/CocoaPods/CocoaPods/releases/tag/1.16.2