### PR TITLE
fix: re-create JS object on dead runtime cache entry 

### DIFF
--- a/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridObject.cpp
@@ -68,11 +68,8 @@ void HybridObject::loadHybridMethods() {
 jsi::Value HybridObject::toObject(jsi::Runtime& runtime) {
   // 1. Check if we have a jsi::WeakObject in cache that we can use to avoid re-creating the object each time
   auto cachedObject = _objectCache.find(&runtime);
-  if (cachedObject != _objectCache.end()) {
+  if (cachedObject != _objectCache.end() && cachedObject->second != nullptr) {
     // 1.1. We have a WeakObject, try to see if it is still alive
-    if (cachedObject->second == nullptr) [[unlikely]] {
-      throw std::runtime_error("HybridObject \"" + getName() + "\" was cached, but the reference got destroyed!");
-    }
     jsi::Value value = cachedObject->second->lock(runtime);
     if (!value.isUndefined()) {
       // 1.2. It is still alive - we can use it instead of creating a new one! But first, let's update memory-size


### PR DESCRIPTION
We are seeing this error on production 

```
Error: Exception in HostFunction: [Worklets] Failed to deserialize CustomSerializable. Reason: Exception in HostFunction: HybridObject "WorkletQueueFactory" was cached, but the reference got destroyed!
    at createWorkletRuntime (native)
    at createWorkletRuntime (/node_modules/react-native-worklets/src/WorkletsModule/NativeWorklets.native.ts:213:58)
    at createWorkletRuntime (/node_modules/react-native-worklets/src/runtimes.native.ts:99:45)
```

I traced it down and created a reproducer using harness. 
Commit:- https://github.com/riteshshukla04/nitro/commit/2edda755f49963e52da9134263c0f1b60a79d851
Pipeline :- https://github.com/riteshshukla04/nitro/actions/runs/29806171166/job/88557062242

This seems to fix the issue for good
Pipeline :- https://github.com/riteshshukla04/nitro/actions/runs/29778995588/job/88475337377 