### PR TITLE
[codex] Fix tab bar icon tint

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -32,10 +32,10 @@ export default function App() {
           component={HybridObjectTestsScreen}
           options={{
             tabBarLabel: 'Tests',
-            tabBarIcon: ({ size, focused }) => (
+            tabBarIcon: ({ size, color }) => (
               <Image
                 source={dna}
-                tintColor={focused ? undefined : 'grey'}
+                tintColor={color}
                 style={{ width: size * 1.2, height: size * 1.2 }}
               />
             ),
@@ -46,10 +46,10 @@ export default function App() {
           component={BenchmarksScreen}
           options={{
             tabBarLabel: 'Benchmarks',
-            tabBarIcon: ({ size, focused }) => (
+            tabBarIcon: ({ size, color }) => (
               <Image
                 source={rocket}
-                tintColor={focused ? undefined : 'grey'}
+                tintColor={color}
                 style={{ width: size * 1.4, height: size * 1.4 }}
               />
             ),
@@ -60,10 +60,10 @@ export default function App() {
           component={ViewScreen}
           options={{
             tabBarLabel: 'View',
-            tabBarIcon: ({ size, focused }) => (
+            tabBarIcon: ({ size, color }) => (
               <Image
                 source={map}
-                tintColor={focused ? undefined : 'grey'}
+                tintColor={color}
                 style={{ width: size, height: size }}
               />
             ),
@@ -74,10 +74,10 @@ export default function App() {
           component={EvalScreen}
           options={{
             tabBarLabel: 'Eval',
-            tabBarIcon: ({ size, focused }) => (
+            tabBarIcon: ({ size, color }) => (
               <Image
                 source={terminal}
-                tintColor={focused ? undefined : 'grey'}
+                tintColor={color}
                 style={{ width: size, height: size }}
               />
             ),


### PR DESCRIPTION
## What changed

Updated the example app's bottom tab icons to use React Navigation's provided `color` value for `Image.tintColor` instead of switching between `undefined` and `grey` based on focus state.

## Why

After the React Native / React Navigation upgrade, the tab bar renders active and inactive icon layers and fades between them. The previous code sent `undefined` for focused icons, which goes through the native iOS/Fabric Image tint reset path and can leave the image layer blank after visiting a tab.

Always passing an explicit tint color keeps the native image rendering mode stable and prevents icons from disappearing after tab switches.

## Impact

The selected tab icons now use the active tab tint color rather than full-color artwork. Inactive icons still use the navigator's inactive tint.

## Validation

- `bun example typecheck`
- `bun --cwd example lint-ci`
- `git diff --check`