### PR TITLE
fix: Remove `@FastNative` from native callbacks entirely

### DIFF
--- a/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
+++ b/packages/nitrogen/src/syntax/kotlin/KotlinFunction.ts
@@ -24,12 +24,6 @@ export function createKotlinFunction(functionType: FunctionType): SourceFile[] {
     .getRequiredImports('kotlin')
     .map((i) => `import ${i.name}`)
     .filter(isNotDuplicate)
-  const funcAnnotations: string[] = []
-  if (!functionType.isSync) {
-    // Async functions immediately schedule calls on a Dispatcher,
-    // we can make those @FastNative as they are not doing any JNI allocations
-    funcAnnotations.push('@FastNative')
-  }
 
   const kotlinCode = `
 ${createFileMetadataString(`${name}.kt`)}
@@ -88,7 +82,6 @@ class ${name}_cxx: ${name} {
   override fun invoke(${kotlinParams.join(', ')}): ${kotlinReturnType}
     = invoke_cxx(${kotlinParamsForward.join(',')})
 
-  ${funcAnnotations.join('\n')}
   private external fun invoke_cxx(${kotlinParams.join(', ')}): ${kotlinReturnType}
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_double.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_double.kt
@@ -59,7 +59,6 @@ class Func_double_cxx: Func_double {
   override fun invoke(): Double
     = invoke_cxx()
 
-  
   private external fun invoke_cxx(): Double
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_double__.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_double__.kt
@@ -59,7 +59,6 @@ class Func_std__shared_ptr_Promise_double___cxx: Func_std__shared_ptr_Promise_do
   override fun invoke(): Promise<Double>
     = invoke_cxx()
 
-  @FastNative
   private external fun invoke_cxx(): Promise<Double>
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double____.kt
@@ -59,7 +59,6 @@ class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_double_____cxx: Func_
   override fun invoke(): Promise<Promise<Double>>
     = invoke_cxx()
 
-  @FastNative
   private external fun invoke_cxx(): Promise<Promise<Double>>
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_ArrayBuffer_____.kt
@@ -60,7 +60,6 @@ class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_std__shared_ptr_Array
   override fun invoke(): Promise<Promise<ArrayBuffer>>
     = invoke_cxx()
 
-  @FastNative
   private external fun invoke_cxx(): Promise<Promise<ArrayBuffer>>
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_void____.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__shared_ptr_Promise_void____.kt
@@ -59,7 +59,6 @@ class Func_std__shared_ptr_Promise_std__shared_ptr_Promise_void_____cxx: Func_st
   override fun invoke(): Promise<Promise<Unit>>
     = invoke_cxx()
 
-  @FastNative
   private external fun invoke_cxx(): Promise<Promise<Unit>>
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__string__.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_Promise_std__string__.kt
@@ -59,7 +59,6 @@ class Func_std__shared_ptr_Promise_std__string___cxx: Func_std__shared_ptr_Promi
   override fun invoke(): Promise<String>
     = invoke_cxx()
 
-  @FastNative
   private external fun invoke_cxx(): Promise<String>
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObjectSpec_.kt
@@ -59,7 +59,6 @@ class Func_std__shared_ptr_margelo__nitro__test__external__HybridSomeExternalObj
   override fun invoke(): com.margelo.nitro.test.external.HybridSomeExternalObjectSpec
     = invoke_cxx()
 
-  
   private external fun invoke_cxx(): com.margelo.nitro.test.external.HybridSomeExternalObjectSpec
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void.kt
@@ -59,7 +59,6 @@ class Func_void_cxx: Func_void {
   override fun invoke(): Unit
     = invoke_cxx()
 
-  @FastNative
   private external fun invoke_cxx(): Unit
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_double.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_double.kt
@@ -59,7 +59,6 @@ class Func_void_double_cxx: Func_void_double {
   override fun invoke(value: Double): Unit
     = invoke_cxx(value)
 
-  @FastNative
   private external fun invoke_cxx(value: Double): Unit
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__exception_ptr.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__exception_ptr.kt
@@ -59,7 +59,6 @@ class Func_void_std__exception_ptr_cxx: Func_void_std__exception_ptr {
   override fun invoke(error: Throwable): Unit
     = invoke_cxx(error)
 
-  @FastNative
   private external fun invoke_cxx(error: Throwable): Unit
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__optional_double_.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__optional_double_.kt
@@ -59,7 +59,6 @@ class Func_void_std__optional_double__cxx: Func_void_std__optional_double_ {
   override fun invoke(maybe: Double?): Unit
     = invoke_cxx(maybe)
 
-  @FastNative
   private external fun invoke_cxx(maybe: Double?): Unit
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__string.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__string.kt
@@ -59,7 +59,6 @@ class Func_void_std__string_cxx: Func_void_std__string {
   override fun invoke(value: String): Unit
     = invoke_cxx(value)
 
-  @FastNative
   private external fun invoke_cxx(value: String): Unit
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__vector_Powertrain_.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/Func_void_std__vector_Powertrain_.kt
@@ -59,7 +59,6 @@ class Func_void_std__vector_Powertrain__cxx: Func_void_std__vector_Powertrain_ {
   override fun invoke(array: Array<Powertrain>): Unit
     = invoke_cxx(array)
 
-  @FastNative
   private external fun invoke_cxx(array: Array<Powertrain>): Unit
 }
 


### PR DESCRIPTION
As a follow-up PR of #1450, we now remove `@FastNative` for ALL native C++ JS Callbacks that are callable from Kotlin, not only sync ones.

There are cases where #1450 can still crash the entire process as described in https://github.com/mrousavy/nitro/issues/1456 - this is pretty rare but can still happen, e.g. react-native-vision-camera uses that path.

So better safe than sorry, let's remove `@FastNative`.