### PR TITLE
test: Add failing tests for clearing optional view props (#1184)

### DIFF
--- a/example/__tests__/views.harness.tsx
+++ b/example/__tests__/views.harness.tsx
@@ -1,0 +1,185 @@
+import * as React from 'react'
+import {
+  describe,
+  it,
+  expect,
+  render,
+  cleanup,
+  waitFor,
+  afterEach,
+} from 'react-native-harness'
+import { callback } from 'react-native-nitro-modules'
+import { TestView, type TestViewRef } from 'react-native-nitro-test'
+
+type TestViewElementProps = React.ComponentProps<typeof TestView>
+type OptionalTestViewProps = Partial<
+  Pick<
+    TestViewElementProps,
+    'optionalString' | 'nullableString' | 'optionalCallback'
+  >
+>
+
+// Prop-parsing errors are thrown during React's commit and are only
+// observable through an error boundary - the test-runner's own boundary
+// would swallow them and remount, masking the failure.
+class CatchRenderErrors extends React.Component<
+  { children: React.ReactNode; onError: (error: unknown) => void },
+  { hasError: boolean }
+> {
+  state = { hasError: false }
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+  componentDidCatch(error: unknown) {
+    this.props.onError(error)
+  }
+  render() {
+    return this.state.hasError ? null : this.props.children
+  }
+}
+
+// React encodes "prop was removed" as `null` (not `undefined`) in the Fabric
+// update payload, which used to crash Nitro's prop parsing:
+// https://github.com/mrousavy/nitro/issues/1184
+describe('TestView optional props', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  async function renderTestView(initialProps: OptionalTestViewProps): Promise<{
+    view: TestViewRef
+    errors: unknown[]
+    update: (newProps: OptionalTestViewProps) => void
+    mountCount: () => number
+  }> {
+    const refs: TestViewRef[] = []
+    const errors: unknown[] = []
+    const hybridRef = callback((ref: TestViewRef) => {
+      refs.push(ref)
+    })
+    let setPropsFromTest: ((props: OptionalTestViewProps) => void) | undefined
+    function Wrapper(): React.ReactElement {
+      const [optionalProps, setOptionalProps] = React.useState(initialProps)
+      setPropsFromTest = setOptionalProps
+      return (
+        <TestView
+          hybridRef={hybridRef}
+          isBlue={false}
+          hasBeenCalled={false}
+          colorScheme="light"
+          someCallback={callback(() => {})}
+          {...optionalProps}
+        />
+      )
+    }
+
+    await render(
+      <CatchRenderErrors onError={(error) => errors.push(error)}>
+        <Wrapper />
+      </CatchRenderErrors>
+    )
+    await waitFor(() => expect(refs.length).toBeGreaterThan(0))
+    return {
+      view: refs[0]!,
+      errors,
+      update: (newProps) => setPropsFromTest!(newProps),
+      mountCount: () => refs.length,
+    }
+  }
+
+  function expectNoRenderErrors(errors: unknown[]): void {
+    if (errors.length > 0) {
+      throw new Error(
+        `Caught render error(s): ${errors.map((e) => String(e)).join('\n')}`
+      )
+    }
+  }
+
+  it('renders with optional props omitted', async () => {
+    const { view, errors } = await renderTestView({})
+    expect(view.optionalString).toBeUndefined()
+    expect(view.optionalCallback).toBeUndefined()
+    expectNoRenderErrors(errors)
+  })
+
+  it('clears optionalString when the prop is removed', async () => {
+    const { view, errors, update, mountCount } = await renderTestView({
+      optionalString: 'hello',
+    })
+    await waitFor(() => expect(view.optionalString).toBe('hello'))
+
+    update({})
+    await waitFor(() =>
+      expect(errors.length > 0 || view.optionalString === undefined).toBe(true)
+    )
+    expectNoRenderErrors(errors)
+    expect(view.optionalString).toBeUndefined()
+    expect(mountCount()).toBe(1)
+  })
+
+  it('clears optionalString when the prop is set to undefined', async () => {
+    const { view, errors, update, mountCount } = await renderTestView({
+      optionalString: 'hello',
+    })
+    await waitFor(() => expect(view.optionalString).toBe('hello'))
+
+    update({ optionalString: undefined })
+    await waitFor(() =>
+      expect(errors.length > 0 || view.optionalString === undefined).toBe(true)
+    )
+    expectNoRenderErrors(errors)
+    expect(view.optionalString).toBeUndefined()
+    expect(mountCount()).toBe(1)
+  })
+
+  it('can re-set optionalString after it was cleared', async () => {
+    const { view, errors, update } = await renderTestView({
+      optionalString: 'first',
+    })
+    await waitFor(() => expect(view.optionalString).toBe('first'))
+
+    update({})
+    await waitFor(() =>
+      expect(errors.length > 0 || view.optionalString === undefined).toBe(true)
+    )
+    update({ optionalString: 'second' })
+    await waitFor(() =>
+      expect(errors.length > 0 || view.optionalString === 'second').toBe(true)
+    )
+    expectNoRenderErrors(errors)
+    expect(view.optionalString).toBe('second')
+  })
+
+  it('clears optionalCallback when the prop is removed', async () => {
+    const { view, errors, update, mountCount } = await renderTestView({
+      optionalCallback: callback(() => {}),
+    })
+    await waitFor(() => expect(view.optionalCallback).toBeDefined())
+
+    update({})
+    await waitFor(() =>
+      expect(errors.length > 0 || view.optionalCallback === undefined).toBe(
+        true
+      )
+    )
+    expectNoRenderErrors(errors)
+    expect(view.optionalCallback).toBeUndefined()
+    expect(mountCount()).toBe(1)
+  })
+
+  it('keeps explicit null for props that model null (nullableString)', async () => {
+    const { view, errors, update } = await renderTestView({
+      nullableString: 'hello',
+    })
+    await waitFor(() => expect(view.nullableString).toBe('hello'))
+
+    // `string | null` props explicitly model `null`, so an explicit `null`
+    // value must still arrive as `null` - not be swallowed into `undefined`.
+    update({ nullableString: null })
+    await waitFor(() =>
+      expect(errors.length > 0 || view.nullableString === null).toBe(true)
+    )
+    expectNoRenderErrors(errors)
+    expect(view.nullableString).toBeNull()
+  })
+})

--- a/example/__tests__/views.harness.tsx
+++ b/example/__tests__/views.harness.tsx
@@ -95,6 +95,20 @@ describe('TestView optional props', () => {
     }
   }
 
+  // Resolves once the prop update landed OR a render error was caught, so a
+  // crashing commit fails fast in `expectNoRenderErrors` with the real error
+  // instead of timing out here.
+  async function waitForUpdateOrError(
+    errors: unknown[],
+    hasUpdated: () => boolean
+  ): Promise<void> {
+    await waitFor(() => {
+      if (errors.length === 0 && !hasUpdated()) {
+        throw new Error('prop update has not reached the native view yet')
+      }
+    })
+  }
+
   it('renders with optional props omitted', async () => {
     const { view, errors } = await renderTestView({})
     expect(view.optionalString).toBeUndefined()
@@ -109,9 +123,7 @@ describe('TestView optional props', () => {
     await waitFor(() => expect(view.optionalString).toBe('hello'))
 
     update({})
-    await waitFor(() =>
-      expect(errors.length > 0 || view.optionalString === undefined).toBe(true)
-    )
+    await waitForUpdateOrError(errors, () => view.optionalString === undefined)
     expectNoRenderErrors(errors)
     expect(view.optionalString).toBeUndefined()
     expect(mountCount()).toBe(1)
@@ -124,9 +136,7 @@ describe('TestView optional props', () => {
     await waitFor(() => expect(view.optionalString).toBe('hello'))
 
     update({ optionalString: undefined })
-    await waitFor(() =>
-      expect(errors.length > 0 || view.optionalString === undefined).toBe(true)
-    )
+    await waitForUpdateOrError(errors, () => view.optionalString === undefined)
     expectNoRenderErrors(errors)
     expect(view.optionalString).toBeUndefined()
     expect(mountCount()).toBe(1)
@@ -139,13 +149,9 @@ describe('TestView optional props', () => {
     await waitFor(() => expect(view.optionalString).toBe('first'))
 
     update({})
-    await waitFor(() =>
-      expect(errors.length > 0 || view.optionalString === undefined).toBe(true)
-    )
+    await waitForUpdateOrError(errors, () => view.optionalString === undefined)
     update({ optionalString: 'second' })
-    await waitFor(() =>
-      expect(errors.length > 0 || view.optionalString === 'second').toBe(true)
-    )
+    await waitForUpdateOrError(errors, () => view.optionalString === 'second')
     expectNoRenderErrors(errors)
     expect(view.optionalString).toBe('second')
   })
@@ -157,10 +163,9 @@ describe('TestView optional props', () => {
     await waitFor(() => expect(view.optionalCallback).toBeDefined())
 
     update({})
-    await waitFor(() =>
-      expect(errors.length > 0 || view.optionalCallback === undefined).toBe(
-        true
-      )
+    await waitForUpdateOrError(
+      errors,
+      () => view.optionalCallback === undefined
     )
     expectNoRenderErrors(errors)
     expect(view.optionalCallback).toBeUndefined()
@@ -176,9 +181,21 @@ describe('TestView optional props', () => {
     // `string | null` props explicitly model `null`, so an explicit `null`
     // value must still arrive as `null` - not be swallowed into `undefined`.
     update({ nullableString: null })
-    await waitFor(() =>
-      expect(errors.length > 0 || view.nullableString === null).toBe(true)
-    )
+    await waitForUpdateOrError(errors, () => view.nullableString === null)
+    expectNoRenderErrors(errors)
+    expect(view.nullableString).toBeNull()
+  })
+
+  it('delivers null when nullableString is removed', async () => {
+    const { view, errors, update } = await renderTestView({
+      nullableString: 'hello',
+    })
+    await waitFor(() => expect(view.nullableString).toBe('hello'))
+
+    // React encodes removal as `null` and native cannot tell it apart from an
+    // explicit `null` - since `string | null` models null, it arrives as-is.
+    update({})
+    await waitForUpdateOrError(errors, () => view.nullableString === null)
     expectNoRenderErrors(errors)
     expect(view.nullableString).toBeNull()
   })

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestView.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestView.kt
@@ -24,6 +24,9 @@ class HybridTestView(
   override var hasBeenCalled: Boolean = false
   override var colorScheme: ColorScheme = ColorScheme.LIGHT
   override var someCallback: () -> Unit = {}
+  override var optionalString: String? = null
+  override var nullableString: Variant_NullType_String? = null
+  override var optionalCallback: (() -> Unit)? = null
 
   // Methods
   override fun someMethod() {

--- a/packages/react-native-nitro-test/ios/HybridTestView.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestView.swift
@@ -21,6 +21,9 @@ class HybridTestView: HybridTestViewSpec {
   var hasBeenCalled: Bool = false
   var colorScheme: ColorScheme = .light
   var someCallback: () -> Void = {}
+  var optionalString: String? = nil
+  var nullableString: Variant_NullType_String? = nil
+  var optionalCallback: (() -> Void)? = nil
 
   // Methods
   func someMethod() throws {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
@@ -15,6 +15,12 @@ namespace margelo::nitro::test { enum class ColorScheme; }
 #include <functional>
 #include "JFunc_void.hpp"
 #include <NitroModules/JNICallable.hpp>
+#include <string>
+#include <optional>
+#include <NitroModules/Null.hpp>
+#include <variant>
+#include "JVariant_NullType_String.hpp"
+#include <NitroModules/JNull.hpp>
 
 namespace margelo::nitro::test {
 
@@ -89,6 +95,41 @@ namespace margelo::nitro::test {
   void JHybridTestViewSpec::setSomeCallback(const std::function<void()>& someCallback) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* someCallback */)>("setSomeCallback_cxx");
     method(_javaPart, JFunc_void_cxx::fromCpp(someCallback));
+  }
+  std::optional<std::string> JHybridTestViewSpec::getOptionalString() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getOptionalString");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
+  }
+  void JHybridTestViewSpec::setOptionalString(const std::optional<std::string>& optionalString) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* optionalString */)>("setOptionalString");
+    method(_javaPart, optionalString.has_value() ? jni::make_jstring(optionalString.value()) : nullptr);
+  }
+  std::optional<std::variant<nitro::NullType, std::string>> JHybridTestViewSpec::getNullableString() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JVariant_NullType_String>()>("getNullableString");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
+  }
+  void JHybridTestViewSpec::setNullableString(const std::optional<std::variant<nitro::NullType, std::string>>& nullableString) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JVariant_NullType_String> /* nullableString */)>("setNullableString");
+    method(_javaPart, nullableString.has_value() ? JVariant_NullType_String::fromCpp(nullableString.value()) : nullptr);
+  }
+  std::optional<std::function<void()>> JHybridTestViewSpec::getOptionalCallback() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>()>("getOptionalCallback_cxx");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional([&]() -> std::function<void()> {
+      if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
+        auto downcast = jni::static_ref_cast<JFunc_void_cxx::javaobject>(__result);
+        return downcast->cthis()->getFunction();
+      } else {
+        auto __resultRef = jni::make_global(__result);
+        return JNICallable<JFunc_void, void()>(std::move(__resultRef));
+      }
+    }()) : std::nullopt;
+  }
+  void JHybridTestViewSpec::setOptionalCallback(const std::optional<std::function<void()>>& optionalCallback) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* optionalCallback */)>("setOptionalCallback_cxx");
+    method(_javaPart, optionalCallback.has_value() ? JFunc_void_cxx::fromCpp(optionalCallback.value()) : nullptr);
   }
 
   // Methods

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
@@ -58,6 +58,12 @@ namespace margelo::nitro::test {
     void setColorScheme(ColorScheme colorScheme) override;
     std::function<void()> getSomeCallback() override;
     void setSomeCallback(const std::function<void()>& someCallback) override;
+    std::optional<std::string> getOptionalString() override;
+    void setOptionalString(const std::optional<std::string>& optionalString) override;
+    std::optional<std::variant<nitro::NullType, std::string>> getNullableString() override;
+    void setNullableString(const std::optional<std::variant<nitro::NullType, std::string>>& nullableString) override;
+    std::optional<std::function<void()>> getOptionalCallback() override;
+    void setOptionalCallback(const std::optional<std::function<void()>>& optionalCallback) override;
 
   public:
     // Methods

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
@@ -53,6 +53,18 @@ void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /*
     hybridView->setSomeCallback(props->someCallback.value);
     props->someCallback.isDirty = false;
   }
+  if (props->optionalString.isDirty) {
+    hybridView->setOptionalString(props->optionalString.value);
+    props->optionalString.isDirty = false;
+  }
+  if (props->nullableString.isDirty) {
+    hybridView->setNullableString(props->nullableString.value);
+    props->nullableString.isDirty = false;
+  }
+  if (props->optionalCallback.isDirty) {
+    hybridView->setOptionalCallback(props->optionalCallback.value);
+    props->optionalCallback.isDirty = false;
+  }
 
   // Update hybridRef if it changed
   if (props->hybridRef.isDirty) {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestViewSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestViewSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.test
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.NullType
 import com.margelo.nitro.core.HybridObject
 import com.margelo.nitro.views.HybridView
 
@@ -56,6 +57,32 @@ abstract class HybridTestViewSpec: HybridView() {
     @DoNotStrip
     set(value) {
       someCallback = value
+    }
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
+  abstract var optionalString: String?
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
+  abstract var nullableString: Variant_NullType_String?
+  
+  abstract var optionalCallback: (() -> Unit)?
+  
+  private var optionalCallback_cxx: Func_void?
+    @Keep
+    @DoNotStrip
+    get() {
+      return optionalCallback?.let { Func_void_java(it) }
+    }
+    @Keep
+    @DoNotStrip
+    set(value) {
+      optionalCallback = value?.let { it }
     }
 
   // Methods

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -2142,5 +2142,35 @@ namespace margelo::nitro::test::bridge::swift {
   inline Result_std__variant_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec___std__string__ create_Result_std__variant_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec___std__string__(const std::exception_ptr& error) noexcept {
     return Result<std::variant<std::shared_ptr<margelo::nitro::test::external::HybridSomeExternalObjectSpec>, std::string>>::withError(error);
   }
+  
+  // pragma MARK: std::optional<std::variant<nitro::NullType, std::string>>
+  /**
+   * Specialized version of `std::optional<std::variant<nitro::NullType, std::string>>`.
+   */
+  using std__optional_std__variant_nitro__NullType__std__string__ = std::optional<std::variant<nitro::NullType, std::string>>;
+  inline std::optional<std::variant<nitro::NullType, std::string>> create_std__optional_std__variant_nitro__NullType__std__string__(const std::variant<nitro::NullType, std::string>& value) noexcept {
+    return std::optional<std::variant<nitro::NullType, std::string>>(value);
+  }
+  inline bool has_value_std__optional_std__variant_nitro__NullType__std__string__(const std::optional<std::variant<nitro::NullType, std::string>>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline std::variant<nitro::NullType, std::string> get_std__optional_std__variant_nitro__NullType__std__string__(const std::optional<std::variant<nitro::NullType, std::string>>& optional) noexcept {
+    return optional.value();
+  }
+  
+  // pragma MARK: std::optional<std::function<void()>>
+  /**
+   * Specialized version of `std::optional<std::function<void()>>`.
+   */
+  using std__optional_std__function_void____ = std::optional<std::function<void()>>;
+  inline std::optional<std::function<void()>> create_std__optional_std__function_void____(const std::function<void()>& value) noexcept {
+    return std::optional<std::function<void()>>(value);
+  }
+  inline bool has_value_std__optional_std__function_void____(const std::optional<std::function<void()>>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline std::function<void()> get_std__optional_std__function_void____(const std::optional<std::function<void()>>& optional) noexcept {
+    return optional.value();
+  }
 
 } // namespace margelo::nitro::test::bridge::swift

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestViewSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestViewSpecSwift.hpp
@@ -17,6 +17,10 @@ namespace margelo::nitro::test { enum class ColorScheme; }
 
 #include "ColorScheme.hpp"
 #include <functional>
+#include <string>
+#include <optional>
+#include <NitroModules/Null.hpp>
+#include <variant>
 
 #include "NitroTest-Swift-Cxx-Umbrella.hpp"
 
@@ -89,6 +93,27 @@ namespace margelo::nitro::test {
     }
     inline void setSomeCallback(const std::function<void()>& someCallback) noexcept override {
       _swiftPart.setSomeCallback(someCallback);
+    }
+    inline std::optional<std::string> getOptionalString() noexcept override {
+      auto __result = _swiftPart.getOptionalString();
+      return __result;
+    }
+    inline void setOptionalString(const std::optional<std::string>& optionalString) noexcept override {
+      _swiftPart.setOptionalString(optionalString);
+    }
+    inline std::optional<std::variant<nitro::NullType, std::string>> getNullableString() noexcept override {
+      auto __result = _swiftPart.getNullableString();
+      return __result;
+    }
+    inline void setNullableString(const std::optional<std::variant<nitro::NullType, std::string>>& nullableString) noexcept override {
+      _swiftPart.setNullableString(nullableString);
+    }
+    inline std::optional<std::function<void()>> getOptionalCallback() noexcept override {
+      auto __result = _swiftPart.getOptionalCallback();
+      return __result;
+    }
+    inline void setOptionalCallback(const std::optional<std::function<void()>>& optionalCallback) noexcept override {
+      _swiftPart.setOptionalCallback(optionalCallback);
     }
 
   public:

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -99,6 +99,21 @@ using namespace margelo::nitro::test::views;
     swiftPart.setSomeCallback(newViewProps.someCallback.value);
     newViewProps.someCallback.isDirty = false;
   }
+  // optionalString: optional
+  if (newViewProps.optionalString.isDirty) {
+    swiftPart.setOptionalString(newViewProps.optionalString.value);
+    newViewProps.optionalString.isDirty = false;
+  }
+  // nullableString: optional
+  if (newViewProps.nullableString.isDirty) {
+    swiftPart.setNullableString(newViewProps.nullableString.value);
+    newViewProps.nullableString.isDirty = false;
+  }
+  // optionalCallback: optional
+  if (newViewProps.optionalCallback.isDirty) {
+    swiftPart.setOptionalCallback(newViewProps.optionalCallback.value);
+    newViewProps.optionalCallback.isDirty = false;
+  }
 
   swiftPart.afterUpdate();
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
@@ -14,6 +14,9 @@ public protocol HybridTestViewSpec_protocol: HybridObject, HybridView {
   var hasBeenCalled: Bool { get set }
   var colorScheme: ColorScheme { get set }
   var someCallback: () -> Void { get set }
+  var optionalString: String? { get set }
+  var nullableString: Variant_NullType_String? { get set }
+  var optionalCallback: (() -> Void)? { get set }
 
   // Methods
   func someMethod() throws -> Void

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
@@ -172,6 +172,105 @@ open class HybridTestViewSpec_cxx {
       }()
     }
   }
+  
+  public final var optionalString: bridge.std__optional_std__string_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_std__string_ in
+        if let __unwrappedValue = self.__implementation.optionalString {
+          return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.optionalString = { () -> String? in
+        if bridge.has_value_std__optional_std__string_(newValue) {
+          let __unwrapped = bridge.get_std__optional_std__string_(newValue)
+          return String(__unwrapped)
+        } else {
+          return nil
+        }
+      }()
+    }
+  }
+  
+  public final var nullableString: bridge.std__optional_std__variant_nitro__NullType__std__string__ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_std__variant_nitro__NullType__std__string__ in
+        if let __unwrappedValue = self.__implementation.nullableString {
+          return bridge.create_std__optional_std__variant_nitro__NullType__std__string__({ () -> bridge.std__variant_nitro__NullType__std__string_ in
+            switch __unwrappedValue {
+              case .first(let __value):
+                return bridge.create_std__variant_nitro__NullType__std__string_(margelo.nitro.NullType.null)
+              case .second(let __value):
+                return bridge.create_std__variant_nitro__NullType__std__string_(std.string(__value))
+            }
+          }().variant)
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.nullableString = { () -> Variant_NullType_String? in
+        if bridge.has_value_std__optional_std__variant_nitro__NullType__std__string__(newValue) {
+          let __unwrapped = bridge.get_std__optional_std__variant_nitro__NullType__std__string__(newValue)
+          return { () -> Variant_NullType_String in
+            let __variant = bridge.std__variant_nitro__NullType__std__string_(__unwrapped)
+            switch __variant.index() {
+              case 0:
+                let __actual = __variant.get_0()
+                return .first(NullType.null)
+              case 1:
+                let __actual = __variant.get_1()
+                return .second(String(__actual))
+              default:
+                fatalError("Variant can never have index \(__variant.index())!")
+            }
+          }()
+        } else {
+          return nil
+        }
+      }()
+    }
+  }
+  
+  public final var optionalCallback: bridge.std__optional_std__function_void____ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_std__function_void____ in
+        if let __unwrappedValue = self.__implementation.optionalCallback {
+          return bridge.create_std__optional_std__function_void____({ () -> bridge.Func_void in
+            let __closureWrapper = Func_void(__unwrappedValue)
+            return bridge.create_Func_void(__closureWrapper.toUnsafe())
+          }())
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.optionalCallback = { () -> (() -> Void)? in
+        if bridge.has_value_std__optional_std__function_void____(newValue) {
+          let __unwrapped = bridge.get_std__optional_std__function_void____(newValue)
+          return { () -> () -> Void in
+            let __wrappedFunction = bridge.wrap_Func_void(__unwrapped)
+            return { () -> Void in
+              __wrappedFunction.call()
+            }
+          }()
+        } else {
+          return nil
+        }
+      }()
+    }
+  }
 
   // Methods
   @inline(__always)

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.cpp
@@ -22,6 +22,12 @@ namespace margelo::nitro::test {
       prototype.registerHybridSetter("colorScheme", &HybridTestViewSpec::setColorScheme);
       prototype.registerHybridGetter("someCallback", &HybridTestViewSpec::getSomeCallback);
       prototype.registerHybridSetter("someCallback", &HybridTestViewSpec::setSomeCallback);
+      prototype.registerHybridGetter("optionalString", &HybridTestViewSpec::getOptionalString);
+      prototype.registerHybridSetter("optionalString", &HybridTestViewSpec::setOptionalString);
+      prototype.registerHybridGetter("nullableString", &HybridTestViewSpec::getNullableString);
+      prototype.registerHybridSetter("nullableString", &HybridTestViewSpec::setNullableString);
+      prototype.registerHybridGetter("optionalCallback", &HybridTestViewSpec::getOptionalCallback);
+      prototype.registerHybridSetter("optionalCallback", &HybridTestViewSpec::setOptionalCallback);
       prototype.registerHybridMethod("someMethod", &HybridTestViewSpec::someMethod);
     });
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.hpp
@@ -18,6 +18,10 @@ namespace margelo::nitro::test { enum class ColorScheme; }
 
 #include "ColorScheme.hpp"
 #include <functional>
+#include <string>
+#include <optional>
+#include <NitroModules/Null.hpp>
+#include <variant>
 
 namespace margelo::nitro::test {
 
@@ -54,6 +58,12 @@ namespace margelo::nitro::test {
       virtual void setColorScheme(ColorScheme colorScheme) = 0;
       virtual std::function<void()> getSomeCallback() = 0;
       virtual void setSomeCallback(const std::function<void()>& someCallback) = 0;
+      virtual std::optional<std::string> getOptionalString() = 0;
+      virtual void setOptionalString(const std::optional<std::string>& optionalString) = 0;
+      virtual std::optional<std::variant<nitro::NullType, std::string>> getNullableString() = 0;
+      virtual void setNullableString(const std::optional<std::variant<nitro::NullType, std::string>>& nullableString) = 0;
+      virtual std::optional<std::function<void()>> getOptionalCallback() = 0;
+      virtual void setOptionalCallback(const std::optional<std::function<void()>>& optionalCallback) = 0;
 
     public:
       // Methods

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
@@ -66,6 +66,36 @@ namespace margelo::nitro::test::views {
         throw std::runtime_error(std::string("TestView.someCallback: ") + exc.what());
       }
     }()),
+    optionalString([&]() -> CachedProp<std::optional<std::string>> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("optionalString", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.optionalString;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<std::optional<std::string>>::fromRawValue(*runtime, value, sourceProps.optionalString);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("TestView.optionalString: ") + exc.what());
+      }
+    }()),
+    nullableString([&]() -> CachedProp<std::optional<std::variant<nitro::NullType, std::string>>> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("nullableString", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.nullableString;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<std::optional<std::variant<nitro::NullType, std::string>>>::fromRawValue(*runtime, value, sourceProps.nullableString);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("TestView.nullableString: ") + exc.what());
+      }
+    }()),
+    optionalCallback([&]() -> CachedProp<std::optional<std::function<void()>>> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("optionalCallback", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.optionalCallback;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<std::optional<std::function<void()>>>::fromRawValue(*runtime, value.asObject(*runtime).getProperty(*runtime, PropNameIDCache::get(*runtime, "f")), sourceProps.optionalCallback);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("TestView.optionalCallback: ") + exc.what());
+      }
+    }()),
     hybridRef([&]() -> CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>> {
       try {
         const react::RawValue* rawValue = rawProps.at("hybridRef", nullptr, nullptr);
@@ -83,6 +113,9 @@ namespace margelo::nitro::test::views {
       case hashString("hasBeenCalled"): return true;
       case hashString("colorScheme"): return true;
       case hashString("someCallback"): return true;
+      case hashString("optionalString"): return true;
+      case hashString("nullableString"): return true;
+      case hashString("optionalCallback"): return true;
       case hashString("hybridRef"): return true;
       default: return false;
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
@@ -18,9 +18,12 @@
 
 #include "ColorScheme.hpp"
 #include <functional>
+#include <string>
+#include <optional>
+#include <NitroModules/Null.hpp>
+#include <variant>
 #include <memory>
 #include "HybridTestViewSpec.hpp"
-#include <optional>
 
 namespace margelo::nitro::test::views {
 
@@ -46,6 +49,9 @@ namespace margelo::nitro::test::views {
     CachedProp<bool> hasBeenCalled;
     CachedProp<ColorScheme> colorScheme;
     CachedProp<std::function<void()>> someCallback;
+    CachedProp<std::optional<std::string>> optionalString;
+    CachedProp<std::optional<std::variant<nitro::NullType, std::string>>> nullableString;
+    CachedProp<std::optional<std::function<void()>>> optionalCallback;
     CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>> hybridRef;
 
   private:

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/json/TestViewConfig.json
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/json/TestViewConfig.json
@@ -8,6 +8,9 @@
     "hasBeenCalled": true,
     "colorScheme": true,
     "someCallback": true,
+    "optionalString": true,
+    "nullableString": true,
+    "optionalCallback": true,
     "hybridRef": true
   }
 }

--- a/packages/react-native-nitro-test/src/specs/TestView.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestView.nitro.ts
@@ -11,6 +11,9 @@ export interface TestViewProps extends HybridViewProps {
   hasBeenCalled: boolean
   colorScheme: ColorScheme
   someCallback: () => void
+  optionalString?: string
+  nullableString?: string | null
+  optionalCallback?: () => void
 }
 export interface TestViewMethods extends HybridViewMethods {
   someMethod(): void


### PR DESCRIPTION
Repro-only PR for #1184 (companion to the fix in #1432): setting an optional view prop and then clearing it (removing it, or setting it to `undefined`) crashes React's commit. **The new harness tests fail in CI on this PR - that's the point.**

```
Exception in HostFunction: TestView.optionalString: Value is null, expected a String
    at cloneNodeWithNewProps (native)
```

Adds `optionalString` / `nullableString` / `optionalCallback` to the existing `TestView` spec and on-device harness tests that set and then clear each of them. 4 of the 7 tests fail on `main`; with #1432 all 7 pass.

The tests live in `example/__tests__/views.harness.tsx` rather than `getTests.ts` because the bug is only reachable by rendering a view and re-rendering it with the prop removed - it needs React's commit path. The Harness workflows pick the file up on both platforms.

## Checklist

- [x] Targets `main`, narrow scope.
- [x] Repro-only: the test fails in CI, demonstrating the bug deterministically.
- [x] `bun specs` run, generated files committed.
- [x] `bun lint-all` passes locally.
- [x] No existing specs or test cases removed, no unrelated refactors.
- [x] Conventional Commits.
