### PR TITLE
[codex] fix Swift wait fractional sleep

### DIFF
--- a/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
@@ -399,7 +399,8 @@ class HybridTestObjectSwift: HybridTestObjectSwiftKotlinSpec {
 
   func wait(seconds: Double) throws -> Promise<Void> {
     return Promise.async {
-      try await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
+      let nanoseconds = UInt64((seconds * 1_000_000_000).rounded())
+      try await Task.sleep(nanoseconds: nanoseconds)
     }
   }
 


### PR DESCRIPTION
## What changed

Fixes the Swift test object's `wait(seconds:)` implementation so fractional second values are converted to nanoseconds before constructing the `UInt64` delay.

## Why

`UInt64(seconds) * 1_000_000_000` truncated fractional values first, so `wait(0.5)` became a zero-nanosecond sleep. That made the promise parallel test unable to validate Swift-side waiting behavior correctly.

## Validation

- `swift format --in-place packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift`
- `git diff --check`