### PR TITLE
fix: Public headers not exposed in objcxx interop

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "react-native-nitro",

--- a/example/ios/NitroExample.xcodeproj/project.pbxproj
+++ b/example/ios/NitroExample.xcodeproj/project.pbxproj
@@ -255,13 +255,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-NitroExample/Pods-NitroExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-NitroExample/Pods-NitroExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -298,13 +294,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-NitroExample/Pods-NitroExample-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-NitroExample/Pods-NitroExample-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -536,7 +528,10 @@
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -616,7 +611,10 @@
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;

--- a/example/ios/NitroExample.xcodeproj/project.pbxproj
+++ b/example/ios/NitroExample.xcodeproj/project.pbxproj
@@ -255,9 +255,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-NitroExample/Pods-NitroExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-NitroExample/Pods-NitroExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -294,9 +298,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-NitroExample/Pods-NitroExample-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-NitroExample/Pods-NitroExample-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -409,7 +417,7 @@
 				PRODUCT_NAME = NitroExample;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_OBJC_INTEROP_MODE = objc;
+				SWIFT_OBJC_INTEROP_MODE = objcxx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -443,7 +451,7 @@
 				PRODUCT_NAME = NitroExample;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_OBJC_INTEROP_MODE = objc;
+				SWIFT_OBJC_INTEROP_MODE = objcxx;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -528,10 +536,7 @@
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -611,10 +616,7 @@
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;

--- a/example/ios/NitroExample/AppDelegate.swift
+++ b/example/ios/NitroExample/AppDelegate.swift
@@ -9,6 +9,7 @@ import UIKit
 import React
 import React_RCTAppDelegate
 import ReactAppDependencyProvider
+import NitroTest
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/example/ios/NitroExample/AppDelegate.swift
+++ b/example/ios/NitroExample/AppDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 import React
 import React_RCTAppDelegate
 import ReactAppDependencyProvider
-import NitroTest
+import NitroModules
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2228,7 +2228,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: ffe60ef62e2a91482e52813d93d1827f6c7297f8
-  NitroModules: 16bc17a076b12304d608f7c915b9d321f56dfc19
+  NitroModules: 41e456ee8c8ad54d22957a3e4b3ecab1acbb9e70
   NitroTest: 015ec3bddf31c0bd83c0d6d4e10b6d3a42e4e18d
   NitroTestExternal: 01bc29bd779142e98432f2178760baebb134de57
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2227,7 +2227,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: f0e8ed549bb5a3befb3e292e5c0dafd3e2cee3ab
+  hermes-engine: ffe60ef62e2a91482e52813d93d1827f6c7297f8
   NitroModules: 16bc17a076b12304d608f7c915b9d321f56dfc19
   NitroTest: 015ec3bddf31c0bd83c0d6d4e10b6d3a42e4e18d
   NitroTestExternal: 01bc29bd779142e98432f2178760baebb134de57
@@ -2239,7 +2239,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 72454b4caa0309d15c45de529b1c5a0e4607cf9a
+  React-Core-prebuilt: 34bd65b8de409b525d8545cc92b58961427d2015
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
@@ -2303,7 +2303,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: 0f100aa6334186385a43f0dd13d63efc6805ea55
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: 86c5427d73b954c0671c6ab9691d486b196595b6
+  ReactNativeDependencies: df1f53d0ec63baf19e6057b5921e50d5bc45560c
   RNScreens: 991cc417cd396602a6cf59a42139e5a9d91462a9
   Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
 

--- a/packages/react-native-nitro-modules/NitroModules.podspec
+++ b/packages/react-native-nitro-modules/NitroModules.podspec
@@ -33,32 +33,8 @@ Pod::Spec.new do |s|
   ]
   s.public_header_files = [
     # Public C++ headers will be exposed in modulemap (for Swift)
-    "cpp/core/AnyMap.hpp",
-    "cpp/core/ArrayBuffer.hpp",
-    "cpp/core/HybridObject.hpp",
-    "cpp/core/Null.hpp",
-    "cpp/core/Promise.hpp",
-    "cpp/entrypoint/HybridNitroModulesProxy.hpp",
-    "cpp/entrypoint/InstallNitro.hpp",
-    "cpp/registry/HybridObjectRegistry.hpp",
-    "cpp/jsi/JSIConverter.hpp",
-    "cpp/jsi/JSIHelpers.hpp",
-    "cpp/platform/NitroLogger.hpp",
-    "cpp/threading/Dispatcher.hpp",
-    "cpp/utils/JSCallback.hpp",
-    "cpp/utils/FastVectorCopy.hpp",
-    "cpp/utils/NitroHash.hpp",
-    "cpp/utils/NitroDefines.hpp",
-    "cpp/utils/PropNameIDCache.hpp",
-    "cpp/views/CachedProp.hpp",
-    # Public iOS-specific headers that will be exposed in modulemap (for Swift)
-    "ios/core/ArrayBufferHolder.hpp",
-    "ios/core/PromiseHolder.hpp",
-    "ios/utils/AnyMapUtils.hpp",
-    "ios/utils/Result.hpp",
-    "ios/utils/DateToChronoDate.hpp",
-    "ios/utils/RuntimeError.hpp",
-    "ios/utils/SwiftClosure.hpp",
+   "cpp/**/*.hpp",
+   "ios/**/*.hpp"
   ]
 
   xcconfig = {

--- a/packages/react-native-nitro-test/NitroTest.podspec
+++ b/packages/react-native-nitro-test/NitroTest.podspec
@@ -23,7 +23,6 @@ Pod::Spec.new do |s|
 
   load 'nitrogen/generated/ios/NitroTest+autolinking.rb'
   add_nitrogen_files(s)
-
   s.dependency 'React-jsi'
   s.dependency 'React-callinvoker'
   s.dependency 'NitroTestExternal'


### PR DESCRIPTION
All tests passes in my local fork -> https://github.com/riteshshukla04/nitro/actions/runs/26724236835

LMK if this looks good . I will revert the interop back to normal

The repro PR is here https://github.com/mrousavy/nitro/pull/1371