### PR TITLE
Fix iOS Harness ASan compiler path

### DIFF
--- a/.github/workflows/harness-ios.yml
+++ b/.github/workflows/harness-ios.yml
@@ -152,8 +152,11 @@ jobs:
         working-directory: example/ios
         run: |
           set -o pipefail
+          CLANG="$(xcrun -f clang)"
+          CLANGXX="$(xcrun -f clang++)"
           SANITIZER_FLAGS="${{ matrix.sanitizer.xcodebuild_flags }}"
           xcodebuild \
+            CC="${CLANG}" CPLUSPLUS="${CLANGXX}" LD="${CLANG}" LDPLUSPLUS="${CLANGXX}" \
             -derivedDataPath build -UseModernBuildSystem=YES \
             -workspace NitroExample.xcworkspace \
             -scheme NitroExample \


### PR DESCRIPTION
## What

Restore the explicit Xcode `clang`/`clang++` compiler and linker paths for the iOS Harness build.

## Why

The main `Harness iOS` run started failing only for `Harness iOS (ASan, new architecture)` after the previous cleanup removed these lines. Comparing the last green PR commit (`498db21f`) with the first failing PR commit (`833a98f8`) shows this was the only workflow diff.

The failed ASan build reports:

- `Explicit modules is enabled but the compiler was not recognized`
- `Could not get lib darwin path`

The workflow also installs ccache symlinks for `clang`/`clang++`, so without the explicit `xcrun` paths Xcode can pick up the launcher instead of its real compiler. The restored lines are the known-green setup.

## Validation

- Parsed `.github/workflows/harness-ios.yml` with Ruby YAML
- Ran `git diff --check`