### PR TITLE
fix: raw Props arguments issue

### DIFF
--- a/packages/nitrogen/src/views/CppHybridViewComponent.ts
+++ b/packages/nitrogen/src/views/CppHybridViewComponent.ts
@@ -209,7 +209,8 @@ namespace ${namespace} {
       `
 ${name}([&]() -> CachedProp<${type}> {
   try {
-    const react::RawValue* rawValue = rawProps.at("${prop.name}", nullptr, nullptr);
+  
+    const react::RawValue* rawValue = getRawProp(rawProps, "${prop.name}");
     if (rawValue == nullptr) return sourceProps.${name};
     const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
     return CachedProp<${type}>::fromRawValue(*runtime, ${valueConversion}, sourceProps.${name});
@@ -234,6 +235,7 @@ ${createFileMetadataString(`${component}.cpp`)}
 #include <NitroModules/NitroDefines.hpp>
 #include <NitroModules/JSIConverter.hpp>
 #include <NitroModules/PropNameIDCache.hpp>
+#include <NitroModules/RawPropsCompat.hpp>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/ComponentDescriptor.h>

--- a/packages/nitrogen/src/views/CppHybridViewComponent.ts
+++ b/packages/nitrogen/src/views/CppHybridViewComponent.ts
@@ -209,7 +209,6 @@ namespace ${namespace} {
       `
 ${name}([&]() -> CachedProp<${type}> {
   try {
-  
     const react::RawValue* rawValue = getRawProp(rawProps, "${prop.name}");
     if (rawValue == nullptr) return sourceProps.${name};
     const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;

--- a/packages/react-native-nitro-modules/cpp/views/RawPropsCompat.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/RawPropsCompat.hpp
@@ -1,0 +1,26 @@
+
+// TODO- CLEAN UP AFTER 0.87 becomes the norm
+
+#pragma once
+
+namespace margelo::nitro {
+
+template <typename TRawProps>
+auto getRawProp(const TRawProps& rawProps, const char* name, int /* preferred */)
+    -> decltype(rawProps.at(name)) {
+  return rawProps.at(name);
+}
+
+template <typename TRawProps>
+auto getRawProp(const TRawProps& rawProps, const char* name, long /* fallback */)
+    -> decltype(rawProps.at(name, nullptr, nullptr)) {
+  return rawProps.at(name, nullptr, nullptr);
+}
+
+template <typename TRawProps>
+auto getRawProp(const TRawProps& rawProps, const char* name)
+    -> decltype(getRawProp(rawProps, name, 0)) {
+  return getRawProp(rawProps, name, 0);
+}
+
+} // namespace margelo::nitro

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
@@ -29,9 +29,6 @@ namespace margelo::nitro::test::views {
     react::ViewProps(context, sourceProps, rawProps, filterObjectKeys),
     isBlue([&]() -> CachedProp<bool> {
       try {
-        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
-        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
-        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
         const react::RawValue* rawValue = getRawProp(rawProps, "isBlue");
         if (rawValue == nullptr) return sourceProps.isBlue;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
@@ -42,9 +39,6 @@ namespace margelo::nitro::test::views {
     }()),
     hybridRef([&]() -> CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridRecyclableTestViewSpec>& /* ref */)>>> {
       try {
-        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
-        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
-        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
         const react::RawValue* rawValue = getRawProp(rawProps, "hybridRef");
         if (rawValue == nullptr) return sourceProps.hybridRef;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
@@ -13,6 +13,7 @@
 #include <NitroModules/NitroDefines.hpp>
 #include <NitroModules/JSIConverter.hpp>
 #include <NitroModules/PropNameIDCache.hpp>
+#include <NitroModules/RawPropsCompat.hpp>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/ComponentDescriptor.h>
@@ -28,7 +29,10 @@ namespace margelo::nitro::test::views {
     react::ViewProps(context, sourceProps, rawProps, filterObjectKeys),
     isBlue([&]() -> CachedProp<bool> {
       try {
-        const react::RawValue* rawValue = rawProps.at("isBlue", nullptr, nullptr);
+        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
+        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
+        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
+        const react::RawValue* rawValue = getRawProp(rawProps, "isBlue");
         if (rawValue == nullptr) return sourceProps.isBlue;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<bool>::fromRawValue(*runtime, value, sourceProps.isBlue);
@@ -38,7 +42,10 @@ namespace margelo::nitro::test::views {
     }()),
     hybridRef([&]() -> CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridRecyclableTestViewSpec>& /* ref */)>>> {
       try {
-        const react::RawValue* rawValue = rawProps.at("hybridRef", nullptr, nullptr);
+        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
+        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
+        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
+        const react::RawValue* rawValue = getRawProp(rawProps, "hybridRef");
         if (rawValue == nullptr) return sourceProps.hybridRef;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridRecyclableTestViewSpec>& /* ref */)>>>::fromRawValue(*runtime, value.asObject(*runtime).getProperty(*runtime, PropNameIDCache::get(*runtime, "f")), sourceProps.hybridRef);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
@@ -39,9 +39,6 @@ namespace margelo::nitro::test::views {
     }()),
     hasBeenCalled([&]() -> CachedProp<bool> {
       try {
-        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
-        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
-        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
         const react::RawValue* rawValue = getRawProp(rawProps, "hasBeenCalled");
         if (rawValue == nullptr) return sourceProps.hasBeenCalled;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
@@ -52,9 +49,6 @@ namespace margelo::nitro::test::views {
     }()),
     colorScheme([&]() -> CachedProp<ColorScheme> {
       try {
-        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
-        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
-        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
         const react::RawValue* rawValue = getRawProp(rawProps, "colorScheme");
         if (rawValue == nullptr) return sourceProps.colorScheme;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
@@ -65,9 +59,6 @@ namespace margelo::nitro::test::views {
     }()),
     someCallback([&]() -> CachedProp<std::function<void()>> {
       try {
-        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
-        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
-        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
         const react::RawValue* rawValue = getRawProp(rawProps, "someCallback");
         if (rawValue == nullptr) return sourceProps.someCallback;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
@@ -78,9 +69,6 @@ namespace margelo::nitro::test::views {
     }()),
     hybridRef([&]() -> CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>> {
       try {
-        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
-        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
-        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
         const react::RawValue* rawValue = getRawProp(rawProps, "hybridRef");
         if (rawValue == nullptr) return sourceProps.hybridRef;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
@@ -13,6 +13,7 @@
 #include <NitroModules/NitroDefines.hpp>
 #include <NitroModules/JSIConverter.hpp>
 #include <NitroModules/PropNameIDCache.hpp>
+#include <NitroModules/RawPropsCompat.hpp>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/ComponentDescriptor.h>
@@ -28,7 +29,7 @@ namespace margelo::nitro::test::views {
     react::ViewProps(context, sourceProps, rawProps, filterObjectKeys),
     isBlue([&]() -> CachedProp<bool> {
       try {
-        const react::RawValue* rawValue = rawProps.at("isBlue", nullptr, nullptr);
+        const react::RawValue* rawValue = getRawProp(rawProps, "isBlue");
         if (rawValue == nullptr) return sourceProps.isBlue;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<bool>::fromRawValue(*runtime, value, sourceProps.isBlue);
@@ -38,7 +39,10 @@ namespace margelo::nitro::test::views {
     }()),
     hasBeenCalled([&]() -> CachedProp<bool> {
       try {
-        const react::RawValue* rawValue = rawProps.at("hasBeenCalled", nullptr, nullptr);
+        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
+        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
+        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
+        const react::RawValue* rawValue = getRawProp(rawProps, "hasBeenCalled");
         if (rawValue == nullptr) return sourceProps.hasBeenCalled;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<bool>::fromRawValue(*runtime, value, sourceProps.hasBeenCalled);
@@ -48,7 +52,10 @@ namespace margelo::nitro::test::views {
     }()),
     colorScheme([&]() -> CachedProp<ColorScheme> {
       try {
-        const react::RawValue* rawValue = rawProps.at("colorScheme", nullptr, nullptr);
+        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
+        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
+        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
+        const react::RawValue* rawValue = getRawProp(rawProps, "colorScheme");
         if (rawValue == nullptr) return sourceProps.colorScheme;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<ColorScheme>::fromRawValue(*runtime, value, sourceProps.colorScheme);
@@ -58,7 +65,10 @@ namespace margelo::nitro::test::views {
     }()),
     someCallback([&]() -> CachedProp<std::function<void()>> {
       try {
-        const react::RawValue* rawValue = rawProps.at("someCallback", nullptr, nullptr);
+        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
+        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
+        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
+        const react::RawValue* rawValue = getRawProp(rawProps, "someCallback");
         if (rawValue == nullptr) return sourceProps.someCallback;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<std::function<void()>>::fromRawValue(*runtime, value.asObject(*runtime).getProperty(*runtime, PropNameIDCache::get(*runtime, "f")), sourceProps.someCallback);
@@ -68,7 +78,10 @@ namespace margelo::nitro::test::views {
     }()),
     hybridRef([&]() -> CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>> {
       try {
-        const react::RawValue* rawValue = rawProps.at("hybridRef", nullptr, nullptr);
+        // `getRawProp` adapts to React Native's `RawProps::at(...)` signature, which
+        // changed from `at(name, prefix, suffix)` to `at(name)` in RN 0.87 (nightly
+        // 2026-06-25). See NitroModules/RawPropsCompat.hpp.
+        const react::RawValue* rawValue = getRawProp(rawProps, "hybridRef");
         if (rawValue == nullptr) return sourceProps.hybridRef;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>>::fromRawValue(*runtime, value.asObject(*runtime).getProperty(*runtime, PropNameIDCache::get(*runtime, "f")), sourceProps.hybridRef);


### PR DESCRIPTION
Raw props accept dont accept 3 arguments now . This is causing Viison Camera and nitro image to fail in nightly . See https://github.com/react/react-native/commit/67381e157faadd9f18db1ff8710d8d46c3c1dae5
