### PR TITLE
Run Harness with ASan and TSan in CI

### DIFF
--- a/.github/workflows/harness-android.yml
+++ b/.github/workflows/harness-android.yml
@@ -80,12 +80,18 @@ env:
 
 jobs:
   harness_android_new:
-    name: Harness Android (new architecture)
+    name: Harness Android (${{ matrix.sanitizer.name }}, new architecture)
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         min-sdk:
           - '26'
+        sanitizer:
+          - name: Default
+            gradle_property: ""
+          - name: ASan
+            gradle_property: "address"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -122,13 +128,13 @@ jobs:
             ~/.gradle/wrapper
             example/android/.gradle
             example/android/app/.cxx
-          key: ${{ runner.os }}-gradle-${{ matrix.min-sdk }}-${{ env.DEVICE_ARCH }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ runner.os }}-gradle-${{ matrix.min-sdk }}-${{ env.DEVICE_ARCH }}-${{ matrix.sanitizer.name }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-${{ matrix.min-sdk }}-${{ env.DEVICE_ARCH }}-
+            ${{ runner.os }}-gradle-${{ matrix.min-sdk }}-${{ env.DEVICE_ARCH }}-${{ matrix.sanitizer.name }}-
             ${{ runner.os }}-gradle-
       - name: Build Android app
         working-directory: example/android
-        run: ./gradlew :app:assembleDebug --no-daemon --build-cache -PreactNativeArchitectures=${{ env.DEVICE_ARCH }}
+        run: ./gradlew :app:assembleDebug --no-daemon --build-cache -PreactNativeArchitectures=${{ env.DEVICE_ARCH }} -PnitroSanitizer=${{ matrix.sanitizer.gradle_property }}
 
       - name: Run Harness E2E tests
         # TODO: switch to @v1.3.0 once upstream publishes the GitHub Action tag.

--- a/.github/workflows/harness-ios.yml
+++ b/.github/workflows/harness-ios.yml
@@ -84,8 +84,18 @@ env:
 
 jobs:
   harness_ios_new:
-    name: Harness iOS (new architecture)
+    name: Harness iOS (${{ matrix.sanitizer.name }}, new architecture)
     runs-on: macOS-26
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+          - name: Default
+            xcodebuild_flags: ""
+          - name: ASan
+            xcodebuild_flags: "-enableAddressSanitizer YES"
+          - name: TSan
+            xcodebuild_flags: "-enableThreadSanitizer YES"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -100,7 +110,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           max-size: 1.5G
-          key: ${{ runner.os }}-${{ runner.arch }}-xcode${{ env.XCODE_VERSION }}-ccache-example-ios
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode${{ env.XCODE_VERSION }}-${{ matrix.sanitizer.name }}-ccache-example-ios
           create-symlink: true
       - name: Setup ccache behavior
         run: |
@@ -134,24 +144,25 @@ jobs:
         uses: actions/cache@v6
         with:
           path: example/ios/build
-          key: ${{ runner.os }}-${{ runner.arch }}-xcode${{ env.XCODE_VERSION }}-dd-${{ hashFiles('bun.lock', 'example/Gemfile.lock', 'example/ios/Podfile.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode${{ env.XCODE_VERSION }}-${{ matrix.sanitizer.name }}-dd-${{ hashFiles('bun.lock', 'example/Gemfile.lock', 'example/ios/Podfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-xcode${{ env.XCODE_VERSION }}-dd-
+            ${{ runner.os }}-${{ runner.arch }}-xcode${{ env.XCODE_VERSION }}-${{ matrix.sanitizer.name }}-dd-
 
       - name: Build iOS app
         working-directory: example/ios
         run: |
           set -o pipefail
+          SANITIZER_FLAGS="${{ matrix.sanitizer.xcodebuild_flags }}"
           xcodebuild \
-            CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
             -derivedDataPath build -UseModernBuildSystem=YES \
             -workspace NitroExample.xcworkspace \
             -scheme NitroExample \
             -sdk iphonesimulator \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,arch=arm64,name=${{ env.DEVICE_MODEL }}' \
+            -destination 'generic/platform=iOS Simulator' \
+            ${SANITIZER_FLAGS} \
             -showBuildTimingSummary \
-            ONLY_ACTIVE_ARCH=YES \
+            ARCHS=arm64 \
             build \
             CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -77,6 +77,19 @@ def isNewArchitectureEnabled() {
 }
 logger.warn("Building with newArchEnabled = ${isNewArchitectureEnabled()}...")
 
+def nitroSanitizer = rootProject.findProperty('nitroSanitizer') ?: ''
+def nitroSanitizerRuntime = [
+    address: 'asan',
+][nitroSanitizer]
+def nitroSanitizerUsesWrap = nitroSanitizer == 'address'
+
+if (nitroSanitizer != '' && nitroSanitizerRuntime == null) {
+    throw new GradleException("Unsupported nitroSanitizer: ${nitroSanitizer}")
+}
+
+def nitroSanitizerJniLibsDir = layout.buildDirectory.dir("generated/nitroSanitizerJniLibs")
+def nitroSanitizerResourcesDir = layout.buildDirectory.dir("generated/nitroSanitizerResources")
+
 android {
     ndkVersion rootProject.ext.ndkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -110,6 +123,21 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    if (nitroSanitizerRuntime != null) {
+        packaging {
+            jniLibs {
+                useLegacyPackaging = true
+            }
+        }
+        sourceSets {
+            debug {
+                jniLibs.srcDir(nitroSanitizerJniLibsDir)
+                if (nitroSanitizerUsesWrap) {
+                    resources.srcDir(nitroSanitizerResourcesDir)
+                }
+            }
+        }
+    }
 }
 
 dependencies {
@@ -120,5 +148,66 @@ dependencies {
         implementation("com.facebook.react:hermes-android")
     } else {
         implementation jscFlavor
+    }
+}
+
+if (nitroSanitizerRuntime != null) {
+    def abiToRuntimeArch = [
+        'arm64-v8a': 'aarch64',
+        'armeabi-v7a': 'arm',
+        'x86': 'i686',
+        'x86_64': 'x86_64',
+    ]
+    def architectures = (rootProject.findProperty('reactNativeArchitectures') ?: 'armeabi-v7a,x86,x86_64,arm64-v8a').split(',')
+    def copyNitroSanitizerRuntime = tasks.register('copyNitroSanitizerRuntime', Sync) {
+        into(nitroSanitizerJniLibsDir)
+
+        architectures.each { abi ->
+            def runtimeArch = abiToRuntimeArch[abi]
+            if (runtimeArch == null) {
+                throw new GradleException("Unsupported ABI for nitroSanitizer: ${abi}")
+            }
+
+            def runtimeFileName = "libclang_rt.${nitroSanitizerRuntime}-${runtimeArch}-android.so"
+            def runtimeFiles = fileTree("${android.ndkDirectory}/toolchains/llvm/prebuilt") {
+                include "**/${runtimeFileName}"
+            }
+
+            from({ runtimeFiles.files }) {
+                into abi
+            }
+            doFirst {
+                if (runtimeFiles.files.size() != 1) {
+                    throw new GradleException("Expected one ${runtimeFileName} in ${android.ndkDirectory}, found ${runtimeFiles.files.size()}")
+                }
+            }
+        }
+    }
+    def copyNitroSanitizerWrap = nitroSanitizerUsesWrap ? tasks.register('copyNitroSanitizerWrap', Sync) {
+        into(nitroSanitizerResourcesDir)
+
+        def wrapScript = file("${android.ndkDirectory}/wrap.sh/asan.sh")
+        architectures.each { abi ->
+            from(wrapScript) {
+                rename { 'wrap.sh' }
+                into "lib/${abi}"
+            }
+        }
+        doFirst {
+            if (!wrapScript.isFile()) {
+                throw new GradleException("Expected ASan wrap script at ${wrapScript}")
+            }
+        }
+    } : null
+
+    afterEvaluate {
+        tasks.named('mergeDebugJniLibFolders').configure {
+            dependsOn(copyNitroSanitizerRuntime)
+        }
+        if (copyNitroSanitizerWrap != null) {
+            tasks.named('processDebugJavaRes').configure {
+                dependsOn(copyNitroSanitizerWrap)
+            }
+        }
     }
 }

--- a/packages/react-native-nitro-modules/android/CMakeLists.txt
+++ b/packages/react-native-nitro-modules/android/CMakeLists.txt
@@ -18,6 +18,14 @@ add_library(NitroModules SHARED
             ${android_files}
 )
 
+set(NITRO_SANITIZER "" CACHE STRING "Native sanitizer")
+if(NITRO_SANITIZER STREQUAL "address")
+  target_compile_options(NitroModules PUBLIC -fsanitize=address -fno-omit-frame-pointer)
+  set_target_properties(NitroModules PROPERTIES LINK_FLAGS "-fsanitize=address")
+elseif(NOT NITRO_SANITIZER STREQUAL "")
+  message(FATAL_ERROR "Unsupported NITRO_SANITIZER: ${NITRO_SANITIZER}")
+endif()
+
 # Specifies a path to native header files.
 include_directories(
   # Shared C++ includes

--- a/packages/react-native-nitro-modules/android/build.gradle
+++ b/packages/react-native-nitro-modules/android/build.gradle
@@ -52,7 +52,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-frtti -fexceptions -Wall -Wextra -fstack-protector-all"
-        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON", "-DNITRO_SANITIZER=${rootProject.findProperty('nitroSanitizer') ?: ''}"
         abiFilters (*reactNativeArchitectures())
 
         buildTypes {

--- a/packages/react-native-nitro-test-external/android/CMakeLists.txt
+++ b/packages/react-native-nitro-test-external/android/CMakeLists.txt
@@ -10,6 +10,14 @@ add_library(${PACKAGE_NAME} SHARED
         src/main/cpp/cpp-adapter.cpp
 )
 
+set(NITRO_SANITIZER "" CACHE STRING "Native sanitizer")
+if(NITRO_SANITIZER STREQUAL "address")
+  target_compile_options(${PACKAGE_NAME} PUBLIC -fsanitize=address -fno-omit-frame-pointer)
+  set_target_properties(${PACKAGE_NAME} PROPERTIES LINK_FLAGS "-fsanitize=address")
+elseif(NOT NITRO_SANITIZER STREQUAL "")
+  message(FATAL_ERROR "Unsupported NITRO_SANITIZER: ${NITRO_SANITIZER}")
+endif()
+
 # Add Nitrogen specs :)
 include(${CMAKE_SOURCE_DIR}/../nitrogen/generated/android/NitroTestExternal+autolinking.cmake)
 

--- a/packages/react-native-nitro-test-external/android/build.gradle
+++ b/packages/react-native-nitro-test-external/android/build.gradle
@@ -49,7 +49,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-frtti -fexceptions -Wall -Wextra -fstack-protector-all"
-        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON", "-DNITRO_SANITIZER=${rootProject.findProperty('nitroSanitizer') ?: ''}"
         abiFilters (*reactNativeArchitectures())
 
         buildTypes {

--- a/packages/react-native-nitro-test/android/CMakeLists.txt
+++ b/packages/react-native-nitro-test/android/CMakeLists.txt
@@ -11,6 +11,14 @@ add_library(${PACKAGE_NAME} SHARED
         ../cpp/HybridTestObjectCpp.cpp
 )
 
+set(NITRO_SANITIZER "" CACHE STRING "Native sanitizer")
+if(NITRO_SANITIZER STREQUAL "address")
+  target_compile_options(${PACKAGE_NAME} PUBLIC -fsanitize=address -fno-omit-frame-pointer)
+  set_target_properties(${PACKAGE_NAME} PROPERTIES LINK_FLAGS "-fsanitize=address")
+elseif(NOT NITRO_SANITIZER STREQUAL "")
+  message(FATAL_ERROR "Unsupported NITRO_SANITIZER: ${NITRO_SANITIZER}")
+endif()
+
 # Add Nitrogen specs :)
 include(${CMAKE_SOURCE_DIR}/../nitrogen/generated/android/NitroTest+autolinking.cmake)
 

--- a/packages/react-native-nitro-test/android/build.gradle
+++ b/packages/react-native-nitro-test/android/build.gradle
@@ -48,7 +48,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-frtti -fexceptions -Wall -Wextra -fstack-protector-all"
-        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON", "-DNITRO_SANITIZER=${rootProject.findProperty('nitroSanitizer') ?: ''}"
         abiFilters (*reactNativeArchitectures())
 
         buildTypes {


### PR DESCRIPTION
## What changed

- Runs the iOS Harness workflow for Default, ASan, and TSan.
- Runs the Android Harness workflow for Default and ASan.
- Enables iOS sanitizers through the supported `xcodebuild` sanitizer flags.
- Enables Android ASan through a `nitroSanitizer` Gradle property that forwards to CMake and packages the NDK ASan runtime plus the NDK-provided ASan `wrap.sh` for debug APKs.

## Notes

Android TSan is intentionally skipped for now. The CI app did not get far enough to request its Metro bundle, and making it launch would require custom wrapper plumbing that is not worth adding here.

## Validation

- Parsed both Harness workflow YAML files.
- Built Android debug APK locally for Default and ASan with `x86_64`.
- Verified the Default APK has no sanitizer runtime or `wrap.sh`.
- Verified the ASan APK includes `libclang_rt.asan-x86_64-android.so` and `wrap.sh`.