### PR TITLE
docs: Add react-native-alternate-app-icon module to the Nitro Modules list

### DIFF
--- a/docs/docs/resources/awesome-nitro-modules.md
+++ b/docs/docs/resources/awesome-nitro-modules.md
@@ -98,6 +98,7 @@ A curated collection of community-built Nitro Modules.
 | Module | Description | Links |
 |--------|-------------|-------|
 | **react-native-unistyles** | Universal styling system | [GitHub](https://github.com/jpudysz/react-native-unistyles) |
+| **react-native-alternate-app-icon** | Dynamic alternate app icon switching (iOS & Android) | [GitHub](https://github.com/rutvik24/react-native-alternate-app-icon) |
 
 ### Text & Content
 

--- a/docs/docs/resources/awesome-nitro-modules.md
+++ b/docs/docs/resources/awesome-nitro-modules.md
@@ -98,7 +98,7 @@ A curated collection of community-built Nitro Modules.
 | Module | Description | Links |
 |--------|-------------|-------|
 | **react-native-unistyles** | Universal styling system | [GitHub](https://github.com/jpudysz/react-native-unistyles) |
-| **react-native-alternate-app-icon** | Dynamic alternate app icon switching (iOS & Android) | [GitHub](https://github.com/rutvik24/react-native-alternate-app-icon) |
+| **react-native-alternate-app-icon** | Dynamic alternate app icon switching | [GitHub](https://github.com/rutvik24/react-native-alternate-app-icon) |
 
 ### Text & Content
 


### PR DESCRIPTION
This PR adds the [react-native-alternate-app-icon](https://github.com/rutvik24/react-native-alternate-app-icon) module to the "Awesome Nitro Modules" list. This was originally part of #1373 but has been split into a separate PR as requested.