### PR TITLE
fix: Make `Sync<..>` functions non-`@FastNative`

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
@@ -24,6 +24,12 @@ export function createKotlinFunction(functionType: FunctionType): SourceFile[] {
     .getRequiredImports('kotlin')
     .map((i) => `import ${i.name}`)
     .filter(isNotDuplicate)
+  const funcAnnotations: string[] = []
+  if (!functionType.isSync) {
+    // Async functions immediately schedule calls on a Dispatcher,
+    // we can make those @FastNative as they are not doing any JNI allocations
+    funcAnnotations.push('@FastNative')
+  }
 
   const kotlinCode = `
 ${createFileMetadataString(`${name}.kt`)}
@@ -82,7 +88,7 @@ class ${name}_cxx: ${name} {
   override fun invoke(${kotlinParams.join(', ')}): ${kotlinReturnType}
     = invoke_cxx(${kotlinParamsForward.join(',')})
 
-  @FastNative
+  ${funcAnnotations.join('\n')}
   private external fun invoke_cxx(${kotlinParams.join(', ')}): ${kotlinReturnType}
 }
 

--- a/packages/nitrogen/src/syntax/types/FunctionType.ts
+++ b/packages/nitrogen/src/syntax/types/FunctionType.ts
@@ -28,7 +28,7 @@ export class FunctionType implements Type {
     if (isSync && returnType.kind === 'void') {
       throw new Error(
         `Function \`${this.jsName}\` cannot be sync (\`Sync<...>\`) AND return \`void\`, as this is ambiguous. ` +
-        `Either return a value (even if it's just a \`boolean\`) to keep it sync, or make it async.`
+          `Either return a value (even if it's just a \`boolean\`) to keep it sync, or make it async.`
       )
     }
   }

--- a/packages/nitrogen/src/syntax/types/FunctionType.ts
+++ b/packages/nitrogen/src/syntax/types/FunctionType.ts
@@ -12,6 +12,7 @@ export interface GetFunctionCodeOptions extends GetCodeOptions {
 export class FunctionType implements Type {
   readonly returnType: Type
   readonly parameters: NamedType[]
+  readonly isSync: boolean
 
   constructor(returnType: Type, parameters: NamedType[], isSync = false) {
     if (returnType.kind === 'void' || isSync) {
@@ -22,11 +23,12 @@ export class FunctionType implements Type {
       this.returnType = new PromiseType(returnType)
     }
     this.parameters = parameters
+    this.isSync = isSync
 
     if (isSync && returnType.kind === 'void') {
       throw new Error(
         `Function \`${this.jsName}\` cannot be sync (\`Sync<...>\`) AND return \`void\`, as this is ambiguous. ` +
-          `Either return a value (even if it's just a \`boolean\`) to keep it sync, or make it async.`
+        `Either return a value (even if it's just a \`boolean\`) to keep it sync, or make it async.`
       )
     }
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_double.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_double.kt
@@ -59,7 +59,7 @@ class Func_double_cxx: Func_double {
   override fun invoke(): Double
     = invoke_cxx()
 
-  @FastNative
+  
   private external fun invoke_cxx(): Double
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_.kt
@@ -59,7 +59,7 @@ class Func_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObj
   override fun invoke(): com.margelo.nitro.test.external.HybridSomeExternalObjectSpec
     = invoke_cxx()
 
-  @FastNative
+  
   private external fun invoke_cxx(): com.margelo.nitro.test.external.HybridSomeExternalObjectSpec
 }
 


### PR DESCRIPTION
Synchronous functions (`Sync<...>`) run blocking, and theoretically could perform JNI allocations.

This was surfaced in VisionCamera - if your Frame Processor (`onFrame(…)`) runs, it may call into native/JNI again to do some allocations.
This violates the `@FastNative` promise; you shouldn't do any long work in there or perform JNI allocations, as the JVM/GC is blocked for that time.
That could stall GC if we hit GC limits, causing reports like this one: https://github.com/mrousavy/react-native-vision-camera/issues/4097

So as a solution, we make `Sync<..>` funcs no longer `@FastNative`. Only async funcs are `@FastNative`, as they immediately schedule a call on the `Dispatcher` and don't do any JNI allocations, giving the JVM/GC an easier time.