### PR TITLE
test(nitro-test): reproduce C++ Promise<T> data race (resolve vs JSIConverter::toJSI)

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1429,6 +1429,29 @@ export function getTests(
           .didNotThrow()
           .equals(true)
     ),
+    createTest(
+      'newTestObjectAsync() under parallel load does not data-race (run under Thread Sanitizer)',
+      async () =>
+        (
+          await it(async () => {
+            // C++-only: the C++ `Promise<T>` race. `newTestObjectAsync` resolves a HybridObject
+            // off the JS thread; the race is between resolve() and JSIConverter::toJSI reading
+            // Promise `_state` on the JS thread. Passes functionally — the verdict is Thread
+            // Sanitizer (build the example with ENABLE_THREAD_SANITIZER=YES).
+            const HybridTestObjectCpp =
+              getHybridObjectConstructor<TestObjectCpp>('TestObjectCpp')
+            const cpp = new HybridTestObjectCpp()
+            for (let round = 0; round < 20; round++) {
+              await Promise.all(
+                Array.from({ length: 32 }, () => cpp.newTestObjectAsync())
+              )
+            }
+            return true
+          })
+        )
+          .didNotThrow()
+          .equals(true)
+    ),
     createTest('promiseThatResolvesVoidInstantly() works', async () =>
       (await it(() => testObject.promiseThatResolvesVoidInstantly()))
         .didNotThrow()

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -690,6 +690,13 @@ std::shared_ptr<HybridTestObjectCppSpec> HybridTestObjectCpp::newTestObject() {
   return std::make_shared<HybridTestObjectCpp>();
 }
 
+std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> HybridTestObjectCpp::newTestObjectAsync() {
+  // Resolves a HybridObject off the JS thread (on the Nitro ThreadPool). The near-instant closure
+  // keeps the resolve()-vs-toJSI window wide so the C++ Promise `_state` race surfaces under TSan.
+  return Promise<std::shared_ptr<HybridTestObjectCppSpec>>::async(
+      []() -> std::shared_ptr<HybridTestObjectCppSpec> { return std::make_shared<HybridTestObjectCpp>(); });
+}
+
 jsi::Value HybridTestObjectCpp::rawJsiFunc(jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* args, size_t count) {
   jsi::Array array(runtime, count);
   for (size_t i = 0; i < count; i++) {

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -203,6 +203,7 @@ public:
   void setAllValuesTo(const std::shared_ptr<ArrayBuffer>& buffer, double value) override;
   std::shared_ptr<Promise<std::shared_ptr<ArrayBuffer>>> createArrayBufferAsync() override;
   std::shared_ptr<HybridTestObjectCppSpec> newTestObject() override;
+  std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> newTestObjectAsync() override;
 
   std::shared_ptr<HybridBaseSpec> createBase() override;
   std::shared_ptr<HybridChildSpec> createChild() override;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -57,6 +57,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("flip", &HybridTestObjectCppSpec::flip);
       prototype.registerHybridMethod("passTuple", &HybridTestObjectCppSpec::passTuple);
       prototype.registerHybridMethod("newTestObject", &HybridTestObjectCppSpec::newTestObject);
+      prototype.registerHybridMethod("newTestObjectAsync", &HybridTestObjectCppSpec::newTestObjectAsync);
       prototype.registerHybridMethod("getVariantHybrid", &HybridTestObjectCppSpec::getVariantHybrid);
       prototype.registerHybridMethod("bounceAnyHybrid", &HybridTestObjectCppSpec::bounceAnyHybrid);
       prototype.registerHybridMethod("bounceCustomType", &HybridTestObjectCppSpec::bounceCustomType);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -63,6 +63,7 @@ namespace margelo::nitro::test { struct ExternalObjectStruct; }
 #include "Powertrain.hpp"
 #include "OldEnum.hpp"
 #include <functional>
+#include <NitroModules/Promise.hpp>
 #include "Person.hpp"
 #include <NitroModules/HybridObject.hpp>
 #include "CustomString.hpp"
@@ -70,7 +71,6 @@ namespace margelo::nitro::test { struct ExternalObjectStruct; }
 #include "Car.hpp"
 #include "HybridChildSpec.hpp"
 #include <NitroModules/AnyMap.hpp>
-#include <NitroModules/Promise.hpp>
 #include <NitroModules/ArrayBuffer.hpp>
 #include <unordered_map>
 #include "MapWrapper.hpp"
@@ -160,6 +160,7 @@ namespace margelo::nitro::test {
       virtual std::tuple<double, double, double> flip(const std::tuple<double, double, double>& tuple) = 0;
       virtual std::tuple<double, std::string, bool> passTuple(const std::tuple<double, std::string, bool>& tuple) = 0;
       virtual std::shared_ptr<HybridTestObjectCppSpec> newTestObject() = 0;
+      virtual std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> newTestObjectAsync() = 0;
       virtual std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person> getVariantHybrid(const std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person>& variant) = 0;
       virtual std::shared_ptr<HybridObject> bounceAnyHybrid(const std::shared_ptr<HybridObject>& object) = 0;
       virtual CustomString bounceCustomType(CustomString value) = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -341,6 +341,9 @@ export interface TestObjectCpp
   // Type-specifics
   readonly thisObject: TestObjectCpp
   newTestObject(): TestObjectCpp
+  // Returns a HybridObject from a Promise resolved off the JS thread (on the ThreadPool, via
+  // Promise::async). Used to reproduce the data race between resolve() and JSIConverter::toJSI.
+  newTestObjectAsync(): Promise<TestObjectCpp>
   optionalHybrid?: TestObjectCpp
   getVariantHybrid(variant: TestObjectCpp | Person): TestObjectCpp | Person
 


### PR DESCRIPTION
Reproduction PR for #1396 (per the [contributing guide](https://nitro.margelo.com/docs/contributing)).

## What this adds
- `TestObjectCpp.newTestObjectAsync()` — returns a HybridObject from a `Promise::async`, i.e. the Promise is **resolved off the JS thread** (on the Nitro ThreadPool).
- A `getTests.ts` test that hammers it under parallel load (`20 × 32` concurrent calls).

## The race
Between `Promise<T>::resolve()` — which writes `_state` under `_mutex` — and `JSIConverter<shared_ptr<Promise<T>>>::toJSI`, which reads `_state` **lock-free** via `isPending()`/`isResolved()`/`getResult()` on the JS thread the instant the hybrid method returns. No happens-before → data race on the `std::variant _state`.

## How to see it
The test **passes functionally** — the verdict is Thread Sanitizer. Enable it from Xcode:

1. Open `example/ios/NitroExample.xcworkspace`.
2. **Product → Scheme → Edit Scheme…** (`⌘<`) → **Run** → **Diagnostics** tab → check **Thread Sanitizer**.
3. Pick an iOS Simulator and **Run** (`⌘R`).
4. On the **HybridObject Tests** screen, run the `newTestObjectAsync() under parallel load …` test (or **Run all tests**).

TSan reports the race on `Promise::_state` (`resolve` at `Promise.hpp:105` vs `isPending` at `Promise.hpp:248`) in the debug console / Issue Navigator. The test itself still shows ✅ — TSan is the signal. Confirmed on iPhone 17 simulator (iOS 26.4).

<img width="1195" height="719" alt="image" src="https://github.com/user-attachments/assets/aa19a339-cae3-41b4-9f40-9adfa9acd5d1" />


My debug log looks like this:

```log
[HybridObjectRegistry] Registering HybridObject "TestObjectCpp"...
[HybridObjectRegistry] Successfully registered HybridObject "TestObjectCpp"!
[HybridObjectRegistry] Registering HybridObject "TestObjectSwiftKotlin"...
[HybridObjectRegistry] Successfully registered HybridObject "TestObjectSwiftKotlin"!
[HybridObjectRegistry] Registering HybridObject "Base"...
[HybridObjectRegistry] Successfully registered HybridObject "Base"!
[HybridObjectRegistry] Registering HybridObject "Child"...
[HybridObjectRegistry] Successfully registered HybridObject "Child"!
[HybridObjectRegistry] Registering HybridObject "PlatformObject"...
[HybridObjectRegistry] Successfully registered HybridObject "PlatformObject"!
[HybridObjectRegistry] Registering HybridObject "TestView"...
[HybridObjectRegistry] Successfully registered HybridObject "TestView"!
[HybridObjectRegistry] Registering HybridObject "RecyclableTestView"...
[HybridObjectRegistry] Successfully registered HybridObject "RecyclableTestView"!
[HybridObjectRegistry] Registering HybridObject "SomeExternalObject"...
[HybridObjectRegistry] Successfully registered HybridObject "SomeExternalObject"!
`UIScene` lifecycle will soon be required. Failure to adopt will result in an assert in the future.
_setUpFeatureFlags called with release level 2
[RCTMultipartDataTask] GET http://localhost:8081/index.bundle?platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=com.mrousavy.nitro.example
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0619 16:36:15.096875 1839689728 ReactInstance.cpp:267] ReactInstance: evaluateJavaScript() with JS bundle
nw_socket_handle_socket_event [C5.1.1:1] Socket SO_ERROR [61: Connection refused]
nw_endpoint_flow_failed_with_error [C5.1.1 ::1.8097 in_progress socket-flow (satisfied (Path is satisfied), interface: lo0)] already failing, returning
nw_socket_handle_socket_event [C5.1.2:1] Socket SO_ERROR [61: Connection refused]
nw_endpoint_flow_failed_with_error [C5.1.2 127.0.0.1:8097 in_progress socket-flow (satisfied (Path is satisfied), interface: lo0)] already failing, returning
nw_endpoint_flow_failed_with_error [C5.1.2 127.0.0.1:8097 cancelled socket-flow ((null))] already failing, returning
nw_connection_get_connected_socket_block_invoke [C5] Client called nw_connection_get_connected_socket on unconnected nw_connection
TCP Conn 0x10cf00640 Failed : error 0:61 [61]
Running "NitroExample" with {"rootTag":11,"initialProps":{},"fabric":true}
[Dispatcher] Installing global Dispatcher Holder into Runtime "HermesRuntime[RNBridgeless] (com.facebook.react.runtime.JavaScript)"...
[JSICache] Creating new JSICache<T> for runtime HermesRuntime[RNBridgeless] (com.facebook.react.runtime.JavaScript)..
[HybridObjectPrototype] Creating new JS prototype for C++ instance type "HybridNitroModulesProxy"...
[HybridObjectPrototype] Creating new JS prototype for C++ instance type "HybridObject"...
Deep imports from the 'react-native' package are deprecated ('react-native/Libraries/NativeComponent/NativeComponentRegistry'). Source: /Users/boga/Work/Margelo/Nitro/nitro/packages/react-native-nitro-modules/src/views/getHostComponent.ts 4:0
[HybridObjectPrototype] Creating new JS prototype for C++ instance type "HybridTestObjectCpp"...
[HybridObjectPrototype] Creating new JS prototype for C++ instance type "HybridTestObjectCppSpec"...
[HybridObjectPrototype] Creating new JS prototype for C++ instance type "HybridTestObjectSwiftKotlinSpec"...
[HybridObjectPrototype] Creating new JS prototype for C++ instance type "HybridBaseSpec"...
[HybridObjectPrototype] Creating new JS prototype for C++ instance type "HybridChildSpec"...
[HybridObjectPrototype] Creating new JS prototype for C++ instance type "HybridPlatformObjectSpec"...
Prototype chain of Child:
  HybridObject<Child> \^[[2m(1 props)\^[[0m
   ∟ Prototype<HybridChildSpec> \^[[2m(3 props)\^[[0m
      ∟ Prototype<HybridBaseSpec> \^[[2m(2 props)\^[[0m
         ∟ Prototype<HybridObject> \^[[2m(5 props)\^[[0m
            ∟ {} \^[[2m(0 props)\^[[0m
               ∟ {} \^[[2m(0 props)\^[[0m
10
20
30
Prototype chain of TestObjectCpp:
  HybridObject<TestObjectCpp> \^[[2m(1 props)\^[[0m
   ∟ Prototype<HybridTestObjectCpp> \^[[2m(2 props)\^[[0m
      ∟ Prototype<HybridTestObjectCppSpec> \^[[2m(127 props)\^[[0m
         ∟ Prototype<HybridObject> \^[[2m(5 props)\^[[0m
            ∟ {} \^[[2m(0 props)\^[[0m
               ∟ {} \^[[2m(0 props)\^[[0m
Showing Tests for HybridObject "TestObjectCpp"
RCTScrollViewComponentView implements focusItemsInRect: - caching for linear focus movement is limited as long as this view is on screen.
Showing Tests for HybridObject "TestObjectCpp"
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baf4ec0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baf4ec0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12bac0060 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12bac0060 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12bac0840 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12bac0840 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baf3540 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baf3540 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baf4ec0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baf4ec0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12bac0060 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12bac0060 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12bac0840 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12bac0840 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baf3540 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baf3540 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baf4ec0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baf4ec0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x13880e730 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x13880e730 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x10bd0d770 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x10bd0d770 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x11fdb0550 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x11fdb0550 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baed060 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baed060 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x13880e730 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x13880e730 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x10bd0d770 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x10bd0d770 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x11fdb0550 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x11fdb0550 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baed060 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x12baed060 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
       CHHapticPattern.mm:487   +[CHHapticPattern patternForKey:error:]: Failed to read pattern library data: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x13880e730 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
<_UIKBFeedbackGenerator: 0x111222340>: Error creating CHHapticPattern: Error Domain=NSCocoaErrorDomain Code=260 "The file “hapticpatternlibrary.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSURL=file:///Library/Audio/Tunings/Generic/Haptics/Library/hapticpatternlibrary.plist, NSUnderlyingError=0x13880e730 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
Showing Tests for HybridObject "TestObjectCpp"
IOSurfaceClientSetSurfaceNotify failed e00002c7
Showing Tests for HybridObject "TestObjectCpp"
Showing Tests for HybridObject "TestObjectCpp"
Showing Tests for HybridObject "TestObjectCpp"
Showing Tests for HybridObject "TestObjectCpp"
⏳ Test "newTestObjectAsync() under parallel load does not data-race (run under Thread Sanitizer)" started...
[ThreadPool] Creating ThreadPool "nitro-thread" with 3 initial threads (max: 10)...
[ThreadPool] Adding Thread 1 to ThreadPool "nitro-thread"...
[ThreadPool] Adding Thread 2 to ThreadPool "nitro-thread"...
[ThreadPool] Adding Thread 3 to ThreadPool "nitro-thread"...
==================
WARNING: ThreadSanitizer: data race (pid=82343)
  Write of size 4 at 0x00011af56aa0 by thread T27 (mutexes: write M0):
    #0 std::__1::__variant_detail::__dtor<std::__1::__variant_detail::__traits<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>, (std::__1::__variant_detail::_Trait)1>::__destroy[abi:dee210106]() <null> (NitroExample.debug.dylib:arm64+0x27d140)
    #1 auto& std::__1::__variant_detail::__assignment<std::__1::__variant_detail::__traits<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>>::__emplace[abi:dee210106]<1ul, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>(std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>&&) <null> (NitroExample.debug.dylib:arm64+0x280920)
    #2 void std::__1::__variant_detail::__assignment<std::__1::__variant_detail::__traits<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>>::__assign_alt[abi:dee210106]<1ul, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>(std::__1::__variant_detail::__alt<1ul, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>&, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>&&)::'unnamed'::operator()(std::__1::integral_constant<bool, true>) const <null> (NitroExample.debug.dylib:arm64+0x280788)
    #3 void std::__1::__variant_detail::__assignment<std::__1::__variant_detail::__traits<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>>::__assign_alt[abi:dee210106]<1ul, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>(std::__1::__variant_detail::__alt<1ul, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>&, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>&&) <null> (NitroExample.debug.dylib:arm64+0x280638)
    #4 void std::__1::__variant_detail::__impl<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>::__assign[abi:dee210106]<1ul, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>(std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>&&) <null> (NitroExample.debug.dylib:arm64+0x280574)
    #5 std::__1::variant<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>& std::__1::variant<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>::operator=[abi:dee210106]<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, 0, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, 1ul, 0>(std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>&&) <null> (NitroExample.debug.dylib:arm64+0x280240)
    #6 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::resolve(std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>&&) <null> (NitroExample.debug.dylib:arm64+0x280038)
    #7 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()::operator()() const <null> (NitroExample.debug.dylib:arm64+0x27fe30)
    #8 std::__1::__invoke_result_impl<void, margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&>(margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&) <null> (NitroExample.debug.dylib:arm64+0x27fdbc)
    #9 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:dee210106]<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&>(margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&) <null> (NitroExample.debug.dylib:arm64+0x27fd68)
    #10 void std::__1::__invoke_r[abi:dee210106]<void, margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&>(margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&) <null> (NitroExample.debug.dylib:arm64+0x27fd14)
    #11 std::__1::__function::__func<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'(), void ()>::operator()() <null> (NitroExample.debug.dylib:arm64+0x27f518)
    #12 std::__1::__function::__value_func<void ()>::operator()[abi:dee210106]() const <null> (NitroExample.debug.dylib:arm64+0x38e34)
    #13 std::__1::function<void ()>::operator()() const <null> (NitroExample.debug.dylib:arm64+0x33f7c)
    #14 margelo::nitro::ThreadPool::addThread()::$_0::operator()() const <null> (NitroExample.debug.dylib:arm64+0x112564)
    #15 std::__1::__invoke_result_impl<void, margelo::nitro::ThreadPool::addThread()::$_0>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::ThreadPool::addThread()::$_0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x11239c)
    #16 void std::__1::__thread_execute[abi:dee210106]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, margelo::nitro::ThreadPool::addThread()::$_0>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, margelo::nitro::ThreadPool::addThread()::$_0>&, std::__1::__tuple_indices<>) <null> (NitroExample.debug.dylib:arm64+0x112200)
    #17 void* std::__1::__thread_proxy[abi:dee210106]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, margelo::nitro::ThreadPool::addThread()::$_0>>(void*) <null> (NitroExample.debug.dylib:arm64+0x111a5c)

  Previous read of size 4 at 0x00011af56aa0 by thread T9:
    #0 std::__1::__variant_detail::__base<(std::__1::__variant_detail::_Trait)1, std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>::index[abi:dee210106]() const <null> (NitroExample.debug.dylib:arm64+0x27c900)
    #1 std::__1::variant<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>::index[abi:dee210106]() const <null> (NitroExample.debug.dylib:arm64+0x27c8b0)
    #2 bool std::__1::__holds_alternative[abi:dee210106]<0ul, std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>(std::__1::variant<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr> const&) <null> (NitroExample.debug.dylib:arm64+0x27c860)
    #3 bool std::__1::holds_alternative[abi:dee210106]<std::__1::monostate, std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>(std::__1::variant<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr> const&) <null> (NitroExample.debug.dylib:arm64+0x27c818)
    #4 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::isPending() const <null> (NitroExample.debug.dylib:arm64+0x27c420)
    #5 margelo::nitro::JSIConverter<std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>, void>::toJSI(facebook::jsi::Runtime&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> const&) <null> (NitroExample.debug.dylib:arm64+0x2f1c7c)
    #6 facebook::jsi::Value margelo::nitro::HybridFunction::callMethod<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(margelo::nitro::test::HybridTestObjectCppSpec*, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), facebook::jsi::Runtime&, facebook::jsi::Value const*, unsigned long, std::__1::integer_sequence<unsigned long>) <null> (NitroExample.debug.dylib:arm64+0x2f1ba4)
    #7 margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) const <null> (NitroExample.debug.dylib:arm64+0x2f15f4)
    #8 std::__1::__invoke_result_impl<void, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f11e0)
    #9 facebook::jsi::Value std::__1::__invoke_void_return_wrapper<facebook::jsi::Value, false>::__call[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f10fc)
    #10 margelo::nitro::test::HybridTestObjectCppSpec std::__1::__invoke_r[abi:dee210106]<facebook::jsi::Value, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f1058)
    #11 std::__1::__function::__func<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long), facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f0c08)
    #12 facebook::hermes::(anonymous namespace)::HermesRuntimeImpl::HFContext::func(void*, hermes::vm::Runtime&) <null> (hermesvm:arm64+0x439ac)

  Location is heap block of size 136 at 0x00011af56a90 allocated by thread T9:
    #0 operator new(unsigned long) <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x89288)
    #1 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::create() <null> (NitroExample.debug.dylib:arm64+0x27b20c)
    #2 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&) <null> (NitroExample.debug.dylib:arm64+0x1ee868)
    #3 margelo::nitro::test::HybridTestObjectCpp::newTestObjectAsync() <null> (NitroExample.debug.dylib:arm64+0x1ee784)
    #4 facebook::jsi::Value margelo::nitro::HybridFunction::callMethod<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(margelo::nitro::test::HybridTestObjectCppSpec*, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), facebook::jsi::Runtime&, facebook::jsi::Value const*, unsigned long, std::__1::integer_sequence<unsigned long>) <null> (NitroExample.debug.dylib:arm64+0x2f1b90)
    #5 margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) const <null> (NitroExample.debug.dylib:arm64+0x2f15f4)
    #6 std::__1::__invoke_result_impl<void, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f11e0)
    #7 facebook::jsi::Value std::__1::__invoke_void_return_wrapper<facebook::jsi::Value, false>::__call[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f10fc)
    #8 margelo::nitro::test::HybridTestObjectCppSpec std::__1::__invoke_r[abi:dee210106]<facebook::jsi::Value, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f1058)
    #9 std::__1::__function::__func<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long), facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f0c08)
    #10 facebook::hermes::(anonymous namespace)::HermesRuntimeImpl::HFContext::func(void*, hermes::vm::Runtime&) <null> (hermesvm:arm64+0x439ac)

  Mutex M0 (0x00011af56ad8) created at:
    #0 pthread_mutex_lock <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x32480)
    #1 std::__1::mutex::lock() <null> (libc++.1.dylib:arm64+0x21460)
    #2 std::__1::unique_lock<std::__1::mutex>::unique_lock[abi:dee210106](std::__1::mutex&) <null> (NitroExample.debug.dylib:arm64+0x91944)
    #3 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::resolve(std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>&&) <null> (NitroExample.debug.dylib:arm64+0x280018)
    #4 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()::operator()() const <null> (NitroExample.debug.dylib:arm64+0x27fe30)
    #5 std::__1::__invoke_result_impl<void, margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&>(margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&) <null> (NitroExample.debug.dylib:arm64+0x27fdbc)
    #6 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:dee210106]<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&>(margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&) <null> (NitroExample.debug.dylib:arm64+0x27fd68)
    #7 void std::__1::__invoke_r[abi:dee210106]<void, margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&>(margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'()&) <null> (NitroExample.debug.dylib:arm64+0x27fd14)
    #8 std::__1::__function::__func<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&)::'lambda'(), void ()>::operator()() <null> (NitroExample.debug.dylib:arm64+0x27f518)
    #9 std::__1::__function::__value_func<void ()>::operator()[abi:dee210106]() const <null> (NitroExample.debug.dylib:arm64+0x38e34)
    #10 std::__1::function<void ()>::operator()() const <null> (NitroExample.debug.dylib:arm64+0x33f7c)
    #11 margelo::nitro::ThreadPool::addThread()::$_0::operator()() const <null> (NitroExample.debug.dylib:arm64+0x112564)
    #12 std::__1::__invoke_result_impl<void, margelo::nitro::ThreadPool::addThread()::$_0>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::ThreadPool::addThread()::$_0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x11239c)
    #13 void std::__1::__thread_execute[abi:dee210106]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, margelo::nitro::ThreadPool::addThread()::$_0>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, margelo::nitro::ThreadPool::addThread()::$_0>&, std::__1::__tuple_indices<>) <null> (NitroExample.debug.dylib:arm64+0x112200)
    #14 void* std::__1::__thread_proxy[abi:dee210106]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, margelo::nitro::ThreadPool::addThread()::$_0>>(void*) <null> (NitroExample.debug.dylib:arm64+0x111a5c)

  Thread T27 (tid=23518533, running) created by thread T9 at:
    #0 pthread_create <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x306c8)
    #1 std::__1::__libcpp_thread_create[abi:dee210106](_opaque_pthread_t**, void* (*)(void*), void*) <null> (NitroExample.debug.dylib:arm64+0x1119c4)
    #2 std::__1::thread::thread[abi:dee210106]<margelo::nitro::ThreadPool::addThread()::$_0, 0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x111770)
    #3 std::__1::thread::thread[abi:dee210106]<margelo::nitro::ThreadPool::addThread()::$_0, 0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x111698)
    #4 std::__1::thread* std::__1::construct_at[abi:dee210106]<std::__1::thread, margelo::nitro::ThreadPool::addThread()::$_0, std::__1::thread*>(std::__1::thread*, margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x11162c)
    #5 std::__1::thread* std::__1::__construct_at[abi:dee210106]<std::__1::thread, margelo::nitro::ThreadPool::addThread()::$_0, std::__1::thread*>(std::__1::thread*, margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x1115a8)
    #6 void std::__1::allocator_traits<std::__1::allocator<std::__1::thread>>::construct[abi:dee210106]<std::__1::thread, margelo::nitro::ThreadPool::addThread()::$_0, 0>(std::__1::allocator<std::__1::thread>&, std::__1::thread*, margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x11134c)
    #7 std::__1::thread* std::__1::vector<std::__1::thread, std::__1::allocator<std::__1::thread>>::__emplace_back_slow_path<margelo::nitro::ThreadPool::addThread()::$_0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x1111e0)
    #8 std::__1::thread& std::__1::vector<std::__1::thread, std::__1::allocator<std::__1::thread>>::emplace_back<margelo::nitro::ThreadPool::addThread()::$_0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x10ec8c)
    #9 margelo::nitro::ThreadPool::addThread() <null> (NitroExample.debug.dylib:arm64+0x10e878)
    #10 margelo::nitro::ThreadPool::ThreadPool(char const*, unsigned long, unsigned long) <null> (NitroExample.debug.dylib:arm64+0x10e484)
    #11 margelo::nitro::ThreadPool::ThreadPool(char const*, unsigned long, unsigned long) <null> (NitroExample.debug.dylib:arm64+0x10ea84)
    #12 margelo::nitro::ThreadPool::shared() <null> (NitroExample.debug.dylib:arm64+0x10f38c)
    #13 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&) <null> (NitroExample.debug.dylib:arm64+0x1ee870)
    #14 margelo::nitro::test::HybridTestObjectCpp::newTestObjectAsync() <null> (NitroExample.debug.dylib:arm64+0x1ee784)
    #15 facebook::jsi::Value margelo::nitro::HybridFunction::callMethod<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(margelo::nitro::test::HybridTestObjectCppSpec*, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), facebook::jsi::Runtime&, facebook::jsi::Value const*, unsigned long, std::__1::integer_sequence<unsigned long>) <null> (NitroExample.debug.dylib:arm64+0x2f1b90)
    #16 margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) const <null> (NitroExample.debug.dylib:arm64+0x2f15f4)
    #17 std::__1::__invoke_result_impl<void, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f11e0)
    #18 facebook::jsi::Value std::__1::__invoke_void_return_wrapper<facebook::jsi::Value, false>::__call[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f10fc)
    #19 margelo::nitro::test::HybridTestObjectCppSpec std::__1::__invoke_r[abi:dee210106]<facebook::jsi::Value, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f1058)
    #20 std::__1::__function::__func<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long), facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f0c08)
    #21 facebook::hermes::(anonymous namespace)::HermesRuntimeImpl::HFContext::func(void*, hermes::vm::Runtime&) <null> (hermesvm:arm64+0x439ac)

  Thread T9 (tid=23517955, running) created by main thread at:
    #0 pthread_create <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x306c8)
    #1 -[NSThread startAndReturnError:] <null> (Foundation:arm64+0x8efb94)
    #2 @objc NitroExample.AppDelegate.application(_: __C.UIApplication, didFinishLaunchingWithOptions: Swift.Optional<Swift.Dictionary<__C.UIApplicationLaunchOptionsKey, Any>>) -> Swift.Bool <null> (NitroExample.debug.dylib:arm64+0x5364)
    #3 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] <null> (UIKitCore:arm64+0x12179ec)
    #4 static NitroExample.AppDelegate.$main() -> () <null> (NitroExample.debug.dylib:arm64+0x56b0)
    #5 __debug_main_executable_dylib_entry_point <null> (NitroExample.debug.dylib:arm64+0x6528)
    #6 <null> <null> (dyld:arm64+0xb0b0)

SUMMARY: ThreadSanitizer: data race (/Users/boga/Library/Developer/CoreSimulator/Devices/9753895D-1F8D-4444-B637-7C29FC829B71/data/Containers/Bundle/Application/E278AE99-A52F-49BE-8449-9C38EB97A11F/NitroExample.app/NitroExample.debug.dylib:arm64+0x27d140) in std::__1::__variant_detail::__dtor<std::__1::__variant_detail::__traits<std::__1::monostate, std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>, std::exception_ptr>, (std::__1::__variant_detail::_Trait)1>::__destroy[abi:dee210106]()+0x58
==================
ThreadSanitizer report breakpoint hit. Use 'thread info -s' to get extended information about the report.

==================
WARNING: ThreadSanitizer: data race (pid=82343)
  Read of size 8 at 0x0001080c3400 by thread T9:
    #0 std::__1::deque<std::__1::function<void ()>, std::__1::allocator<std::__1::function<void ()>>>::size[abi:dee210106]() const <null> (NitroExample.debug.dylib:arm64+0x11020c)
    #1 std::__1::deque<std::__1::function<void ()>, std::__1::allocator<std::__1::function<void ()>>>::empty[abi:dee210106]() const <null> (NitroExample.debug.dylib:arm64+0x112a58)
    #2 std::__1::queue<std::__1::function<void ()>, std::__1::deque<std::__1::function<void ()>, std::__1::allocator<std::__1::function<void ()>>>>::empty[abi:dee210106]() const <null> (NitroExample.debug.dylib:arm64+0x10ef00)
    #3 margelo::nitro::ThreadPool::run(std::__1::function<void ()>&&) <null> (NitroExample.debug.dylib:arm64+0x10ed7c)
    #4 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&) <null> (NitroExample.debug.dylib:arm64+0x1ee8b4)
    #5 margelo::nitro::test::HybridTestObjectCpp::newTestObjectAsync() <null> (NitroExample.debug.dylib:arm64+0x1ee784)
    #6 facebook::jsi::Value margelo::nitro::HybridFunction::callMethod<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(margelo::nitro::test::HybridTestObjectCppSpec*, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), facebook::jsi::Runtime&, facebook::jsi::Value const*, unsigned long, std::__1::integer_sequence<unsigned long>) <null> (NitroExample.debug.dylib:arm64+0x2f1b90)
    #7 margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) const <null> (NitroExample.debug.dylib:arm64+0x2f15f4)
    #8 std::__1::__invoke_result_impl<void, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f11e0)
    #9 facebook::jsi::Value std::__1::__invoke_void_return_wrapper<facebook::jsi::Value, false>::__call[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f10fc)
    #10 margelo::nitro::test::HybridTestObjectCppSpec std::__1::__invoke_r[abi:dee210106]<facebook::jsi::Value, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f1058)
    #11 std::__1::__function::__func<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long), facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f0c08)
    #12 facebook::hermes::(anonymous namespace)::HermesRuntimeImpl::HFContext::func(void*, hermes::vm::Runtime&) <null> (hermesvm:arm64+0x439ac)

  Previous write of size 8 at 0x0001080c3400 by thread T26 (mutexes: write M0):
    #0 std::__1::deque<std::__1::function<void ()>, std::__1::allocator<std::__1::function<void ()>>>::pop_front() <null> (NitroExample.debug.dylib:arm64+0x112e08)
    #1 std::__1::queue<std::__1::function<void ()>, std::__1::deque<std::__1::function<void ()>, std::__1::allocator<std::__1::function<void ()>>>>::pop[abi:dee210106]() <null> (NitroExample.debug.dylib:arm64+0x1127bc)
    #2 margelo::nitro::ThreadPool::addThread()::$_0::operator()() const <null> (NitroExample.debug.dylib:arm64+0x11253c)
    #3 std::__1::__invoke_result_impl<void, margelo::nitro::ThreadPool::addThread()::$_0>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::ThreadPool::addThread()::$_0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x11239c)
    #4 void std::__1::__thread_execute[abi:dee210106]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, margelo::nitro::ThreadPool::addThread()::$_0>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, margelo::nitro::ThreadPool::addThread()::$_0>&, std::__1::__tuple_indices<>) <null> (NitroExample.debug.dylib:arm64+0x112200)
    #5 void* std::__1::__thread_proxy[abi:dee210106]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, margelo::nitro::ThreadPool::addThread()::$_0>>(void*) <null> (NitroExample.debug.dylib:arm64+0x111a5c)

  Location is global 'margelo::nitro::ThreadPool::shared()::shared' at 0x0001080c33c0 (NitroExample.debug.dylib+0xd97400)

  Mutex M0 (0x0001080c3408) created at:
    #0 pthread_mutex_lock <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x32480)
    #1 std::__1::mutex::lock() <null> (libc++.1.dylib:arm64+0x21460)
    #2 std::__1::unique_lock<std::__1::mutex>::unique_lock[abi:dee210106](std::__1::mutex&) <null> (NitroExample.debug.dylib:arm64+0x91944)
    #3 margelo::nitro::ThreadPool::addThread() <null> (NitroExample.debug.dylib:arm64+0x10e760)
    #4 margelo::nitro::ThreadPool::ThreadPool(char const*, unsigned long, unsigned long) <null> (NitroExample.debug.dylib:arm64+0x10e484)
    #5 margelo::nitro::ThreadPool::ThreadPool(char const*, unsigned long, unsigned long) <null> (NitroExample.debug.dylib:arm64+0x10ea84)
    #6 margelo::nitro::ThreadPool::shared() <null> (NitroExample.debug.dylib:arm64+0x10f38c)
    #7 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&) <null> (NitroExample.debug.dylib:arm64+0x1ee870)
    #8 margelo::nitro::test::HybridTestObjectCpp::newTestObjectAsync() <null> (NitroExample.debug.dylib:arm64+0x1ee784)
    #9 facebook::jsi::Value margelo::nitro::HybridFunction::callMethod<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(margelo::nitro::test::HybridTestObjectCppSpec*, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), facebook::jsi::Runtime&, facebook::jsi::Value const*, unsigned long, std::__1::integer_sequence<unsigned long>) <null> (NitroExample.debug.dylib:arm64+0x2f1b90)
    #10 margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) const <null> (NitroExample.debug.dylib:arm64+0x2f15f4)
    #11 std::__1::__invoke_result_impl<void, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f11e0)
    #12 facebook::jsi::Value std::__1::__invoke_void_return_wrapper<facebook::jsi::Value, false>::__call[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f10fc)
    #13 margelo::nitro::test::HybridTestObjectCppSpec std::__1::__invoke_r[abi:dee210106]<facebook::jsi::Value, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f1058)
    #14 std::__1::__function::__func<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long), facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f0c08)
    #15 facebook::hermes::(anonymous namespace)::HermesRuntimeImpl::HFContext::func(void*, hermes::vm::Runtime&) <null> (hermesvm:arm64+0x439ac)

  Thread T9 (tid=23517955, running) created by main thread at:
    #0 pthread_create <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x306c8)
    #1 -[NSThread startAndReturnError:] <null> (Foundation:arm64+0x8efb94)
    #2 @objc NitroExample.AppDelegate.application(_: __C.UIApplication, didFinishLaunchingWithOptions: Swift.Optional<Swift.Dictionary<__C.UIApplicationLaunchOptionsKey, Any>>) -> Swift.Bool <null> (NitroExample.debug.dylib:arm64+0x5364)
    #3 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] <null> (UIKitCore:arm64+0x12179ec)
    #4 static NitroExample.AppDelegate.$main() -> () <null> (NitroExample.debug.dylib:arm64+0x56b0)
    #5 __debug_main_executable_dylib_entry_point <null> (NitroExample.debug.dylib:arm64+0x6528)
    #6 <null> <null> (dyld:arm64+0xb0b0)

  Thread T26 (tid=23518532, running) created by thread T9 at:
    #0 pthread_create <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x306c8)
    #1 std::__1::__libcpp_thread_create[abi:dee210106](_opaque_pthread_t**, void* (*)(void*), void*) <null> (NitroExample.debug.dylib:arm64+0x1119c4)
    #2 std::__1::thread::thread[abi:dee210106]<margelo::nitro::ThreadPool::addThread()::$_0, 0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x111770)
    #3 std::__1::thread::thread[abi:dee210106]<margelo::nitro::ThreadPool::addThread()::$_0, 0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x111698)
    #4 std::__1::thread* std::__1::construct_at[abi:dee210106]<std::__1::thread, margelo::nitro::ThreadPool::addThread()::$_0, std::__1::thread*>(std::__1::thread*, margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x11162c)
    #5 std::__1::thread* std::__1::__construct_at[abi:dee210106]<std::__1::thread, margelo::nitro::ThreadPool::addThread()::$_0, std::__1::thread*>(std::__1::thread*, margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x1115a8)
    #6 void std::__1::allocator_traits<std::__1::allocator<std::__1::thread>>::construct[abi:dee210106]<std::__1::thread, margelo::nitro::ThreadPool::addThread()::$_0, 0>(std::__1::allocator<std::__1::thread>&, std::__1::thread*, margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x11134c)
    #7 std::__1::thread* std::__1::vector<std::__1::thread, std::__1::allocator<std::__1::thread>>::__emplace_back_slow_path<margelo::nitro::ThreadPool::addThread()::$_0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x1111e0)
    #8 std::__1::thread& std::__1::vector<std::__1::thread, std::__1::allocator<std::__1::thread>>::emplace_back<margelo::nitro::ThreadPool::addThread()::$_0>(margelo::nitro::ThreadPool::addThread()::$_0&&) <null> (NitroExample.debug.dylib:arm64+0x10ec8c)
    #9 margelo::nitro::ThreadPool::addThread() <null> (NitroExample.debug.dylib:arm64+0x10e878)
    #10 margelo::nitro::ThreadPool::ThreadPool(char const*, unsigned long, unsigned long) <null> (NitroExample.debug.dylib:arm64+0x10e484)
    #11 margelo::nitro::ThreadPool::ThreadPool(char const*, unsigned long, unsigned long) <null> (NitroExample.debug.dylib:arm64+0x10ea84)
    #12 margelo::nitro::ThreadPool::shared() <null> (NitroExample.debug.dylib:arm64+0x10f38c)
    #13 margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>::async(std::__1::function<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec> ()>&&) <null> (NitroExample.debug.dylib:arm64+0x1ee870)
    #14 margelo::nitro::test::HybridTestObjectCpp::newTestObjectAsync() <null> (NitroExample.debug.dylib:arm64+0x1ee784)
    #15 facebook::jsi::Value margelo::nitro::HybridFunction::callMethod<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(margelo::nitro::test::HybridTestObjectCppSpec*, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), facebook::jsi::Runtime&, facebook::jsi::Value const*, unsigned long, std::__1::integer_sequence<unsigned long>) <null> (NitroExample.debug.dylib:arm64+0x2f1b90)
    #16 margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) const <null> (NitroExample.debug.dylib:arm64+0x2f15f4)
    #17 std::__1::__invoke_result_impl<void, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>::type std::__1::__invoke[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f11e0)
    #18 facebook::jsi::Value std::__1::__invoke_void_return_wrapper<facebook::jsi::Value, false>::__call[abi:dee210106]<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f10fc)
    #19 margelo::nitro::test::HybridTestObjectCppSpec std::__1::__invoke_r[abi:dee210106]<facebook::jsi::Value, margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long>(margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f1058)
    #20 std::__1::__function::__func<margelo::nitro::HybridFunction margelo::nitro::HybridFunction::createHybridFunction<margelo::nitro::test::HybridTestObjectCppSpec, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<margelo::nitro::Promise<std::__1::shared_ptr<margelo::nitro::test::HybridTestObjectCppSpec>>> (margelo::nitro::test::HybridTestObjectCppSpec::*)(), margelo::nitro::FunctionKind)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long), facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned long&&) <null> (NitroExample.debug.dylib:arm64+0x2f0c08)
    #21 facebook::hermes::(anonymous namespace)::HermesRuntimeImpl::HFContext::func(void*, hermes::vm::Runtime&) <null> (hermesvm:arm64+0x439ac)

SUMMARY: ThreadSanitizer: data race (/Users/boga/Library/Developer/CoreSimulator/Devices/9753895D-1F8D-4444-B637-7C29FC829B71/data/Containers/Bundle/Application/E278AE99-A52F-49BE-8449-9C38EB97A11F/NitroExample.app/NitroExample.debug.dylib:arm64+0x11020c) in std::__1::deque<std::__1::function<void ()>, std::__1::allocator<std::__1::function<void ()>>>::size[abi:dee210106]() const+0x34
==================
ThreadSanitizer report breakpoint hit. Use 'thread info -s' to get extended information about the report.

✅ Test "newTestObjectAsync() under parallel load does not data-race (run under Thread Sanitizer)" passed!
Showing Tests for HybridObject "TestObjectCpp"
```