### PR TITLE
fix(core): synchronize C++ Promise<T> state-inspection accessors

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/Promise.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.cpp
@@ -56,11 +56,12 @@ void Promise<void>::resolve() {
   assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
 #endif
   std::vector<OnResolvedFunc> listeners;
+  std::vector<OnRejectedFunc> dropped;
   {
     std::unique_lock lock(_mutex);
     _isResolved = true;
     listeners = std::move(_onResolvedListeners);
-    clearAllListeners(lock);
+    dropped = std::move(_onRejectedListeners);
   }
   for (const auto& onResolved : listeners) {
     onResolved();
@@ -76,11 +77,12 @@ void Promise<void>::reject(const std::exception_ptr& exception) {
   assertPromiseState(*this, PromiseTask::WANTS_TO_REJECT);
 #endif
   std::vector<OnRejectedFunc> listeners;
+  std::vector<OnResolvedFunc> dropped;
   {
     std::unique_lock lock(_mutex);
     _error = exception;
     listeners = std::move(_onRejectedListeners);
-    clearAllListeners(lock);
+    dropped = std::move(_onResolvedListeners);
   }
   for (const auto& onRejected : listeners) {
     onRejected(exception);
@@ -147,11 +149,6 @@ const std::exception_ptr& Promise<void>::getError() const {
     throw std::runtime_error("Cannot get error when Promise<void> is not yet rejected!");
   }
   return _error;
-}
-
-void Promise<void>::clearAllListeners(const std::unique_lock<std::mutex>&) noexcept {
-  _onResolvedListeners.clear();
-  _onRejectedListeners.clear();
 }
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/core/Promise.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.cpp
@@ -121,7 +121,6 @@ void Promise<void>::addOnRejectedListener(OnRejectedFunc&& onRejected) {
 void Promise<void>::addOnRejectedListener(const OnRejectedFunc& onRejected) {
   std::unique_lock lock(_mutex);
   if (isRejected(lock)) {
-    // Promise is already rejected! Call the callback immediately.
     std::exception_ptr error = _error;
     lock.unlock();
     onRejected(error);

--- a/packages/react-native-nitro-modules/cpp/core/Promise.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.cpp
@@ -92,29 +92,24 @@ void Promise<void>::reject(const std::exception_ptr& exception) {
 void Promise<void>::addOnResolvedListener(OnResolvedFunc&& onResolved) {
   std::unique_lock lock(_mutex);
   if (isResolved(lock)) {
-    // Promise is already resolved! Call the callback immediately.
     lock.unlock();
     onResolved();
   } else {
-    // Promise is not yet resolved, put the listener in our queue.
     _onResolvedListeners.push_back(std::move(onResolved));
   }
 }
 void Promise<void>::addOnResolvedListener(const OnResolvedFunc& onResolved) {
   std::unique_lock lock(_mutex);
   if (isResolved(lock)) {
-    // Promise is already resolved! Call the callback immediately.
     lock.unlock();
     onResolved();
   } else {
-    // Promise is not yet resolved, put the listener in our queue.
     _onResolvedListeners.push_back(onResolved);
   }
 }
 void Promise<void>::addOnRejectedListener(OnRejectedFunc&& onRejected) {
   std::unique_lock lock(_mutex);
   if (isRejected(lock)) {
-    // Promise is already rejected! Call the callback immediately.
     std::exception_ptr error = _error;
     lock.unlock();
     onRejected(error);

--- a/packages/react-native-nitro-modules/cpp/core/Promise.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.cpp
@@ -59,7 +59,8 @@ void Promise<void>::resolve() {
   {
     std::unique_lock lock(_mutex);
     _isResolved = true;
-    listeners = takeResolvedListenersAndClearAllListeners(lock);
+    listeners = std::move(_onResolvedListeners);
+    clearAllListeners(lock);
   }
   for (const auto& onResolved : listeners) {
     onResolved();
@@ -78,7 +79,8 @@ void Promise<void>::reject(const std::exception_ptr& exception) {
   {
     std::unique_lock lock(_mutex);
     _error = exception;
-    listeners = takeRejectedListenersAndClearAllListeners(lock);
+    listeners = std::move(_onRejectedListeners);
+    clearAllListeners(lock);
   }
   for (const auto& onRejected : listeners) {
     onRejected(exception);
@@ -86,48 +88,50 @@ void Promise<void>::reject(const std::exception_ptr& exception) {
 }
 
 void Promise<void>::addOnResolvedListener(OnResolvedFunc&& onResolved) {
-  {
-    std::unique_lock lock(_mutex);
-    if (!isResolved(lock)) {
-      _onResolvedListeners.push_back(std::move(onResolved));
-      return;
-    }
+  std::unique_lock lock(_mutex);
+  if (isResolved(lock)) {
+    // Promise is already resolved! Call the callback immediately.
+    lock.unlock();
+    onResolved();
+  } else {
+    // Promise is not yet resolved, put the listener in our queue.
+    _onResolvedListeners.push_back(std::move(onResolved));
   }
-  onResolved();
 }
 void Promise<void>::addOnResolvedListener(const OnResolvedFunc& onResolved) {
-  {
-    std::unique_lock lock(_mutex);
-    if (!isResolved(lock)) {
-      _onResolvedListeners.push_back(onResolved);
-      return;
-    }
+  std::unique_lock lock(_mutex);
+  if (isResolved(lock)) {
+    // Promise is already resolved! Call the callback immediately.
+    lock.unlock();
+    onResolved();
+  } else {
+    // Promise is not yet resolved, put the listener in our queue.
+    _onResolvedListeners.push_back(onResolved);
   }
-  onResolved();
 }
 void Promise<void>::addOnRejectedListener(OnRejectedFunc&& onRejected) {
-  std::exception_ptr error;
-  {
-    std::unique_lock lock(_mutex);
-    if (!isRejected(lock)) {
-      _onRejectedListeners.push_back(std::move(onRejected));
-      return;
-    }
-    error = _error;
+  std::unique_lock lock(_mutex);
+  if (isRejected(lock)) {
+    // Promise is already rejected! Call the callback immediately.
+    std::exception_ptr error = _error;
+    lock.unlock();
+    onRejected(error);
+  } else {
+    // Promise is not yet rejected, put the listener in our queue.
+    _onRejectedListeners.push_back(std::move(onRejected));
   }
-  onRejected(error);
 }
 void Promise<void>::addOnRejectedListener(const OnRejectedFunc& onRejected) {
-  std::exception_ptr error;
-  {
-    std::unique_lock lock(_mutex);
-    if (!isRejected(lock)) {
-      _onRejectedListeners.push_back(onRejected);
-      return;
-    }
-    error = _error;
+  std::unique_lock lock(_mutex);
+  if (isRejected(lock)) {
+    // Promise is already rejected! Call the callback immediately.
+    std::exception_ptr error = _error;
+    lock.unlock();
+    onRejected(error);
+  } else {
+    // Promise is not yet rejected, put the listener in our queue.
+    _onRejectedListeners.push_back(onRejected);
   }
-  onRejected(error);
 }
 
 std::future<void> Promise<void>::await() {
@@ -143,18 +147,6 @@ const std::exception_ptr& Promise<void>::getError() const {
     throw std::runtime_error("Cannot get error when Promise<void> is not yet rejected!");
   }
   return _error;
-}
-
-std::vector<Promise<void>::OnResolvedFunc> Promise<void>::takeResolvedListenersAndClearAllListeners(const std::unique_lock<std::mutex>& lock) {
-  auto listeners = std::move(_onResolvedListeners);
-  clearAllListeners(lock);
-  return listeners;
-}
-
-std::vector<Promise<void>::OnRejectedFunc> Promise<void>::takeRejectedListenersAndClearAllListeners(const std::unique_lock<std::mutex>& lock) {
-  auto listeners = std::move(_onRejectedListeners);
-  clearAllListeners(lock);
-  return listeners;
 }
 
 void Promise<void>::clearAllListeners(const std::unique_lock<std::mutex>&) noexcept {

--- a/packages/react-native-nitro-modules/cpp/core/Promise.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.cpp
@@ -52,15 +52,18 @@ std::shared_ptr<Promise<void>> Promise<void>::rejected(const std::exception_ptr&
 }
 
 void Promise<void>::resolve() {
-  std::unique_lock lock(_mutex);
 #ifdef NITRO_DEBUG
   assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
 #endif
-  _isResolved = true;
-  for (const auto& onResolved : _onResolvedListeners) {
+  std::vector<OnResolvedFunc> listeners;
+  {
+    std::unique_lock lock(_mutex);
+    _isResolved = true;
+    listeners = takeResolvedListenersAndClearAllListeners(lock);
+  }
+  for (const auto& onResolved : listeners) {
     onResolved();
   }
-  didFinish();
 }
 
 void Promise<void>::reject(const std::exception_ptr& exception) {
@@ -68,50 +71,63 @@ void Promise<void>::reject(const std::exception_ptr& exception) {
     throw std::runtime_error("Cannot reject Promise<void> with a null exception_ptr!");
   }
 
-  std::unique_lock lock(_mutex);
 #ifdef NITRO_DEBUG
   assertPromiseState(*this, PromiseTask::WANTS_TO_REJECT);
 #endif
-  _error = exception;
-  for (const auto& onRejected : _onRejectedListeners) {
+  std::vector<OnRejectedFunc> listeners;
+  {
+    std::unique_lock lock(_mutex);
+    _error = exception;
+    listeners = takeRejectedListenersAndClearAllListeners(lock);
+  }
+  for (const auto& onRejected : listeners) {
     onRejected(exception);
   }
-  didFinish();
 }
 
 void Promise<void>::addOnResolvedListener(OnResolvedFunc&& onResolved) {
-  std::unique_lock lock(_mutex);
-  if (_isResolved) {
-    onResolved();
-  } else {
-    _onResolvedListeners.push_back(std::move(onResolved));
+  {
+    std::unique_lock lock(_mutex);
+    if (!isResolved(lock)) {
+      _onResolvedListeners.push_back(std::move(onResolved));
+      return;
+    }
   }
+  onResolved();
 }
 void Promise<void>::addOnResolvedListener(const OnResolvedFunc& onResolved) {
-  std::unique_lock lock(_mutex);
-  if (_isResolved) {
-    onResolved();
-  } else {
-    _onResolvedListeners.push_back(onResolved);
+  {
+    std::unique_lock lock(_mutex);
+    if (!isResolved(lock)) {
+      _onResolvedListeners.push_back(onResolved);
+      return;
+    }
   }
+  onResolved();
 }
 void Promise<void>::addOnRejectedListener(OnRejectedFunc&& onRejected) {
-  std::unique_lock lock(_mutex);
-  if (_error) {
-    onRejected(_error);
-  } else {
-    // Promise is not yet rejected, put the listener in our queue.
-    _onRejectedListeners.push_back(std::move(onRejected));
+  std::exception_ptr error;
+  {
+    std::unique_lock lock(_mutex);
+    if (!isRejected(lock)) {
+      _onRejectedListeners.push_back(std::move(onRejected));
+      return;
+    }
+    error = _error;
   }
+  onRejected(error);
 }
 void Promise<void>::addOnRejectedListener(const OnRejectedFunc& onRejected) {
-  std::unique_lock lock(_mutex);
-  if (_error) {
-    onRejected(_error);
-  } else {
-    // Promise is not yet rejected, put the listener in our queue.
-    _onRejectedListeners.push_back(onRejected);
+  std::exception_ptr error;
+  {
+    std::unique_lock lock(_mutex);
+    if (!isRejected(lock)) {
+      _onRejectedListeners.push_back(onRejected);
+      return;
+    }
+    error = _error;
   }
+  onRejected(error);
 }
 
 std::future<void> Promise<void>::await() {
@@ -122,13 +138,26 @@ std::future<void> Promise<void>::await() {
 }
 
 const std::exception_ptr& Promise<void>::getError() const {
-  if (!isRejected()) {
+  std::unique_lock lock(_mutex);
+  if (!isRejected(lock)) {
     throw std::runtime_error("Cannot get error when Promise<void> is not yet rejected!");
   }
   return _error;
 }
 
-void Promise<void>::didFinish() noexcept {
+std::vector<Promise<void>::OnResolvedFunc> Promise<void>::takeResolvedListenersAndClearAllListeners(const std::unique_lock<std::mutex>& lock) {
+  auto listeners = std::move(_onResolvedListeners);
+  clearAllListeners(lock);
+  return listeners;
+}
+
+std::vector<Promise<void>::OnRejectedFunc> Promise<void>::takeRejectedListenersAndClearAllListeners(const std::unique_lock<std::mutex>& lock) {
+  auto listeners = std::move(_onRejectedListeners);
+  clearAllListeners(lock);
+  return listeners;
+}
+
+void Promise<void>::clearAllListeners(const std::unique_lock<std::mutex>&) noexcept {
   _onResolvedListeners.clear();
   _onRejectedListeners.clear();
 }

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -102,17 +102,16 @@ public:
     assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
 #endif
     std::vector<OnResolvedFunc> listeners;
+    const TResult* resolvedValue;
     {
       std::unique_lock lock(_mutex);
       _state = std::move(result);
-      listeners = takeResolvedListenersAndClearAllListeners(lock);
+      resolvedValue = &std::get<TResult>(_state);
+      listeners = std::move(_onResolvedListeners);
+      clearAllListeners(lock);
     }
-    if (listeners.empty()) {
-      return;
-    }
-    const TResult& resolvedValue = getResult();
     for (const auto& onResolved : listeners) {
-      onResolved(resolvedValue);
+      onResolved(*resolvedValue);
     }
   }
   void resolve(const TResult& result) {
@@ -120,17 +119,16 @@ public:
     assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
 #endif
     std::vector<OnResolvedFunc> listeners;
+    const TResult* resolvedValue;
     {
       std::unique_lock lock(_mutex);
       _state = result;
-      listeners = takeResolvedListenersAndClearAllListeners(lock);
+      resolvedValue = &std::get<TResult>(_state);
+      listeners = std::move(_onResolvedListeners);
+      clearAllListeners(lock);
     }
-    if (listeners.empty()) {
-      return;
-    }
-    const TResult& resolvedValue = getResult();
     for (const auto& onResolved : listeners) {
-      onResolved(resolvedValue);
+      onResolved(*resolvedValue);
     }
   }
   /**
@@ -149,7 +147,8 @@ public:
     {
       std::unique_lock lock(_mutex);
       _state = exception;
-      listeners = takeRejectedListenersAndClearAllListeners(lock);
+      listeners = std::move(_onRejectedListeners);
+      clearAllListeners(lock);
     }
     for (const auto& onRejected : listeners) {
       onRejected(exception);
@@ -162,24 +161,28 @@ public:
    * If the Promise is already resolved, the listener will be immediately called.
    */
   void addOnResolvedListener(OnResolvedFunc&& onResolved) {
-    {
-      std::unique_lock lock(_mutex);
-      if (!isResolved(lock)) {
-        _onResolvedListeners.push_back(std::move(onResolved));
-        return;
-      }
+    std::unique_lock lock(_mutex);
+    if (std::holds_alternative<TResult>(_state)) {
+      // Promise is already resolved! Call the callback immediately.
+      const TResult& result = std::get<TResult>(_state);
+      lock.unlock();
+      onResolved(result);
+    } else {
+      // Promise is not yet resolved, put the listener in our queue.
+      _onResolvedListeners.push_back(std::move(onResolved));
     }
-    onResolved(getResult());
   }
   void addOnResolvedListener(const OnResolvedFunc& onResolved) {
-    {
-      std::unique_lock lock(_mutex);
-      if (!isResolved(lock)) {
-        _onResolvedListeners.push_back(onResolved);
-        return;
-      }
+    std::unique_lock lock(_mutex);
+    if (std::holds_alternative<TResult>(_state)) {
+      // Promise is already resolved! Call the callback immediately.
+      const TResult& result = std::get<TResult>(_state);
+      lock.unlock();
+      onResolved(result);
+    } else {
+      // Promise is not yet resolved, put the listener in our queue.
+      _onResolvedListeners.push_back(onResolved);
     }
-    onResolved(getResult());
   }
 
   /**
@@ -187,28 +190,28 @@ public:
    * If the Promise is already rejected, the listener will be immediately called.
    */
   void addOnRejectedListener(OnRejectedFunc&& onRejected) {
-    std::exception_ptr error;
-    {
-      std::unique_lock lock(_mutex);
-      if (!isRejected(lock)) {
-        _onRejectedListeners.push_back(std::move(onRejected));
-        return;
-      }
-      error = std::get<std::exception_ptr>(_state);
+    std::unique_lock lock(_mutex);
+    if (std::holds_alternative<std::exception_ptr>(_state)) {
+      // Promise is already rejected! Call the callback immediately.
+      std::exception_ptr error = std::get<std::exception_ptr>(_state);
+      lock.unlock();
+      onRejected(error);
+    } else {
+      // Promise is not yet rejected, put the listener in our queue.
+      _onRejectedListeners.push_back(std::move(onRejected));
     }
-    onRejected(error);
   }
   void addOnRejectedListener(const OnRejectedFunc& onRejected) {
-    std::exception_ptr error;
-    {
-      std::unique_lock lock(_mutex);
-      if (!isRejected(lock)) {
-        _onRejectedListeners.push_back(onRejected);
-        return;
-      }
-      error = std::get<std::exception_ptr>(_state);
+    std::unique_lock lock(_mutex);
+    if (std::holds_alternative<std::exception_ptr>(_state)) {
+      // Promise is already rejected! Call the callback immediately.
+      std::exception_ptr error = std::get<std::exception_ptr>(_state);
+      lock.unlock();
+      onRejected(error);
+    } else {
+      // Promise is not yet rejected, put the listener in our queue.
+      _onRejectedListeners.push_back(onRejected);
     }
-    onRejected(error);
   }
 
 public:
@@ -287,16 +290,6 @@ private:
   inline bool isPending(const std::unique_lock<std::mutex>&) const noexcept {
     return std::holds_alternative<std::monostate>(_state);
   }
-  std::vector<OnResolvedFunc> takeResolvedListenersAndClearAllListeners(const std::unique_lock<std::mutex>& lock) {
-    auto listeners = std::move(_onResolvedListeners);
-    clearAllListeners(lock);
-    return listeners;
-  }
-  std::vector<OnRejectedFunc> takeRejectedListenersAndClearAllListeners(const std::unique_lock<std::mutex>& lock) {
-    auto listeners = std::move(_onRejectedListeners);
-    clearAllListeners(lock);
-    return listeners;
-  }
   void clearAllListeners(const std::unique_lock<std::mutex>&) noexcept {
     _onResolvedListeners.clear();
     _onRejectedListeners.clear();
@@ -371,8 +364,6 @@ private:
   inline bool isPending(const std::unique_lock<std::mutex>&) const noexcept {
     return !_isResolved && _error == nullptr;
   }
-  std::vector<OnResolvedFunc> takeResolvedListenersAndClearAllListeners(const std::unique_lock<std::mutex>&);
-  std::vector<OnRejectedFunc> takeRejectedListenersAndClearAllListeners(const std::unique_lock<std::mutex>&);
   void clearAllListeners(const std::unique_lock<std::mutex>&) noexcept;
 
 private:

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -98,26 +98,40 @@ public:
    * Resolves this Promise with the given result, and calls any pending listeners.
    */
   void resolve(TResult&& result) {
-    std::unique_lock lock(_mutex);
 #ifdef NITRO_DEBUG
     assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
 #endif
-    _state = std::move(result);
-    for (const auto& onResolved : _onResolvedListeners) {
-      onResolved(std::get<TResult>(_state));
+    std::vector<OnResolvedFunc> listeners;
+    {
+      std::unique_lock lock(_mutex);
+      _state = std::move(result);
+      listeners = takeResolvedListenersAndClearAllListeners(lock);
     }
-    didFinish();
+    if (listeners.empty()) {
+      return;
+    }
+    const TResult& resolvedValue = getResult();
+    for (const auto& onResolved : listeners) {
+      onResolved(resolvedValue);
+    }
   }
   void resolve(const TResult& result) {
-    std::unique_lock lock(_mutex);
 #ifdef NITRO_DEBUG
     assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
 #endif
-    _state = result;
-    for (const auto& onResolved : _onResolvedListeners) {
-      onResolved(std::get<TResult>(_state));
+    std::vector<OnResolvedFunc> listeners;
+    {
+      std::unique_lock lock(_mutex);
+      _state = result;
+      listeners = takeResolvedListenersAndClearAllListeners(lock);
     }
-    didFinish();
+    if (listeners.empty()) {
+      return;
+    }
+    const TResult& resolvedValue = getResult();
+    for (const auto& onResolved : listeners) {
+      onResolved(resolvedValue);
+    }
   }
   /**
    * Rejects this Promise with the given error, and calls any pending listeners.
@@ -128,15 +142,18 @@ public:
       throw std::runtime_error("Cannot reject Promise<" + typeName + "> with a null exception_ptr!");
     }
 
-    std::unique_lock lock(_mutex);
 #ifdef NITRO_DEBUG
     assertPromiseState(*this, PromiseTask::WANTS_TO_REJECT);
 #endif
-    _state = exception;
-    for (const auto& onRejected : _onRejectedListeners) {
+    std::vector<OnRejectedFunc> listeners;
+    {
+      std::unique_lock lock(_mutex);
+      _state = exception;
+      listeners = takeRejectedListenersAndClearAllListeners(lock);
+    }
+    for (const auto& onRejected : listeners) {
       onRejected(exception);
     }
-    didFinish();
   }
 
 public:
@@ -145,24 +162,24 @@ public:
    * If the Promise is already resolved, the listener will be immediately called.
    */
   void addOnResolvedListener(OnResolvedFunc&& onResolved) {
-    std::unique_lock lock(_mutex);
-    if (std::holds_alternative<TResult>(_state)) {
-      // Promise is already resolved! Call the callback immediately
-      onResolved(std::get<TResult>(_state));
-    } else {
-      // Promise is not yet resolved, put the listener in our queue.
-      _onResolvedListeners.push_back(std::move(onResolved));
+    {
+      std::unique_lock lock(_mutex);
+      if (!isResolved(lock)) {
+        _onResolvedListeners.push_back(std::move(onResolved));
+        return;
+      }
     }
+    onResolved(getResult());
   }
   void addOnResolvedListener(const OnResolvedFunc& onResolved) {
-    std::unique_lock lock(_mutex);
-    if (std::holds_alternative<TResult>(_state)) {
-      // Promise is already resolved! Call the callback immediately
-      onResolved(std::get<TResult>(_state));
-    } else {
-      // Promise is not yet resolved, put the listener in our queue.
-      _onResolvedListeners.push_back(onResolved);
+    {
+      std::unique_lock lock(_mutex);
+      if (!isResolved(lock)) {
+        _onResolvedListeners.push_back(onResolved);
+        return;
+      }
     }
+    onResolved(getResult());
   }
 
   /**
@@ -170,24 +187,28 @@ public:
    * If the Promise is already rejected, the listener will be immediately called.
    */
   void addOnRejectedListener(OnRejectedFunc&& onRejected) {
-    std::unique_lock lock(_mutex);
-    if (std::holds_alternative<std::exception_ptr>(_state)) {
-      // Promise is already rejected! Call the callback immediately
-      onRejected(std::get<std::exception_ptr>(_state));
-    } else {
-      // Promise is not yet rejected, put the listener in our queue.
-      _onRejectedListeners.push_back(std::move(onRejected));
+    std::exception_ptr error;
+    {
+      std::unique_lock lock(_mutex);
+      if (!isRejected(lock)) {
+        _onRejectedListeners.push_back(std::move(onRejected));
+        return;
+      }
+      error = std::get<std::exception_ptr>(_state);
     }
+    onRejected(error);
   }
   void addOnRejectedListener(const OnRejectedFunc& onRejected) {
-    std::unique_lock lock(_mutex);
-    if (std::holds_alternative<std::exception_ptr>(_state)) {
-      // Promise is already rejected! Call the callback immediately
-      onRejected(std::get<std::exception_ptr>(_state));
-    } else {
-      // Promise is not yet rejected, put the listener in our queue.
-      _onRejectedListeners.push_back(onRejected);
+    std::exception_ptr error;
+    {
+      std::unique_lock lock(_mutex);
+      if (!isRejected(lock)) {
+        _onRejectedListeners.push_back(onRejected);
+        return;
+      }
+      error = std::get<std::exception_ptr>(_state);
     }
+    onRejected(error);
   }
 
 public:
@@ -207,7 +228,8 @@ public:
    * If the Promise is not resolved, this will throw.
    */
   inline const TResult& getResult() const {
-    if (!isResolved()) {
+    std::unique_lock lock(_mutex);
+    if (!isResolved(lock)) {
       std::string typeName = TypeInfo::getFriendlyTypename<TResult>(true);
       throw std::runtime_error("Cannot get result when Promise<" + typeName + "> is not yet resolved!");
     }
@@ -218,7 +240,8 @@ public:
    * If the Promise is not rejected, this will throw.
    */
   inline const std::exception_ptr& getError() const {
-    if (!isRejected()) {
+    std::unique_lock lock(_mutex);
+    if (!isRejected(lock)) {
       std::string typeName = TypeInfo::getFriendlyTypename<TResult>(true);
       throw std::runtime_error("Cannot get error when Promise<" + typeName + "> is not yet rejected!");
     }
@@ -231,25 +254,50 @@ public:
    */
   [[nodiscard]]
   inline bool isResolved() const noexcept {
-    return std::holds_alternative<TResult>(_state);
+    std::unique_lock lock(_mutex);
+    return isResolved(lock);
   }
   /**
    * Gets whether this Promise has been rejected with an error, or not.
    */
   [[nodiscard]]
   inline bool isRejected() const noexcept {
-    return std::holds_alternative<std::exception_ptr>(_state);
+    std::unique_lock lock(_mutex);
+    return isRejected(lock);
   }
   /**
    * Gets whether this Promise has not yet been resolved nor rejected.
    */
   [[nodiscard]]
   inline bool isPending() const noexcept {
-    return std::holds_alternative<std::monostate>(_state);
+    std::unique_lock lock(_mutex);
+    return isPending(lock);
   }
 
 private:
-  void didFinish() noexcept {
+  [[nodiscard]]
+  inline bool isResolved(const std::unique_lock<std::mutex>&) const noexcept {
+    return std::holds_alternative<TResult>(_state);
+  }
+  [[nodiscard]]
+  inline bool isRejected(const std::unique_lock<std::mutex>&) const noexcept {
+    return std::holds_alternative<std::exception_ptr>(_state);
+  }
+  [[nodiscard]]
+  inline bool isPending(const std::unique_lock<std::mutex>&) const noexcept {
+    return std::holds_alternative<std::monostate>(_state);
+  }
+  std::vector<OnResolvedFunc> takeResolvedListenersAndClearAllListeners(const std::unique_lock<std::mutex>& lock) {
+    auto listeners = std::move(_onResolvedListeners);
+    clearAllListeners(lock);
+    return listeners;
+  }
+  std::vector<OnRejectedFunc> takeRejectedListenersAndClearAllListeners(const std::unique_lock<std::mutex>& lock) {
+    auto listeners = std::move(_onRejectedListeners);
+    clearAllListeners(lock);
+    return listeners;
+  }
+  void clearAllListeners(const std::unique_lock<std::mutex>&) noexcept {
     _onResolvedListeners.clear();
     _onRejectedListeners.clear();
   }
@@ -258,7 +306,7 @@ private:
   std::variant<std::monostate, TResult, std::exception_ptr> _state;
   std::vector<OnResolvedFunc> _onResolvedListeners;
   std::vector<OnRejectedFunc> _onRejectedListeners;
-  std::mutex _mutex;
+  mutable std::mutex _mutex;
 };
 
 // Specialization for void
@@ -301,20 +349,34 @@ public:
 
 public:
   inline bool isResolved() const noexcept {
-    return _isResolved;
+    std::unique_lock lock(_mutex);
+    return isResolved(lock);
   }
   inline bool isRejected() const noexcept {
-    return _error != nullptr;
+    std::unique_lock lock(_mutex);
+    return isRejected(lock);
   }
   inline bool isPending() const noexcept {
-    return !isResolved() && !isRejected();
+    std::unique_lock lock(_mutex);
+    return isPending(lock);
   }
 
 private:
-  void didFinish() noexcept;
+  inline bool isResolved(const std::unique_lock<std::mutex>&) const noexcept {
+    return _isResolved;
+  }
+  inline bool isRejected(const std::unique_lock<std::mutex>&) const noexcept {
+    return _error != nullptr;
+  }
+  inline bool isPending(const std::unique_lock<std::mutex>&) const noexcept {
+    return !_isResolved && _error == nullptr;
+  }
+  std::vector<OnResolvedFunc> takeResolvedListenersAndClearAllListeners(const std::unique_lock<std::mutex>&);
+  std::vector<OnRejectedFunc> takeRejectedListenersAndClearAllListeners(const std::unique_lock<std::mutex>&);
+  void clearAllListeners(const std::unique_lock<std::mutex>&) noexcept;
 
 private:
-  std::mutex _mutex;
+  mutable std::mutex _mutex;
   bool _isResolved = false;
   std::exception_ptr _error;
   std::vector<OnResolvedFunc> _onResolvedListeners;

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -164,24 +164,20 @@ public:
   void addOnResolvedListener(OnResolvedFunc&& onResolved) {
     std::unique_lock lock(_mutex);
     if (std::holds_alternative<TResult>(_state)) {
-      // Promise is already resolved! Call the callback immediately.
       const TResult& result = std::get<TResult>(_state);
       lock.unlock();
       onResolved(result);
     } else {
-      // Promise is not yet resolved, put the listener in our queue.
       _onResolvedListeners.push_back(std::move(onResolved));
     }
   }
   void addOnResolvedListener(const OnResolvedFunc& onResolved) {
     std::unique_lock lock(_mutex);
     if (std::holds_alternative<TResult>(_state)) {
-      // Promise is already resolved! Call the callback immediately.
       const TResult& result = std::get<TResult>(_state);
       lock.unlock();
       onResolved(result);
     } else {
-      // Promise is not yet resolved, put the listener in our queue.
       _onResolvedListeners.push_back(onResolved);
     }
   }
@@ -193,24 +189,20 @@ public:
   void addOnRejectedListener(OnRejectedFunc&& onRejected) {
     std::unique_lock lock(_mutex);
     if (std::holds_alternative<std::exception_ptr>(_state)) {
-      // Promise is already rejected! Call the callback immediately.
       std::exception_ptr error = std::get<std::exception_ptr>(_state);
       lock.unlock();
       onRejected(error);
     } else {
-      // Promise is not yet rejected, put the listener in our queue.
       _onRejectedListeners.push_back(std::move(onRejected));
     }
   }
   void addOnRejectedListener(const OnRejectedFunc& onRejected) {
     std::unique_lock lock(_mutex);
     if (std::holds_alternative<std::exception_ptr>(_state)) {
-      // Promise is already rejected! Call the callback immediately.
       std::exception_ptr error = std::get<std::exception_ptr>(_state);
       lock.unlock();
       onRejected(error);
     } else {
-      // Promise is not yet rejected, put the listener in our queue.
       _onRejectedListeners.push_back(onRejected);
     }
   }

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -120,17 +120,15 @@ public:
     assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
 #endif
     std::vector<OnResolvedFunc> listeners;
-    std::vector<OnRejectedFunc> dropped;
-    const TResult* resolvedValue;
+    std::vector<OnResolvedFunc> listeners;
     {
       std::unique_lock lock(_mutex);
       _state = result;
-      resolvedValue = &std::get<TResult>(_state);
       listeners = std::move(_onResolvedListeners);
-      dropped = std::move(_onRejectedListeners);
+      clearAllListeners(lock);
     }
     for (const auto& onResolved : listeners) {
-      onResolved(*resolvedValue);
+      onResolved(result);
     }
   }
   /**

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -102,13 +102,14 @@ public:
     assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
 #endif
     std::vector<OnResolvedFunc> listeners;
+    std::vector<OnRejectedFunc> dropped;
     const TResult* resolvedValue;
     {
       std::unique_lock lock(_mutex);
       _state = std::move(result);
       resolvedValue = &std::get<TResult>(_state);
       listeners = std::move(_onResolvedListeners);
-      clearAllListeners(lock);
+      dropped = std::move(_onRejectedListeners);
     }
     for (const auto& onResolved : listeners) {
       onResolved(*resolvedValue);
@@ -119,13 +120,14 @@ public:
     assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
 #endif
     std::vector<OnResolvedFunc> listeners;
+    std::vector<OnRejectedFunc> dropped;
     const TResult* resolvedValue;
     {
       std::unique_lock lock(_mutex);
       _state = result;
       resolvedValue = &std::get<TResult>(_state);
       listeners = std::move(_onResolvedListeners);
-      clearAllListeners(lock);
+      dropped = std::move(_onRejectedListeners);
     }
     for (const auto& onResolved : listeners) {
       onResolved(*resolvedValue);
@@ -144,11 +146,12 @@ public:
     assertPromiseState(*this, PromiseTask::WANTS_TO_REJECT);
 #endif
     std::vector<OnRejectedFunc> listeners;
+    std::vector<OnResolvedFunc> dropped;
     {
       std::unique_lock lock(_mutex);
       _state = exception;
       listeners = std::move(_onRejectedListeners);
-      clearAllListeners(lock);
+      dropped = std::move(_onResolvedListeners);
     }
     for (const auto& onRejected : listeners) {
       onRejected(exception);
@@ -290,10 +293,6 @@ private:
   inline bool isPending(const std::unique_lock<std::mutex>&) const noexcept {
     return std::holds_alternative<std::monostate>(_state);
   }
-  void clearAllListeners(const std::unique_lock<std::mutex>&) noexcept {
-    _onResolvedListeners.clear();
-    _onRejectedListeners.clear();
-  }
 
 private:
   std::variant<std::monostate, TResult, std::exception_ptr> _state;
@@ -364,7 +363,6 @@ private:
   inline bool isPending(const std::unique_lock<std::mutex>&) const noexcept {
     return !_isResolved && _error == nullptr;
   }
-  void clearAllListeners(const std::unique_lock<std::mutex>&) noexcept;
 
 private:
   mutable std::mutex _mutex;

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -166,8 +166,10 @@ public:
     if (std::holds_alternative<TResult>(_state)) {
       const TResult& result = std::get<TResult>(_state);
       lock.unlock();
+      // Promise is already resolved! Call the callback immediately
       onResolved(result);
     } else {
+      // Promise is not yet resolved, put the listener in our queue.
       _onResolvedListeners.push_back(std::move(onResolved));
     }
   }
@@ -176,8 +178,10 @@ public:
     if (std::holds_alternative<TResult>(_state)) {
       const TResult& result = std::get<TResult>(_state);
       lock.unlock();
+      // Promise is already resolved! Call the callback immediately
       onResolved(result);
     } else {
+      // Promise is not yet resolved, put the listener in our queue.
       _onResolvedListeners.push_back(onResolved);
     }
   }
@@ -191,8 +195,10 @@ public:
     if (std::holds_alternative<std::exception_ptr>(_state)) {
       std::exception_ptr error = std::get<std::exception_ptr>(_state);
       lock.unlock();
+      // Promise is already rejected! Call the callback immediately
       onRejected(error);
     } else {
+      // Promise is not yet rejected, put the listener in our queue.
       _onRejectedListeners.push_back(std::move(onRejected));
     }
   }
@@ -201,8 +207,10 @@ public:
     if (std::holds_alternative<std::exception_ptr>(_state)) {
       std::exception_ptr error = std::get<std::exception_ptr>(_state);
       lock.unlock();
+      // Promise is already rejected! Call the callback immediately
       onRejected(error);
     } else {
+      // Promise is not yet rejected, put the listener in our queue.
       _onRejectedListeners.push_back(onRejected);
     }
   }

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -120,12 +120,12 @@ public:
     assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
 #endif
     std::vector<OnResolvedFunc> listeners;
-    std::vector<OnResolvedFunc> listeners;
+    std::vector<OnRejectedFunc> dropped;
     {
       std::unique_lock lock(_mutex);
       _state = result;
       listeners = std::move(_onResolvedListeners);
-      clearAllListeners(lock);
+      dropped = std::move(_onRejectedListeners);
     }
     for (const auto& onResolved : listeners) {
       onResolved(result);


### PR DESCRIPTION
Fixes #1396.

`Promise<T>::resolve()`/`reject()` write `_state` under `_mutex`, but the state-inspection accessors (`isPending`/`isResolved`/`isRejected`/`getResult`/`getError`) read it **lock-free**. `JSIConverter<shared_ptr<Promise<T>>>::toJSI` runs those reads on the JS thread the instant a hybrid method returns, racing an off-JS-thread `resolve()` (`Promise::async` thread pool, `Promise.parallel`, or a main-thread resolve) — a data race on the `std::variant _state`.

## Fix
- Make `_mutex` `mutable` and take it in the inspection accessors (state check inlined to avoid recursive self-locking).
- Per-accessor locking is sufficient — no combined snapshot needed: `_state`'s transition is one-shot/monotonic (`pending → value | error`, never back), so the `isPending()` → `getResult()` check-then-act is safe, and `getResult()` may still return a reference (the value is immutable after resolution; the lock just supplies the happens-before).
- Pop listeners under the lock and invoke them outside it (matching the Swift fix in #1338), so user callbacks never run while holding `_mutex`. Same treatment for the `Promise<void>` specialization.

## Verification
Reproduction in #1397 (adds `newTestObjectAsync` + a parallel-load test). Building the example with Thread Sanitizer (`ENABLE_THREAD_SANITIZER=YES` / scheme Diagnostics):
- **Before:** TSan reports the race on `Promise::_state` (`resolve` at `Promise.hpp:105` vs `isPending` at `Promise.hpp:248`, via `toJSI`).
- **After:** that race is gone. Confirmed on iPhone 17 simulator (iOS 26.4), and via a standalone TSan harness against the real `Promise.hpp` (0 races, was ~4/run).

> Out of scope: the same TSan run also surfaces a separate, pre-existing `ThreadPool::run()` deque race — not addressed here.