### PR TITLE
chore: Upgrade Android toolchain to NDK r29

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     ext {
-        buildToolsVersion = "36.0.0"
+        buildToolsVersion = "36.1.0"
         minSdkVersion = 24
         compileSdkVersion = 36
         targetSdkVersion = 36
-        ndkVersion = "27.1.12297006"
+        ndkVersion = "29.0.14206865"
         kotlinVersion = "2.1.21"
     }
     repositories {

--- a/packages/react-native-nitro-modules/android/gradle.properties
+++ b/packages/react-native-nitro-modules/android/gradle.properties
@@ -2,4 +2,4 @@ Nitro_kotlinVersion=2.1.21
 Nitro_minSdkVersion=23
 Nitro_targetSdkVersion=36
 Nitro_compileSdkVersion=36
-Nitro_ndkVersion=27.1.12297006
+Nitro_ndkVersion=29.0.14206865

--- a/packages/react-native-nitro-test-external/android/gradle.properties
+++ b/packages/react-native-nitro-test-external/android/gradle.properties
@@ -2,4 +2,4 @@ NitroTestExternal_kotlinVersion=2.1.21
 NitroTestExternal_minSdkVersion=23
 NitroTestExternal_targetSdkVersion=36
 NitroTestExternal_compileSdkVersion=36
-NitroTestExternal_ndkVersion=27.1.12297006
+NitroTestExternal_ndkVersion=29.0.14206865

--- a/packages/react-native-nitro-test/android/gradle.properties
+++ b/packages/react-native-nitro-test/android/gradle.properties
@@ -2,4 +2,4 @@ Nitro_kotlinVersion=2.1.21
 Nitro_minSdkVersion=23
 Nitro_targetSdkVersion=36
 Nitro_compileSdkVersion=36
-Nitro_ndkVersion=27.1.12297006
+Nitro_ndkVersion=29.0.14206865

--- a/packages/template/android/gradle.properties
+++ b/packages/template/android/gradle.properties
@@ -2,4 +2,4 @@ $$androidCxxLibName$$_kotlinVersion=2.1.21
 $$androidCxxLibName$$_minSdkVersion=23
 $$androidCxxLibName$$_targetSdkVersion=36
 $$androidCxxLibName$$_compileSdkVersion=36
-$$androidCxxLibName$$_ndkVersion=27.1.12297006
+$$androidCxxLibName$$_ndkVersion=29.0.14206865


### PR DESCRIPTION
## Summary

- upgrade Android Build Tools from 36.0.0 to 36.1.0 in the example app
- upgrade the shared Android NDK pin from 27.1.12297006 to 29.0.14206865 across the example app, Nitro packages, external test package, and generated template
- leave compile/target SDK at API 36; API 37 is still a preview SDK path and Android 16 QPR minor SDKs require a separate Gradle DSL migration

## Validation

- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' bun example build:android`
- `git diff --check`