### PR TITLE
chore: Upgrade Node types to 25.9.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,7 @@
         "zod": "^4.0.5",
       },
       "devDependencies": {
-        "@types/node": "^25.7.0",
+        "@types/node": "^25.9.1",
       },
     },
     "packages/react-native-nitro-modules": {
@@ -1366,7 +1366,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@types/node-forge": ["@types/node-forge@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw=="],
 
@@ -3912,7 +3912,7 @@
 
     "undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 
-    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "unicode-canonical-property-names-ecmascript": ["unicode-canonical-property-names-ecmascript@2.0.1", "", {}, "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg=="],
 

--- a/packages/nitrogen/package.json
+++ b/packages/nitrogen/package.json
@@ -41,7 +41,7 @@
     "zod": "^4.0.5"
   },
   "devDependencies": {
-    "@types/node": "^25.7.0"
+    "@types/node": "^25.9.1"
   },
   "release-it": {
     "npm": {


### PR DESCRIPTION
## Summary
- Upgrade `@types/node` in `nitrogen` to 25.9.1.
- Refresh `bun.lock` for the updated Node ambient typings and `undici-types` range.

## Changelog notes
- `@types/node` 25.9.1 is the latest package and the tagged build for TypeScript 5.8, 5.9, and 6.0.
- `nitrogen` uses standard Node APIs (`fs`, `path`, `process`), and no source changes were required.

## Validation
- `bun install --ignore-scripts`
- `bun nitrogen typecheck`
- `bun nitrogen build`
- `git diff --check`