### PR TITLE
fix(threading): read _tasks.empty() under _queueMutex in ThreadPool::run()

### DIFF
--- a/packages/react-native-nitro-modules/cpp/threading/ThreadPool.cpp
+++ b/packages/react-native-nitro-modules/cpp/threading/ThreadPool.cpp
@@ -16,13 +16,13 @@ ThreadPool::ThreadPool(const char* name, size_t initialThreadsCount, size_t maxT
   Logger::log(LogLevel::Info, TAG, "Creating ThreadPool \"%s\" with %i initial threads (max: %i)...", name, initialThreadsCount,
               maxThreadsCount);
 
+  std::unique_lock<std::mutex> lock(_queueMutex);
   for (size_t i = 0; i < initialThreadsCount; i++) {
-    addThread();
+    addThread(lock);
   }
 }
 
-void ThreadPool::addThread() {
-  std::unique_lock<std::mutex> lock(_queueMutex);
+void ThreadPool::addThread(std::unique_lock<std::mutex>& queueMutexLock) {
   if (!_isAlive) {
     return;
   }
@@ -58,16 +58,14 @@ void ThreadPool::addThread() {
 }
 
 void ThreadPool::run(std::function<void()>&& task) {
-  // If there are tasks still waiting to be finished, just start a new Thread.
-  if (!_tasks.empty() && _threadCount < _threadCountLimit) {
-    addThread();
-  }
-  // New scope because of RAII lock
   {
-    // lock on the mutex - we want to push the task back in the queue
     std::unique_lock<std::mutex> lock(_queueMutex);
     if (!_isAlive) {
       throw std::runtime_error("Cannot queue the given task - the ThreadPool has already been stopped!");
+    }
+    // If there are tasks still waiting to be finished, just start a new Thread.
+    if (!_tasks.empty() && _threadCount < _threadCountLimit) {
+      addThread(lock);
     }
     _tasks.push(std::move(task));
   }

--- a/packages/react-native-nitro-modules/cpp/threading/ThreadPool.hpp
+++ b/packages/react-native-nitro-modules/cpp/threading/ThreadPool.hpp
@@ -42,7 +42,7 @@ private:
    * Adds a new Thread to the current Thread Pool.
    * This grows the size by one, and potentially starts work sooner if other Threads are busy.
    */
-  void addThread();
+  void addThread(std::unique_lock<std::mutex>& queueMutexLock);
 
 public:
   /**


### PR DESCRIPTION
`ThreadPool::run()` checked `_tasks.empty()` before acquiring `_queueMutex`, while worker threads call `_tasks.pop()` under that same mutex. `std::queue` is backed by `std::deque` — even `empty()` reads internal size state that `pop_front()` writes non-atomically, so this is a real data race caught by ThreadSanitizer.

Fix: move the `_tasks.empty()` check inside the existing lock scope. `addThread()` is then called after releasing the lock since it also takes `_queueMutex`.

**TSan report** (from CI on [mfazekas/nitro#2](https://github.com/mfazekas/nitro/pull/2), after the `Promise<T>` race was fixed):

```
WARNING: ThreadSanitizer: data race (pid=30664)
  Read of size 8 at 0x0001033cb400 by thread T8:
    #0 std::deque<function<void()>>::size() const  deque:756
    #1 std::deque<function<void()>>::empty() const  deque:767
    #2 std::queue<function<void()>>::empty() const  queue:378
    #3 margelo::nitro::ThreadPool::run(function<void()>&&)  ThreadPool.cpp:62
    #4 margelo::nitro::Promise<double>::async(function<double()>&&)  Promise.hpp:57
    #5 margelo::nitro::test::HybridTestObjectCpp::promiseReturnsInstantlyAsync()  HybridTestObjectCpp.cpp:559

  Previous write of size 8 at 0x0001033cb400 by thread T15 (mutexes: write M0):
    #0 std::deque<function<void()>>::pop_front()  deque:2302
    #1 std::queue<function<void()>>::pop()  queue:415
    #2 margelo::nitro::ThreadPool::addThread()::lambda  ThreadPool.cpp:51

  Location is global 'margelo::nitro::ThreadPool::shared()::shared'
```

Fix verified clean on [mfazekas/nitro#3](https://github.com/mfazekas/nitro/pull/3) — TSan job passes with no reports.