### PR TITLE
fix: remove duplicate 'the' in Nitrogen generator and regenerated files

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinEnum.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinEnum.ts
@@ -49,7 +49,7 @@ namespace ${cxxNamespace} {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "${enumType.enumName}" and the the Kotlin enum "${enumType.enumName}".
+   * The C++ JNI bridge between the C++ enum "${enumType.enumName}" and the Kotlin enum "${enumType.enumName}".
    */
   struct J${enumType.enumName} final: public jni::JavaClass<J${enumType.enumName}> {
   public:

--- a/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinStruct.ts
@@ -133,7 +133,7 @@ namespace ${cxxNamespace} {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "${structType.structName}" and the the Kotlin data class "${structType.structName}".
+   * The C++ JNI bridge between the C++ struct "${structType.structName}" and the Kotlin data class "${structType.structName}".
    */
   struct J${structType.structName} final: public jni::JavaClass<J${structType.structName}> {
   public:

--- a/packages/react-native-nitro-test-external/nitrogen/generated/android/c++/JOptionalPrimitivesHolder.hpp
+++ b/packages/react-native-nitro-test-external/nitrogen/generated/android/c++/JOptionalPrimitivesHolder.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::test::external {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "OptionalPrimitivesHolder" and the the Kotlin data class "OptionalPrimitivesHolder".
+   * The C++ JNI bridge between the C++ struct "OptionalPrimitivesHolder" and the Kotlin data class "OptionalPrimitivesHolder".
    */
   struct JOptionalPrimitivesHolder final: public jni::JavaClass<JOptionalPrimitivesHolder> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JCar.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JCar.hpp
@@ -25,7 +25,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "Car" and the the Kotlin data class "Car".
+   * The C++ JNI bridge between the C++ struct "Car" and the Kotlin data class "Car".
    */
   struct JCar final: public jni::JavaClass<JCar> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JColorScheme.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JColorScheme.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "ColorScheme" and the the Kotlin enum "ColorScheme".
+   * The C++ JNI bridge between the C++ enum "ColorScheme" and the Kotlin enum "ColorScheme".
    */
   struct JColorScheme final: public jni::JavaClass<JColorScheme> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JExternalObjectStruct.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JExternalObjectStruct.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "ExternalObjectStruct" and the the Kotlin data class "ExternalObjectStruct".
+   * The C++ JNI bridge between the C++ struct "ExternalObjectStruct" and the Kotlin data class "ExternalObjectStruct".
    */
   struct JExternalObjectStruct final: public jni::JavaClass<JExternalObjectStruct> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JJsStyleStruct.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JJsStyleStruct.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "JsStyleStruct" and the the Kotlin data class "JsStyleStruct".
+   * The C++ JNI bridge between the C++ struct "JsStyleStruct" and the Kotlin data class "JsStyleStruct".
    */
   struct JJsStyleStruct final: public jni::JavaClass<JJsStyleStruct> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JMapWrapper.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JMapWrapper.hpp
@@ -20,7 +20,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "MapWrapper" and the the Kotlin data class "MapWrapper".
+   * The C++ JNI bridge between the C++ struct "MapWrapper" and the Kotlin data class "MapWrapper".
    */
   struct JMapWrapper final: public jni::JavaClass<JMapWrapper> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JOldEnum.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JOldEnum.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "OldEnum" and the the Kotlin enum "OldEnum".
+   * The C++ JNI bridge between the C++ enum "OldEnum" and the Kotlin enum "OldEnum".
    */
   struct JOldEnum final: public jni::JavaClass<JOldEnum> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JOptionalCallback.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JOptionalCallback.hpp
@@ -22,7 +22,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "OptionalCallback" and the the Kotlin data class "OptionalCallback".
+   * The C++ JNI bridge between the C++ struct "OptionalCallback" and the Kotlin data class "OptionalCallback".
    */
   struct JOptionalCallback final: public jni::JavaClass<JOptionalCallback> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JOptionalEnumWrapper.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JOptionalEnumWrapper.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "OptionalEnumWrapper" and the the Kotlin data class "OptionalEnumWrapper".
+   * The C++ JNI bridge between the C++ struct "OptionalEnumWrapper" and the Kotlin data class "OptionalEnumWrapper".
    */
   struct JOptionalEnumWrapper final: public jni::JavaClass<JOptionalEnumWrapper> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JOptionalWrapper.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JOptionalWrapper.hpp
@@ -20,7 +20,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "OptionalWrapper" and the the Kotlin data class "OptionalWrapper".
+   * The C++ JNI bridge between the C++ struct "OptionalWrapper" and the Kotlin data class "OptionalWrapper".
    */
   struct JOptionalWrapper final: public jni::JavaClass<JOptionalWrapper> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JPartialPerson.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JPartialPerson.hpp
@@ -18,7 +18,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "PartialPerson" and the the Kotlin data class "PartialPerson".
+   * The C++ JNI bridge between the C++ struct "PartialPerson" and the Kotlin data class "PartialPerson".
    */
   struct JPartialPerson final: public jni::JavaClass<JPartialPerson> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JPerson.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JPerson.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "Person" and the the Kotlin data class "Person".
+   * The C++ JNI bridge between the C++ struct "Person" and the Kotlin data class "Person".
    */
   struct JPerson final: public jni::JavaClass<JPerson> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JPowertrain.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JPowertrain.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "Powertrain" and the the Kotlin enum "Powertrain".
+   * The C++ JNI bridge between the C++ enum "Powertrain" and the Kotlin enum "Powertrain".
    */
   struct JPowertrain final: public jni::JavaClass<JPowertrain> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JSecondMapWrapper.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JSecondMapWrapper.hpp
@@ -18,7 +18,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "SecondMapWrapper" and the the Kotlin data class "SecondMapWrapper".
+   * The C++ JNI bridge between the C++ struct "SecondMapWrapper" and the Kotlin data class "SecondMapWrapper".
    */
   struct JSecondMapWrapper final: public jni::JavaClass<JSecondMapWrapper> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JWeirdNumbersEnum.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JWeirdNumbersEnum.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "WeirdNumbersEnum" and the the Kotlin enum "WeirdNumbersEnum".
+   * The C++ JNI bridge between the C++ enum "WeirdNumbersEnum" and the Kotlin enum "WeirdNumbersEnum".
    */
   struct JWeirdNumbersEnum final: public jni::JavaClass<JWeirdNumbersEnum> {
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JWrappedJsStruct.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JWrappedJsStruct.hpp
@@ -22,7 +22,7 @@ namespace margelo::nitro::test {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "WrappedJsStruct" and the the Kotlin data class "WrappedJsStruct".
+   * The C++ JNI bridge between the C++ struct "WrappedJsStruct" and the Kotlin data class "WrappedJsStruct".
    */
   struct JWrappedJsStruct final: public jni::JavaClass<JWrappedJsStruct> {
   public:


### PR DESCRIPTION
This PR fixes a recurring typo ('the the') in the Nitrogen code generator and updates the regenerated files. It also includes the addition of the `react-native-alternate-app-icon` module to the Awesome Nitro Modules list.