### PR TITLE
chore: Upgrade Zod to 4.4.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
         "react-native-nitro-modules": "^0.35.9",
         "ts-morph": "^28.0.0",
         "yargs": "^18.0.0",
-        "zod": "^4.0.5",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/node": "^25.7.0",
@@ -4106,7 +4106,7 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
@@ -4533,6 +4533,8 @@
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "eslint-plugin-react-hooks/zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
 
     "estree-util-to-js/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 

--- a/packages/nitrogen/package.json
+++ b/packages/nitrogen/package.json
@@ -38,7 +38,7 @@
     "react-native-nitro-modules": "^0.35.9",
     "ts-morph": "^28.0.0",
     "yargs": "^18.0.0",
-    "zod": "^4.0.5"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^25.7.0"


### PR DESCRIPTION
## Summary
- Upgrade `nitrogen`'s direct `zod` dependency to 4.4.3.
- Refresh `bun.lock` for the new direct Zod version.

## Changelog notes
- Zod 4.4.3 is a v4 patch release focused on parser correctness, including fixes for absent object-key fallback/catch handling and preprocess behavior.
- `nitrogen` only uses stable schema APIs (`object`, `enum`, `record`, `infer`, `ZodError`), so no source migration was needed.

## Validation
- `bun install --ignore-scripts`
- `bun nitrogen typecheck`
- `bun nitrogen build`
- `git diff --check`