### PR TITLE
fix: Enable jsi RawProps parser on React Native < 0.82

### DIFF
--- a/packages/nitrogen/src/views/CppHybridViewComponent.ts
+++ b/packages/nitrogen/src/views/CppHybridViewComponent.ts
@@ -239,6 +239,13 @@ ${createFileMetadataString(`${component}.cpp`)}
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/components/view/ViewProps.h>
 
+#if __has_include(<cxxreact/ReactNativeVersion.h>)
+#include <cxxreact/ReactNativeVersion.h>
+#if REACT_NATIVE_VERSION_MINOR >= 82
+#define RAW_PROPS_JSI_VALUE_ENABLED_BY_DEFAULT
+#endif
+#endif
+
 namespace ${namespace} {
 
   extern const char ${nameVariable}[] = "${T}";
@@ -257,7 +264,15 @@ namespace ${namespace} {
 
   ${descriptorClassName}::${descriptorClassName}(const react::ComponentDescriptorParameters& parameters)
     : ConcreteComponentDescriptor(parameters,
-                                  react::RawPropsParser()) {}
+#ifdef RAW_PROPS_JSI_VALUE_ENABLED_BY_DEFAULT
+                                  react::RawPropsParser()
+#else
+                                  // RN < 0.82 defaults the \`useRawPropsJsiValue\` flag to false, but the
+                                  // props constructor above reads every RawValue as a \`jsi::Value\` - so
+                                  // opt in. The \`bool\` overload is deprecated (ignored) on RN >= 0.85.
+                                  react::RawPropsParser(/* enableJsiParser */ true)
+#endif
+                                  ) {}
 
   std::shared_ptr<const react::Props> ${descriptorClassName}::cloneProps(const react::PropsParserContext& context,
                                       ${descriptorIndent}             const std::shared_ptr<const react::Props>& props,

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
@@ -18,6 +18,13 @@
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/components/view/ViewProps.h>
 
+#if __has_include(<cxxreact/ReactNativeVersion.h>)
+#include <cxxreact/ReactNativeVersion.h>
+#if REACT_NATIVE_VERSION_MINOR >= 82
+#define RAW_PROPS_JSI_VALUE_ENABLED_BY_DEFAULT
+#endif
+#endif
+
 namespace margelo::nitro::test::views {
 
   extern const char HybridRecyclableTestViewComponentName[] = "RecyclableTestView";
@@ -57,7 +64,15 @@ namespace margelo::nitro::test::views {
 
   HybridRecyclableTestViewComponentDescriptor::HybridRecyclableTestViewComponentDescriptor(const react::ComponentDescriptorParameters& parameters)
     : ConcreteComponentDescriptor(parameters,
-                                  react::RawPropsParser()) {}
+#ifdef RAW_PROPS_JSI_VALUE_ENABLED_BY_DEFAULT
+                                  react::RawPropsParser()
+#else
+                                  // RN < 0.82 defaults the `useRawPropsJsiValue` flag to false, but the
+                                  // props constructor above reads every RawValue as a `jsi::Value` - so
+                                  // opt in. The `bool` overload is deprecated (ignored) on RN >= 0.85.
+                                  react::RawPropsParser(/* enableJsiParser */ true)
+#endif
+                                  ) {}
 
   std::shared_ptr<const react::Props> HybridRecyclableTestViewComponentDescriptor::cloneProps(const react::PropsParserContext& context,
                                                                                               const std::shared_ptr<const react::Props>& props,

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
@@ -18,6 +18,13 @@
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/components/view/ViewProps.h>
 
+#if __has_include(<cxxreact/ReactNativeVersion.h>)
+#include <cxxreact/ReactNativeVersion.h>
+#if REACT_NATIVE_VERSION_MINOR >= 82
+#define RAW_PROPS_JSI_VALUE_ENABLED_BY_DEFAULT
+#endif
+#endif
+
 namespace margelo::nitro::test::views {
 
   extern const char HybridTestViewComponentName[] = "TestView";
@@ -90,7 +97,15 @@ namespace margelo::nitro::test::views {
 
   HybridTestViewComponentDescriptor::HybridTestViewComponentDescriptor(const react::ComponentDescriptorParameters& parameters)
     : ConcreteComponentDescriptor(parameters,
-                                  react::RawPropsParser()) {}
+#ifdef RAW_PROPS_JSI_VALUE_ENABLED_BY_DEFAULT
+                                  react::RawPropsParser()
+#else
+                                  // RN < 0.82 defaults the `useRawPropsJsiValue` flag to false, but the
+                                  // props constructor above reads every RawValue as a `jsi::Value` - so
+                                  // opt in. The `bool` overload is deprecated (ignored) on RN >= 0.85.
+                                  react::RawPropsParser(/* enableJsiParser */ true)
+#endif
+                                  ) {}
 
   std::shared_ptr<const react::Props> HybridTestViewComponentDescriptor::cloneProps(const react::PropsParserContext& context,
                                                                                     const std::shared_ptr<const react::Props>& props,


### PR DESCRIPTION
Any Nitro view generated with nitrogen 0.36.x throws on mount on React Native <= 0.81:

    Exception in HostFunction: PreviewView.previewOutput: Cannot cast dynamic to a
    jsi::Value type. Please use the 'useRawPropsJsiValue' feature flag to enable
    jsi::Value support for RawValues.
    
  
This PR intends to fix that and has been tested locally on a React Native iOS app and successfully fixes the issue.